### PR TITLE
Fix alignment in relaxed atomics spec test

### DIFF
--- a/test/spec/relaxed-atomics.wast
+++ b/test/spec/relaxed-atomics.wast
@@ -7,573 +7,573 @@
   ;; Memory index must come before memory ordering if present.
   ;; Both immediates are optional; an ommitted memory ordering will be treated as seqcst.
   (func $test-all-ops
-    (drop (i32.atomic.load (i32.const 42)))
-    (drop (i32.atomic.load acqrel (i32.const 42)))
-    (drop (i32.atomic.load seqcst (i32.const 42)))
-    (drop (i32.atomic.load 0 (i32.const 42)))
-    (drop (i32.atomic.load 0 acqrel (i32.const 42)))
-    (drop (i32.atomic.load 0 seqcst (i32.const 42)))
-    (drop (i32.atomic.load 1 (i64.const 42)))
-    (drop (i32.atomic.load 1 acqrel (i64.const 42)))
-    (drop (i32.atomic.load 1 seqcst (i64.const 42)))
-    (drop (i64.atomic.load (i32.const 42)))
-    (drop (i64.atomic.load acqrel (i32.const 42)))
-    (drop (i64.atomic.load seqcst (i32.const 42)))
-    (drop (i64.atomic.load 0 (i32.const 42)))
-    (drop (i64.atomic.load 0 acqrel (i32.const 42)))
-    (drop (i64.atomic.load 0 seqcst (i32.const 42)))
-    (drop (i64.atomic.load 1 (i64.const 42)))
-    (drop (i64.atomic.load 1 acqrel (i64.const 42)))
-    (drop (i64.atomic.load 1 seqcst (i64.const 42)))
-    (drop (i32.atomic.load8_u (i32.const 42)))
-    (drop (i32.atomic.load8_u acqrel (i32.const 42)))
-    (drop (i32.atomic.load8_u seqcst (i32.const 42)))
-    (drop (i32.atomic.load8_u 0 (i32.const 42)))
-    (drop (i32.atomic.load8_u 0 acqrel (i32.const 42)))
-    (drop (i32.atomic.load8_u 0 seqcst (i32.const 42)))
-    (drop (i32.atomic.load8_u 1 (i64.const 42)))
-    (drop (i32.atomic.load8_u 1 acqrel (i64.const 42)))
-    (drop (i32.atomic.load8_u 1 seqcst (i64.const 42)))
-    (drop (i32.atomic.load16_u (i32.const 42)))
-    (drop (i32.atomic.load16_u acqrel (i32.const 42)))
-    (drop (i32.atomic.load16_u seqcst (i32.const 42)))
-    (drop (i32.atomic.load16_u 0 (i32.const 42)))
-    (drop (i32.atomic.load16_u 0 acqrel (i32.const 42)))
-    (drop (i32.atomic.load16_u 0 seqcst (i32.const 42)))
-    (drop (i32.atomic.load16_u 1 (i64.const 42)))
-    (drop (i32.atomic.load16_u 1 acqrel (i64.const 42)))
-    (drop (i32.atomic.load16_u 1 seqcst (i64.const 42)))
-    (drop (i64.atomic.load8_u (i32.const 42)))
-    (drop (i64.atomic.load8_u acqrel (i32.const 42)))
-    (drop (i64.atomic.load8_u seqcst (i32.const 42)))
-    (drop (i64.atomic.load8_u 0 (i32.const 42)))
-    (drop (i64.atomic.load8_u 0 acqrel (i32.const 42)))
-    (drop (i64.atomic.load8_u 0 seqcst (i32.const 42)))
-    (drop (i64.atomic.load8_u 1 (i64.const 42)))
-    (drop (i64.atomic.load8_u 1 acqrel (i64.const 42)))
-    (drop (i64.atomic.load8_u 1 seqcst (i64.const 42)))
-    (drop (i64.atomic.load16_u (i32.const 42)))
-    (drop (i64.atomic.load16_u acqrel (i32.const 42)))
-    (drop (i64.atomic.load16_u seqcst (i32.const 42)))
-    (drop (i64.atomic.load16_u 0 (i32.const 42)))
-    (drop (i64.atomic.load16_u 0 acqrel (i32.const 42)))
-    (drop (i64.atomic.load16_u 0 seqcst (i32.const 42)))
-    (drop (i64.atomic.load16_u 1 (i64.const 42)))
-    (drop (i64.atomic.load16_u 1 acqrel (i64.const 42)))
-    (drop (i64.atomic.load16_u 1 seqcst (i64.const 42)))
-    (drop (i64.atomic.load32_u (i32.const 42)))
-    (drop (i64.atomic.load32_u acqrel (i32.const 42)))
-    (drop (i64.atomic.load32_u seqcst (i32.const 42)))
-    (drop (i64.atomic.load32_u 0 (i32.const 42)))
-    (drop (i64.atomic.load32_u 0 acqrel (i32.const 42)))
-    (drop (i64.atomic.load32_u 0 seqcst (i32.const 42)))
-    (drop (i64.atomic.load32_u 1 (i64.const 42)))
-    (drop (i64.atomic.load32_u 1 acqrel (i64.const 42)))
-    (drop (i64.atomic.load32_u 1 seqcst (i64.const 42)))
-    (i32.atomic.store (i32.const 42) (i32.const 42))
-    (i32.atomic.store acqrel (i32.const 42) (i32.const 42))
-    (i32.atomic.store seqcst (i32.const 42) (i32.const 42))
-    (i32.atomic.store 0 (i32.const 42) (i32.const 42))
-    (i32.atomic.store 0 acqrel (i32.const 42) (i32.const 42))
-    (i32.atomic.store 0 seqcst (i32.const 42) (i32.const 42))
-    (i32.atomic.store 1 (i64.const 42) (i32.const 42))
-    (i32.atomic.store 1 acqrel (i64.const 42) (i32.const 42))
-    (i32.atomic.store 1 seqcst (i64.const 42) (i32.const 42))
-    (i64.atomic.store (i32.const 42) (i64.const 42))
-    (i64.atomic.store acqrel (i32.const 42) (i64.const 42))
-    (i64.atomic.store seqcst (i32.const 42) (i64.const 42))
-    (i64.atomic.store 0 (i32.const 42) (i64.const 42))
-    (i64.atomic.store 0 acqrel (i32.const 42) (i64.const 42))
-    (i64.atomic.store 0 seqcst (i32.const 42) (i64.const 42))
-    (i64.atomic.store 1 (i64.const 42) (i64.const 42))
-    (i64.atomic.store 1 acqrel (i64.const 42) (i64.const 42))
-    (i64.atomic.store 1 seqcst (i64.const 42) (i64.const 42))
-    (i32.atomic.store8 (i32.const 42) (i32.const 42))
-    (i32.atomic.store8 acqrel (i32.const 42) (i32.const 42))
-    (i32.atomic.store8 seqcst (i32.const 42) (i32.const 42))
-    (i32.atomic.store8 0 (i32.const 42) (i32.const 42))
-    (i32.atomic.store8 0 acqrel (i32.const 42) (i32.const 42))
-    (i32.atomic.store8 0 seqcst (i32.const 42) (i32.const 42))
-    (i32.atomic.store8 1 (i64.const 42) (i32.const 42))
-    (i32.atomic.store8 1 acqrel (i64.const 42) (i32.const 42))
-    (i32.atomic.store8 1 seqcst (i64.const 42) (i32.const 42))
-    (i32.atomic.store16 (i32.const 42) (i32.const 42))
-    (i32.atomic.store16 acqrel (i32.const 42) (i32.const 42))
-    (i32.atomic.store16 seqcst (i32.const 42) (i32.const 42))
-    (i32.atomic.store16 0 (i32.const 42) (i32.const 42))
-    (i32.atomic.store16 0 acqrel (i32.const 42) (i32.const 42))
-    (i32.atomic.store16 0 seqcst (i32.const 42) (i32.const 42))
-    (i32.atomic.store16 1 (i64.const 42) (i32.const 42))
-    (i32.atomic.store16 1 acqrel (i64.const 42) (i32.const 42))
-    (i32.atomic.store16 1 seqcst (i64.const 42) (i32.const 42))
-    (i64.atomic.store8 (i32.const 42) (i64.const 42))
-    (i64.atomic.store8 acqrel (i32.const 42) (i64.const 42))
-    (i64.atomic.store8 seqcst (i32.const 42) (i64.const 42))
-    (i64.atomic.store8 0 (i32.const 42) (i64.const 42))
-    (i64.atomic.store8 0 acqrel (i32.const 42) (i64.const 42))
-    (i64.atomic.store8 0 seqcst (i32.const 42) (i64.const 42))
-    (i64.atomic.store8 1 (i64.const 42) (i64.const 42))
-    (i64.atomic.store8 1 acqrel (i64.const 42) (i64.const 42))
-    (i64.atomic.store8 1 seqcst (i64.const 42) (i64.const 42))
-    (i64.atomic.store16 (i32.const 42) (i64.const 42))
-    (i64.atomic.store16 acqrel (i32.const 42) (i64.const 42))
-    (i64.atomic.store16 seqcst (i32.const 42) (i64.const 42))
-    (i64.atomic.store16 0 (i32.const 42) (i64.const 42))
-    (i64.atomic.store16 0 acqrel (i32.const 42) (i64.const 42))
-    (i64.atomic.store16 0 seqcst (i32.const 42) (i64.const 42))
-    (i64.atomic.store16 1 (i64.const 42) (i64.const 42))
-    (i64.atomic.store16 1 acqrel (i64.const 42) (i64.const 42))
-    (i64.atomic.store16 1 seqcst (i64.const 42) (i64.const 42))
-    (i64.atomic.store32 (i32.const 42) (i64.const 42))
-    (i64.atomic.store32 acqrel (i32.const 42) (i64.const 42))
-    (i64.atomic.store32 seqcst (i32.const 42) (i64.const 42))
-    (i64.atomic.store32 0 (i32.const 42) (i64.const 42))
-    (i64.atomic.store32 0 acqrel (i32.const 42) (i64.const 42))
-    (i64.atomic.store32 0 seqcst (i32.const 42) (i64.const 42))
-    (i64.atomic.store32 1 (i64.const 42) (i64.const 42))
-    (i64.atomic.store32 1 acqrel (i64.const 42) (i64.const 42))
-    (i64.atomic.store32 1 seqcst (i64.const 42) (i64.const 42))
-    (drop (i32.atomic.rmw.add (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.add acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.add seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.add 0 (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.add 0 acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.add 0 seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.add 1 (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.add 1 acqrel (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.add 1 seqcst (i64.const 42) (i32.const 42)))
-    (drop (i64.atomic.rmw.add (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.add acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.add seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.add 0 (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.add 0 acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.add 0 seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.add 1 (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.add 1 acqrel (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.add 1 seqcst (i64.const 42) (i64.const 42)))
-    (drop (i32.atomic.rmw8.add_u (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.add_u acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.add_u seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.add_u 0 (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.add_u 0 acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.add_u 0 seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.add_u 1 (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.add_u 1 acqrel (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.add_u 1 seqcst (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.add_u (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.add_u acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.add_u seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.add_u 0 (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.add_u 0 acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.add_u 0 seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.add_u 1 (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.add_u 1 acqrel (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.add_u 1 seqcst (i64.const 42) (i32.const 42)))
-    (drop (i64.atomic.rmw8.add_u (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.add_u acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.add_u seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.add_u 0 (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.add_u 0 acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.add_u 0 seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.add_u 1 (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.add_u 1 acqrel (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.add_u 1 seqcst (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.add_u (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.add_u acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.add_u seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.add_u 0 (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.add_u 0 acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.add_u 0 seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.add_u 1 (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.add_u 1 acqrel (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.add_u 1 seqcst (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.add_u (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.add_u acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.add_u seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.add_u 0 (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.add_u 0 acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.add_u 0 seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.add_u 1 (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.add_u 1 acqrel (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.add_u 1 seqcst (i64.const 42) (i64.const 42)))
-    (drop (i32.atomic.rmw.sub (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.sub acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.sub seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.sub 0 (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.sub 0 acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.sub 0 seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.sub 1 (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.sub 1 acqrel (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.sub 1 seqcst (i64.const 42) (i32.const 42)))
-    (drop (i64.atomic.rmw.sub (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.sub acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.sub seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.sub 0 (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.sub 0 acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.sub 0 seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.sub 1 (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.sub 1 acqrel (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.sub 1 seqcst (i64.const 42) (i64.const 42)))
-    (drop (i32.atomic.rmw8.sub_u (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.sub_u acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.sub_u seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.sub_u 0 (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.sub_u 0 acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.sub_u 0 seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.sub_u 1 (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.sub_u 1 acqrel (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.sub_u 1 seqcst (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.sub_u (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.sub_u acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.sub_u seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.sub_u 0 (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.sub_u 0 acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.sub_u 0 seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.sub_u 1 (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.sub_u 1 acqrel (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.sub_u 1 seqcst (i64.const 42) (i32.const 42)))
-    (drop (i64.atomic.rmw8.sub_u (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.sub_u acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.sub_u seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.sub_u 0 (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.sub_u 0 acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.sub_u 0 seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.sub_u 1 (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.sub_u 1 acqrel (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.sub_u 1 seqcst (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.sub_u (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.sub_u acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.sub_u seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.sub_u 0 (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.sub_u 0 acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.sub_u 0 seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.sub_u 1 (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.sub_u 1 acqrel (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.sub_u 1 seqcst (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.sub_u (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.sub_u acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.sub_u seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.sub_u 0 (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.sub_u 0 acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.sub_u 0 seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.sub_u 1 (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.sub_u 1 acqrel (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.sub_u 1 seqcst (i64.const 42) (i64.const 42)))
-    (drop (i32.atomic.rmw.and (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.and acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.and seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.and 0 (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.and 0 acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.and 0 seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.and 1 (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.and 1 acqrel (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.and 1 seqcst (i64.const 42) (i32.const 42)))
-    (drop (i64.atomic.rmw.and (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.and acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.and seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.and 0 (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.and 0 acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.and 0 seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.and 1 (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.and 1 acqrel (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.and 1 seqcst (i64.const 42) (i64.const 42)))
-    (drop (i32.atomic.rmw8.and_u (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.and_u acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.and_u seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.and_u 0 (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.and_u 0 acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.and_u 0 seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.and_u 1 (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.and_u 1 acqrel (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.and_u 1 seqcst (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.and_u (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.and_u acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.and_u seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.and_u 0 (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.and_u 0 acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.and_u 0 seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.and_u 1 (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.and_u 1 acqrel (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.and_u 1 seqcst (i64.const 42) (i32.const 42)))
-    (drop (i64.atomic.rmw8.and_u (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.and_u acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.and_u seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.and_u 0 (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.and_u 0 acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.and_u 0 seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.and_u 1 (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.and_u 1 acqrel (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.and_u 1 seqcst (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.and_u (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.and_u acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.and_u seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.and_u 0 (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.and_u 0 acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.and_u 0 seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.and_u 1 (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.and_u 1 acqrel (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.and_u 1 seqcst (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.and_u (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.and_u acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.and_u seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.and_u 0 (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.and_u 0 acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.and_u 0 seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.and_u 1 (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.and_u 1 acqrel (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.and_u 1 seqcst (i64.const 42) (i64.const 42)))
-    (drop (i32.atomic.rmw.or (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.or acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.or seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.or 0 (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.or 0 acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.or 0 seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.or 1 (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.or 1 acqrel (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.or 1 seqcst (i64.const 42) (i32.const 42)))
-    (drop (i64.atomic.rmw.or (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.or acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.or seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.or 0 (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.or 0 acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.or 0 seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.or 1 (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.or 1 acqrel (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.or 1 seqcst (i64.const 42) (i64.const 42)))
-    (drop (i32.atomic.rmw8.or_u (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.or_u acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.or_u seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.or_u 0 (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.or_u 0 acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.or_u 0 seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.or_u 1 (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.or_u 1 acqrel (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.or_u 1 seqcst (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.or_u (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.or_u acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.or_u seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.or_u 0 (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.or_u 0 acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.or_u 0 seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.or_u 1 (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.or_u 1 acqrel (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.or_u 1 seqcst (i64.const 42) (i32.const 42)))
-    (drop (i64.atomic.rmw8.or_u (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.or_u acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.or_u seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.or_u 0 (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.or_u 0 acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.or_u 0 seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.or_u 1 (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.or_u 1 acqrel (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.or_u 1 seqcst (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.or_u (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.or_u acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.or_u seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.or_u 0 (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.or_u 0 acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.or_u 0 seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.or_u 1 (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.or_u 1 acqrel (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.or_u 1 seqcst (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.or_u (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.or_u acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.or_u seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.or_u 0 (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.or_u 0 acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.or_u 0 seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.or_u 1 (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.or_u 1 acqrel (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.or_u 1 seqcst (i64.const 42) (i64.const 42)))
-    (drop (i32.atomic.rmw.xor (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.xor acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.xor seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.xor 0 (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.xor 0 acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.xor 0 seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.xor 1 (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.xor 1 acqrel (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.xor 1 seqcst (i64.const 42) (i32.const 42)))
-    (drop (i64.atomic.rmw.xor (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.xor acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.xor seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.xor 0 (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.xor 0 acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.xor 0 seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.xor 1 (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.xor 1 acqrel (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.xor 1 seqcst (i64.const 42) (i64.const 42)))
-    (drop (i32.atomic.rmw8.xor_u (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.xor_u acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.xor_u seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.xor_u 0 (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.xor_u 0 acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.xor_u 0 seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.xor_u 1 (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.xor_u 1 acqrel (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.xor_u 1 seqcst (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.xor_u (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.xor_u acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.xor_u seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.xor_u 0 (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.xor_u 0 acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.xor_u 0 seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.xor_u 1 (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.xor_u 1 acqrel (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.xor_u 1 seqcst (i64.const 42) (i32.const 42)))
-    (drop (i64.atomic.rmw8.xor_u (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.xor_u acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.xor_u seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.xor_u 0 (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.xor_u 0 acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.xor_u 0 seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.xor_u 1 (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.xor_u 1 acqrel (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.xor_u 1 seqcst (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.xor_u (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.xor_u acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.xor_u seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.xor_u 0 (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.xor_u 0 acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.xor_u 0 seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.xor_u 1 (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.xor_u 1 acqrel (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.xor_u 1 seqcst (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.xor_u (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.xor_u acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.xor_u seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.xor_u 0 (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.xor_u 0 acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.xor_u 0 seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.xor_u 1 (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.xor_u 1 acqrel (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.xor_u 1 seqcst (i64.const 42) (i64.const 42)))
-    (drop (i32.atomic.rmw.xchg (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.xchg acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.xchg seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.xchg 0 (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.xchg 0 acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.xchg 0 seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.xchg 1 (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.xchg 1 acqrel (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.xchg 1 seqcst (i64.const 42) (i32.const 42)))
-    (drop (i64.atomic.rmw.xchg (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.xchg acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.xchg seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.xchg 0 (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.xchg 0 acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.xchg 0 seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.xchg 1 (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.xchg 1 acqrel (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.xchg 1 seqcst (i64.const 42) (i64.const 42)))
-    (drop (i32.atomic.rmw8.xchg_u (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.xchg_u acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.xchg_u seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.xchg_u 0 (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.xchg_u 0 acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.xchg_u 0 seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.xchg_u 1 (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.xchg_u 1 acqrel (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.xchg_u 1 seqcst (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.xchg_u (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.xchg_u acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.xchg_u seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.xchg_u 0 (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.xchg_u 0 acqrel (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.xchg_u 0 seqcst (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.xchg_u 1 (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.xchg_u 1 acqrel (i64.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.xchg_u 1 seqcst (i64.const 42) (i32.const 42)))
-    (drop (i64.atomic.rmw8.xchg_u (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.xchg_u acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.xchg_u seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.xchg_u 0 (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.xchg_u 0 acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.xchg_u 0 seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.xchg_u 1 (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.xchg_u 1 acqrel (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.xchg_u 1 seqcst (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.xchg_u (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.xchg_u acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.xchg_u seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.xchg_u 0 (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.xchg_u 0 acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.xchg_u 0 seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.xchg_u 1 (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.xchg_u 1 acqrel (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.xchg_u 1 seqcst (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.xchg_u (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.xchg_u acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.xchg_u seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.xchg_u 0 (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.xchg_u 0 acqrel (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.xchg_u 0 seqcst (i32.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.xchg_u 1 (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.xchg_u 1 acqrel (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.xchg_u 1 seqcst (i64.const 42) (i64.const 42)))
-    (drop (i32.atomic.rmw.cmpxchg (i32.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.cmpxchg acqrel (i32.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.cmpxchg seqcst (i32.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.cmpxchg 0 (i32.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.cmpxchg 0 acqrel (i32.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.cmpxchg 0 seqcst (i32.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.cmpxchg 1 (i64.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.cmpxchg 1 acqrel (i64.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw.cmpxchg 1 seqcst (i64.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i64.atomic.rmw.cmpxchg (i32.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.cmpxchg acqrel (i32.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.cmpxchg seqcst (i32.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.cmpxchg 0 (i32.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.cmpxchg 0 acqrel (i32.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.cmpxchg 0 seqcst (i32.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.cmpxchg 1 (i64.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.cmpxchg 1 acqrel (i64.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw.cmpxchg 1 seqcst (i64.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i32.atomic.rmw8.cmpxchg_u (i32.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.cmpxchg_u acqrel (i32.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.cmpxchg_u seqcst (i32.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.cmpxchg_u 0 (i32.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.cmpxchg_u 0 acqrel (i32.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.cmpxchg_u 0 seqcst (i32.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.cmpxchg_u 1 (i64.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.cmpxchg_u 1 acqrel (i64.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw8.cmpxchg_u 1 seqcst (i64.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.cmpxchg_u (i32.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.cmpxchg_u acqrel (i32.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.cmpxchg_u seqcst (i32.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.cmpxchg_u 0 (i32.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.cmpxchg_u 0 acqrel (i32.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.cmpxchg_u 0 seqcst (i32.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.cmpxchg_u 1 (i64.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.cmpxchg_u 1 acqrel (i64.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i32.atomic.rmw16.cmpxchg_u 1 seqcst (i64.const 42) (i32.const 42) (i32.const 42)))
-    (drop (i64.atomic.rmw8.cmpxchg_u (i32.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.cmpxchg_u acqrel (i32.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.cmpxchg_u seqcst (i32.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.cmpxchg_u 0 (i32.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.cmpxchg_u 0 acqrel (i32.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.cmpxchg_u 0 seqcst (i32.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.cmpxchg_u 1 (i64.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.cmpxchg_u 1 acqrel (i64.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw8.cmpxchg_u 1 seqcst (i64.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.cmpxchg_u (i32.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.cmpxchg_u acqrel (i32.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.cmpxchg_u seqcst (i32.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.cmpxchg_u 0 (i32.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.cmpxchg_u 0 acqrel (i32.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.cmpxchg_u 0 seqcst (i32.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.cmpxchg_u 1 (i64.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.cmpxchg_u 1 acqrel (i64.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw16.cmpxchg_u 1 seqcst (i64.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.cmpxchg_u (i32.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.cmpxchg_u acqrel (i32.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.cmpxchg_u seqcst (i32.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.cmpxchg_u 0 (i32.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.cmpxchg_u 0 acqrel (i32.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.cmpxchg_u 0 seqcst (i32.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.cmpxchg_u 1 (i64.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.cmpxchg_u 1 acqrel (i64.const 42) (i64.const 42) (i64.const 42)))
-    (drop (i64.atomic.rmw32.cmpxchg_u 1 seqcst (i64.const 42) (i64.const 42) (i64.const 42)))
+    (drop (i32.atomic.load (i32.const 0)))
+    (drop (i32.atomic.load acqrel (i32.const 0)))
+    (drop (i32.atomic.load seqcst (i32.const 0)))
+    (drop (i32.atomic.load 0 (i32.const 0)))
+    (drop (i32.atomic.load 0 acqrel (i32.const 0)))
+    (drop (i32.atomic.load 0 seqcst (i32.const 0)))
+    (drop (i32.atomic.load 1 (i64.const 0)))
+    (drop (i32.atomic.load 1 acqrel (i64.const 0)))
+    (drop (i32.atomic.load 1 seqcst (i64.const 0)))
+    (drop (i64.atomic.load (i32.const 0)))
+    (drop (i64.atomic.load acqrel (i32.const 0)))
+    (drop (i64.atomic.load seqcst (i32.const 0)))
+    (drop (i64.atomic.load 0 (i32.const 0)))
+    (drop (i64.atomic.load 0 acqrel (i32.const 0)))
+    (drop (i64.atomic.load 0 seqcst (i32.const 0)))
+    (drop (i64.atomic.load 1 (i64.const 0)))
+    (drop (i64.atomic.load 1 acqrel (i64.const 0)))
+    (drop (i64.atomic.load 1 seqcst (i64.const 0)))
+    (drop (i32.atomic.load8_u (i32.const 0)))
+    (drop (i32.atomic.load8_u acqrel (i32.const 0)))
+    (drop (i32.atomic.load8_u seqcst (i32.const 0)))
+    (drop (i32.atomic.load8_u 0 (i32.const 0)))
+    (drop (i32.atomic.load8_u 0 acqrel (i32.const 0)))
+    (drop (i32.atomic.load8_u 0 seqcst (i32.const 0)))
+    (drop (i32.atomic.load8_u 1 (i64.const 0)))
+    (drop (i32.atomic.load8_u 1 acqrel (i64.const 0)))
+    (drop (i32.atomic.load8_u 1 seqcst (i64.const 0)))
+    (drop (i32.atomic.load16_u (i32.const 0)))
+    (drop (i32.atomic.load16_u acqrel (i32.const 0)))
+    (drop (i32.atomic.load16_u seqcst (i32.const 0)))
+    (drop (i32.atomic.load16_u 0 (i32.const 0)))
+    (drop (i32.atomic.load16_u 0 acqrel (i32.const 0)))
+    (drop (i32.atomic.load16_u 0 seqcst (i32.const 0)))
+    (drop (i32.atomic.load16_u 1 (i64.const 0)))
+    (drop (i32.atomic.load16_u 1 acqrel (i64.const 0)))
+    (drop (i32.atomic.load16_u 1 seqcst (i64.const 0)))
+    (drop (i64.atomic.load8_u (i32.const 0)))
+    (drop (i64.atomic.load8_u acqrel (i32.const 0)))
+    (drop (i64.atomic.load8_u seqcst (i32.const 0)))
+    (drop (i64.atomic.load8_u 0 (i32.const 0)))
+    (drop (i64.atomic.load8_u 0 acqrel (i32.const 0)))
+    (drop (i64.atomic.load8_u 0 seqcst (i32.const 0)))
+    (drop (i64.atomic.load8_u 1 (i64.const 0)))
+    (drop (i64.atomic.load8_u 1 acqrel (i64.const 0)))
+    (drop (i64.atomic.load8_u 1 seqcst (i64.const 0)))
+    (drop (i64.atomic.load16_u (i32.const 0)))
+    (drop (i64.atomic.load16_u acqrel (i32.const 0)))
+    (drop (i64.atomic.load16_u seqcst (i32.const 0)))
+    (drop (i64.atomic.load16_u 0 (i32.const 0)))
+    (drop (i64.atomic.load16_u 0 acqrel (i32.const 0)))
+    (drop (i64.atomic.load16_u 0 seqcst (i32.const 0)))
+    (drop (i64.atomic.load16_u 1 (i64.const 0)))
+    (drop (i64.atomic.load16_u 1 acqrel (i64.const 0)))
+    (drop (i64.atomic.load16_u 1 seqcst (i64.const 0)))
+    (drop (i64.atomic.load32_u (i32.const 0)))
+    (drop (i64.atomic.load32_u acqrel (i32.const 0)))
+    (drop (i64.atomic.load32_u seqcst (i32.const 0)))
+    (drop (i64.atomic.load32_u 0 (i32.const 0)))
+    (drop (i64.atomic.load32_u 0 acqrel (i32.const 0)))
+    (drop (i64.atomic.load32_u 0 seqcst (i32.const 0)))
+    (drop (i64.atomic.load32_u 1 (i64.const 0)))
+    (drop (i64.atomic.load32_u 1 acqrel (i64.const 0)))
+    (drop (i64.atomic.load32_u 1 seqcst (i64.const 0)))
+    (i32.atomic.store (i32.const 0) (i32.const 42))
+    (i32.atomic.store acqrel (i32.const 0) (i32.const 42))
+    (i32.atomic.store seqcst (i32.const 0) (i32.const 42))
+    (i32.atomic.store 0 (i32.const 0) (i32.const 42))
+    (i32.atomic.store 0 acqrel (i32.const 0) (i32.const 42))
+    (i32.atomic.store 0 seqcst (i32.const 0) (i32.const 42))
+    (i32.atomic.store 1 (i64.const 0) (i32.const 42))
+    (i32.atomic.store 1 acqrel (i64.const 0) (i32.const 42))
+    (i32.atomic.store 1 seqcst (i64.const 0) (i32.const 42))
+    (i64.atomic.store (i32.const 0) (i64.const 42))
+    (i64.atomic.store acqrel (i32.const 0) (i64.const 42))
+    (i64.atomic.store seqcst (i32.const 0) (i64.const 42))
+    (i64.atomic.store 0 (i32.const 0) (i64.const 42))
+    (i64.atomic.store 0 acqrel (i32.const 0) (i64.const 42))
+    (i64.atomic.store 0 seqcst (i32.const 0) (i64.const 42))
+    (i64.atomic.store 1 (i64.const 0) (i64.const 42))
+    (i64.atomic.store 1 acqrel (i64.const 0) (i64.const 42))
+    (i64.atomic.store 1 seqcst (i64.const 0) (i64.const 42))
+    (i32.atomic.store8 (i32.const 0) (i32.const 42))
+    (i32.atomic.store8 acqrel (i32.const 0) (i32.const 42))
+    (i32.atomic.store8 seqcst (i32.const 0) (i32.const 42))
+    (i32.atomic.store8 0 (i32.const 0) (i32.const 42))
+    (i32.atomic.store8 0 acqrel (i32.const 0) (i32.const 42))
+    (i32.atomic.store8 0 seqcst (i32.const 0) (i32.const 42))
+    (i32.atomic.store8 1 (i64.const 0) (i32.const 42))
+    (i32.atomic.store8 1 acqrel (i64.const 0) (i32.const 42))
+    (i32.atomic.store8 1 seqcst (i64.const 0) (i32.const 42))
+    (i32.atomic.store16 (i32.const 0) (i32.const 42))
+    (i32.atomic.store16 acqrel (i32.const 0) (i32.const 42))
+    (i32.atomic.store16 seqcst (i32.const 0) (i32.const 42))
+    (i32.atomic.store16 0 (i32.const 0) (i32.const 42))
+    (i32.atomic.store16 0 acqrel (i32.const 0) (i32.const 42))
+    (i32.atomic.store16 0 seqcst (i32.const 0) (i32.const 42))
+    (i32.atomic.store16 1 (i64.const 0) (i32.const 42))
+    (i32.atomic.store16 1 acqrel (i64.const 0) (i32.const 42))
+    (i32.atomic.store16 1 seqcst (i64.const 0) (i32.const 42))
+    (i64.atomic.store8 (i32.const 0) (i64.const 42))
+    (i64.atomic.store8 acqrel (i32.const 0) (i64.const 42))
+    (i64.atomic.store8 seqcst (i32.const 0) (i64.const 42))
+    (i64.atomic.store8 0 (i32.const 0) (i64.const 42))
+    (i64.atomic.store8 0 acqrel (i32.const 0) (i64.const 42))
+    (i64.atomic.store8 0 seqcst (i32.const 0) (i64.const 42))
+    (i64.atomic.store8 1 (i64.const 0) (i64.const 42))
+    (i64.atomic.store8 1 acqrel (i64.const 0) (i64.const 42))
+    (i64.atomic.store8 1 seqcst (i64.const 0) (i64.const 42))
+    (i64.atomic.store16 (i32.const 0) (i64.const 42))
+    (i64.atomic.store16 acqrel (i32.const 0) (i64.const 42))
+    (i64.atomic.store16 seqcst (i32.const 0) (i64.const 42))
+    (i64.atomic.store16 0 (i32.const 0) (i64.const 42))
+    (i64.atomic.store16 0 acqrel (i32.const 0) (i64.const 42))
+    (i64.atomic.store16 0 seqcst (i32.const 0) (i64.const 42))
+    (i64.atomic.store16 1 (i64.const 0) (i64.const 42))
+    (i64.atomic.store16 1 acqrel (i64.const 0) (i64.const 42))
+    (i64.atomic.store16 1 seqcst (i64.const 0) (i64.const 42))
+    (i64.atomic.store32 (i32.const 0) (i64.const 42))
+    (i64.atomic.store32 acqrel (i32.const 0) (i64.const 42))
+    (i64.atomic.store32 seqcst (i32.const 0) (i64.const 42))
+    (i64.atomic.store32 0 (i32.const 0) (i64.const 42))
+    (i64.atomic.store32 0 acqrel (i32.const 0) (i64.const 42))
+    (i64.atomic.store32 0 seqcst (i32.const 0) (i64.const 42))
+    (i64.atomic.store32 1 (i64.const 0) (i64.const 42))
+    (i64.atomic.store32 1 acqrel (i64.const 0) (i64.const 42))
+    (i64.atomic.store32 1 seqcst (i64.const 0) (i64.const 42))
+    (drop (i32.atomic.rmw.add (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.add acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.add seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.add 0 (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.add 0 acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.add 0 seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.add 1 (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.add 1 acqrel (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.add 1 seqcst (i64.const 0) (i32.const 42)))
+    (drop (i64.atomic.rmw.add (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.add acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.add seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.add 0 (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.add 0 acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.add 0 seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.add 1 (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.add 1 acqrel (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.add 1 seqcst (i64.const 0) (i64.const 42)))
+    (drop (i32.atomic.rmw8.add_u (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.add_u acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.add_u seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.add_u 0 (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.add_u 0 acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.add_u 0 seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.add_u 1 (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.add_u 1 acqrel (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.add_u 1 seqcst (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.add_u (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.add_u acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.add_u seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.add_u 0 (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.add_u 0 acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.add_u 0 seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.add_u 1 (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.add_u 1 acqrel (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.add_u 1 seqcst (i64.const 0) (i32.const 42)))
+    (drop (i64.atomic.rmw8.add_u (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.add_u acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.add_u seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.add_u 0 (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.add_u 0 acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.add_u 0 seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.add_u 1 (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.add_u 1 acqrel (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.add_u 1 seqcst (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.add_u (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.add_u acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.add_u seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.add_u 0 (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.add_u 0 acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.add_u 0 seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.add_u 1 (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.add_u 1 acqrel (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.add_u 1 seqcst (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.add_u (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.add_u acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.add_u seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.add_u 0 (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.add_u 0 acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.add_u 0 seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.add_u 1 (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.add_u 1 acqrel (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.add_u 1 seqcst (i64.const 0) (i64.const 42)))
+    (drop (i32.atomic.rmw.sub (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.sub acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.sub seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.sub 0 (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.sub 0 acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.sub 0 seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.sub 1 (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.sub 1 acqrel (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.sub 1 seqcst (i64.const 0) (i32.const 42)))
+    (drop (i64.atomic.rmw.sub (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.sub acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.sub seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.sub 0 (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.sub 0 acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.sub 0 seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.sub 1 (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.sub 1 acqrel (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.sub 1 seqcst (i64.const 0) (i64.const 42)))
+    (drop (i32.atomic.rmw8.sub_u (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.sub_u acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.sub_u seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.sub_u 0 (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.sub_u 0 acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.sub_u 0 seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.sub_u 1 (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.sub_u 1 acqrel (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.sub_u 1 seqcst (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.sub_u (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.sub_u acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.sub_u seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.sub_u 0 (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.sub_u 0 acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.sub_u 0 seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.sub_u 1 (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.sub_u 1 acqrel (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.sub_u 1 seqcst (i64.const 0) (i32.const 42)))
+    (drop (i64.atomic.rmw8.sub_u (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.sub_u acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.sub_u seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.sub_u 0 (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.sub_u 0 acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.sub_u 0 seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.sub_u 1 (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.sub_u 1 acqrel (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.sub_u 1 seqcst (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.sub_u (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.sub_u acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.sub_u seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.sub_u 0 (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.sub_u 0 acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.sub_u 0 seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.sub_u 1 (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.sub_u 1 acqrel (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.sub_u 1 seqcst (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.sub_u (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.sub_u acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.sub_u seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.sub_u 0 (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.sub_u 0 acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.sub_u 0 seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.sub_u 1 (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.sub_u 1 acqrel (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.sub_u 1 seqcst (i64.const 0) (i64.const 42)))
+    (drop (i32.atomic.rmw.and (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.and acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.and seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.and 0 (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.and 0 acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.and 0 seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.and 1 (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.and 1 acqrel (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.and 1 seqcst (i64.const 0) (i32.const 42)))
+    (drop (i64.atomic.rmw.and (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.and acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.and seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.and 0 (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.and 0 acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.and 0 seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.and 1 (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.and 1 acqrel (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.and 1 seqcst (i64.const 0) (i64.const 42)))
+    (drop (i32.atomic.rmw8.and_u (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.and_u acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.and_u seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.and_u 0 (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.and_u 0 acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.and_u 0 seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.and_u 1 (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.and_u 1 acqrel (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.and_u 1 seqcst (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.and_u (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.and_u acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.and_u seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.and_u 0 (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.and_u 0 acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.and_u 0 seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.and_u 1 (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.and_u 1 acqrel (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.and_u 1 seqcst (i64.const 0) (i32.const 42)))
+    (drop (i64.atomic.rmw8.and_u (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.and_u acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.and_u seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.and_u 0 (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.and_u 0 acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.and_u 0 seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.and_u 1 (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.and_u 1 acqrel (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.and_u 1 seqcst (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.and_u (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.and_u acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.and_u seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.and_u 0 (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.and_u 0 acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.and_u 0 seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.and_u 1 (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.and_u 1 acqrel (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.and_u 1 seqcst (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.and_u (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.and_u acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.and_u seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.and_u 0 (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.and_u 0 acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.and_u 0 seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.and_u 1 (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.and_u 1 acqrel (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.and_u 1 seqcst (i64.const 0) (i64.const 42)))
+    (drop (i32.atomic.rmw.or (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.or acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.or seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.or 0 (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.or 0 acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.or 0 seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.or 1 (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.or 1 acqrel (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.or 1 seqcst (i64.const 0) (i32.const 42)))
+    (drop (i64.atomic.rmw.or (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.or acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.or seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.or 0 (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.or 0 acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.or 0 seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.or 1 (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.or 1 acqrel (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.or 1 seqcst (i64.const 0) (i64.const 42)))
+    (drop (i32.atomic.rmw8.or_u (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.or_u acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.or_u seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.or_u 0 (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.or_u 0 acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.or_u 0 seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.or_u 1 (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.or_u 1 acqrel (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.or_u 1 seqcst (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.or_u (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.or_u acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.or_u seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.or_u 0 (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.or_u 0 acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.or_u 0 seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.or_u 1 (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.or_u 1 acqrel (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.or_u 1 seqcst (i64.const 0) (i32.const 42)))
+    (drop (i64.atomic.rmw8.or_u (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.or_u acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.or_u seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.or_u 0 (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.or_u 0 acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.or_u 0 seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.or_u 1 (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.or_u 1 acqrel (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.or_u 1 seqcst (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.or_u (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.or_u acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.or_u seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.or_u 0 (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.or_u 0 acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.or_u 0 seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.or_u 1 (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.or_u 1 acqrel (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.or_u 1 seqcst (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.or_u (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.or_u acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.or_u seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.or_u 0 (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.or_u 0 acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.or_u 0 seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.or_u 1 (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.or_u 1 acqrel (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.or_u 1 seqcst (i64.const 0) (i64.const 42)))
+    (drop (i32.atomic.rmw.xor (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.xor acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.xor seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.xor 0 (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.xor 0 acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.xor 0 seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.xor 1 (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.xor 1 acqrel (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.xor 1 seqcst (i64.const 0) (i32.const 42)))
+    (drop (i64.atomic.rmw.xor (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.xor acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.xor seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.xor 0 (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.xor 0 acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.xor 0 seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.xor 1 (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.xor 1 acqrel (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.xor 1 seqcst (i64.const 0) (i64.const 42)))
+    (drop (i32.atomic.rmw8.xor_u (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.xor_u acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.xor_u seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.xor_u 0 (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.xor_u 0 acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.xor_u 0 seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.xor_u 1 (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.xor_u 1 acqrel (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.xor_u 1 seqcst (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.xor_u (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.xor_u acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.xor_u seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.xor_u 0 (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.xor_u 0 acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.xor_u 0 seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.xor_u 1 (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.xor_u 1 acqrel (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.xor_u 1 seqcst (i64.const 0) (i32.const 42)))
+    (drop (i64.atomic.rmw8.xor_u (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.xor_u acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.xor_u seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.xor_u 0 (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.xor_u 0 acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.xor_u 0 seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.xor_u 1 (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.xor_u 1 acqrel (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.xor_u 1 seqcst (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.xor_u (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.xor_u acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.xor_u seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.xor_u 0 (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.xor_u 0 acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.xor_u 0 seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.xor_u 1 (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.xor_u 1 acqrel (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.xor_u 1 seqcst (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.xor_u (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.xor_u acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.xor_u seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.xor_u 0 (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.xor_u 0 acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.xor_u 0 seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.xor_u 1 (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.xor_u 1 acqrel (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.xor_u 1 seqcst (i64.const 0) (i64.const 42)))
+    (drop (i32.atomic.rmw.xchg (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.xchg acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.xchg seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.xchg 0 (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.xchg 0 acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.xchg 0 seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.xchg 1 (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.xchg 1 acqrel (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw.xchg 1 seqcst (i64.const 0) (i32.const 42)))
+    (drop (i64.atomic.rmw.xchg (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.xchg acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.xchg seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.xchg 0 (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.xchg 0 acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.xchg 0 seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.xchg 1 (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.xchg 1 acqrel (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw.xchg 1 seqcst (i64.const 0) (i64.const 42)))
+    (drop (i32.atomic.rmw8.xchg_u (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.xchg_u acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.xchg_u seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.xchg_u 0 (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.xchg_u 0 acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.xchg_u 0 seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.xchg_u 1 (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.xchg_u 1 acqrel (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw8.xchg_u 1 seqcst (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.xchg_u (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.xchg_u acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.xchg_u seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.xchg_u 0 (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.xchg_u 0 acqrel (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.xchg_u 0 seqcst (i32.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.xchg_u 1 (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.xchg_u 1 acqrel (i64.const 0) (i32.const 42)))
+    (drop (i32.atomic.rmw16.xchg_u 1 seqcst (i64.const 0) (i32.const 42)))
+    (drop (i64.atomic.rmw8.xchg_u (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.xchg_u acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.xchg_u seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.xchg_u 0 (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.xchg_u 0 acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.xchg_u 0 seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.xchg_u 1 (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.xchg_u 1 acqrel (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw8.xchg_u 1 seqcst (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.xchg_u (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.xchg_u acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.xchg_u seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.xchg_u 0 (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.xchg_u 0 acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.xchg_u 0 seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.xchg_u 1 (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.xchg_u 1 acqrel (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw16.xchg_u 1 seqcst (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.xchg_u (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.xchg_u acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.xchg_u seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.xchg_u 0 (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.xchg_u 0 acqrel (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.xchg_u 0 seqcst (i32.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.xchg_u 1 (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.xchg_u 1 acqrel (i64.const 0) (i64.const 42)))
+    (drop (i64.atomic.rmw32.xchg_u 1 seqcst (i64.const 0) (i64.const 42)))
+    (drop (i32.atomic.rmw.cmpxchg (i32.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i32.atomic.rmw.cmpxchg acqrel (i32.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i32.atomic.rmw.cmpxchg seqcst (i32.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i32.atomic.rmw.cmpxchg 0 (i32.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i32.atomic.rmw.cmpxchg 0 acqrel (i32.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i32.atomic.rmw.cmpxchg 0 seqcst (i32.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i32.atomic.rmw.cmpxchg 1 (i64.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i32.atomic.rmw.cmpxchg 1 acqrel (i64.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i32.atomic.rmw.cmpxchg 1 seqcst (i64.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i64.atomic.rmw.cmpxchg (i32.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw.cmpxchg acqrel (i32.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw.cmpxchg seqcst (i32.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw.cmpxchg 0 (i32.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw.cmpxchg 0 acqrel (i32.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw.cmpxchg 0 seqcst (i32.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw.cmpxchg 1 (i64.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw.cmpxchg 1 acqrel (i64.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw.cmpxchg 1 seqcst (i64.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i32.atomic.rmw8.cmpxchg_u (i32.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i32.atomic.rmw8.cmpxchg_u acqrel (i32.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i32.atomic.rmw8.cmpxchg_u seqcst (i32.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i32.atomic.rmw8.cmpxchg_u 0 (i32.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i32.atomic.rmw8.cmpxchg_u 0 acqrel (i32.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i32.atomic.rmw8.cmpxchg_u 0 seqcst (i32.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i32.atomic.rmw8.cmpxchg_u 1 (i64.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i32.atomic.rmw8.cmpxchg_u 1 acqrel (i64.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i32.atomic.rmw8.cmpxchg_u 1 seqcst (i64.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i32.atomic.rmw16.cmpxchg_u (i32.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i32.atomic.rmw16.cmpxchg_u acqrel (i32.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i32.atomic.rmw16.cmpxchg_u seqcst (i32.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i32.atomic.rmw16.cmpxchg_u 0 (i32.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i32.atomic.rmw16.cmpxchg_u 0 acqrel (i32.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i32.atomic.rmw16.cmpxchg_u 0 seqcst (i32.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i32.atomic.rmw16.cmpxchg_u 1 (i64.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i32.atomic.rmw16.cmpxchg_u 1 acqrel (i64.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i32.atomic.rmw16.cmpxchg_u 1 seqcst (i64.const 0) (i32.const 42) (i32.const 42)))
+    (drop (i64.atomic.rmw8.cmpxchg_u (i32.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw8.cmpxchg_u acqrel (i32.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw8.cmpxchg_u seqcst (i32.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw8.cmpxchg_u 0 (i32.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw8.cmpxchg_u 0 acqrel (i32.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw8.cmpxchg_u 0 seqcst (i32.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw8.cmpxchg_u 1 (i64.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw8.cmpxchg_u 1 acqrel (i64.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw8.cmpxchg_u 1 seqcst (i64.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw16.cmpxchg_u (i32.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw16.cmpxchg_u acqrel (i32.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw16.cmpxchg_u seqcst (i32.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw16.cmpxchg_u 0 (i32.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw16.cmpxchg_u 0 acqrel (i32.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw16.cmpxchg_u 0 seqcst (i32.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw16.cmpxchg_u 1 (i64.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw16.cmpxchg_u 1 acqrel (i64.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw16.cmpxchg_u 1 seqcst (i64.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw32.cmpxchg_u (i32.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw32.cmpxchg_u acqrel (i32.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw32.cmpxchg_u seqcst (i32.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw32.cmpxchg_u 0 (i32.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw32.cmpxchg_u 0 acqrel (i32.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw32.cmpxchg_u 0 seqcst (i32.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw32.cmpxchg_u 1 (i64.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw32.cmpxchg_u 1 acqrel (i64.const 0) (i64.const 42) (i64.const 42)))
+    (drop (i64.atomic.rmw32.cmpxchg_u 1 seqcst (i64.const 0) (i64.const 42) (i64.const 42)))
   )
 )
 
@@ -594,34 +594,34 @@
   "\0a\a9\2d\01" ;; Code section
   "\a6\2d\00" ;; func $test-all-ops
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\10" ;; i32.atomic.load
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\10" ;; i32.atomic.load
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\10" ;; i32.atomic.load
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\10" ;; i32.atomic.load
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\10" ;; i32.atomic.load
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -629,7 +629,7 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\10" ;; i32.atomic.load
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -637,57 +637,57 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
     "\fe\10" ;; i32.atomic.load
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
     "\fe\10" ;; i32.atomic.load
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
     "\fe\10" ;; i32.atomic.load
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\11" ;; i64.atomic.load
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\11" ;; i64.atomic.load
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\11" ;; i64.atomic.load
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\11" ;; i64.atomic.load
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\11" ;; i64.atomic.load
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -695,7 +695,7 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\11" ;; i64.atomic.load
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -703,57 +703,57 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
     "\fe\11" ;; i64.atomic.load
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
     "\fe\11" ;; i64.atomic.load
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
     "\fe\11" ;; i64.atomic.load
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\12" ;; i32.atomic.load8_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\12" ;; i32.atomic.load8_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\12" ;; i32.atomic.load8_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\12" ;; i32.atomic.load8_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\12" ;; i32.atomic.load8_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -761,7 +761,7 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\12" ;; i32.atomic.load8_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -769,57 +769,57 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
     "\fe\12" ;; i32.atomic.load8_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
     "\fe\12" ;; i32.atomic.load8_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
     "\fe\12" ;; i32.atomic.load8_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\13" ;; i32.atomic.load16_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\13" ;; i32.atomic.load16_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\13" ;; i32.atomic.load16_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\13" ;; i32.atomic.load16_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\13" ;; i32.atomic.load16_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -827,7 +827,7 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\13" ;; i32.atomic.load16_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -835,57 +835,57 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
     "\fe\13" ;; i32.atomic.load16_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
     "\fe\13" ;; i32.atomic.load16_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
     "\fe\13" ;; i32.atomic.load16_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\14" ;; i64.atomic.load8_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\14" ;; i64.atomic.load8_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\14" ;; i64.atomic.load8_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\14" ;; i64.atomic.load8_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\14" ;; i64.atomic.load8_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -893,7 +893,7 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\14" ;; i64.atomic.load8_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -901,57 +901,57 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
     "\fe\14" ;; i64.atomic.load8_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
     "\fe\14" ;; i64.atomic.load8_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
     "\fe\14" ;; i64.atomic.load8_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\15" ;; i64.atomic.load16_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\15" ;; i64.atomic.load16_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\15" ;; i64.atomic.load16_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\15" ;; i64.atomic.load16_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\15" ;; i64.atomic.load16_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -959,7 +959,7 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\15" ;; i64.atomic.load16_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -967,57 +967,57 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
     "\fe\15" ;; i64.atomic.load16_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
     "\fe\15" ;; i64.atomic.load16_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
     "\fe\15" ;; i64.atomic.load16_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\16" ;; i64.atomic.load32_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\16" ;; i64.atomic.load32_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\16" ;; i64.atomic.load32_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\16" ;; i64.atomic.load32_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\16" ;; i64.atomic.load32_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -1025,7 +1025,7 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
     "\fe\16" ;; i64.atomic.load32_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -1033,524 +1033,524 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
     "\fe\16" ;; i64.atomic.load32_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
     "\fe\16" ;; i64.atomic.load32_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
     "\fe\16" ;; i64.atomic.load32_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\17" ;; i32.atomic.store
     "\02" ;; Alignment of 2
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\17" ;; i32.atomic.store
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\17" ;; i32.atomic.store
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\17" ;; i32.atomic.store
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\17" ;; i32.atomic.store
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\17" ;; i32.atomic.store
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\17" ;; i32.atomic.store
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\17" ;; i32.atomic.store
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\17" ;; i32.atomic.store
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\18" ;; i64.atomic.store
     "\02" ;; Alignment of 2
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\18" ;; i64.atomic.store
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\18" ;; i64.atomic.store
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\18" ;; i64.atomic.store
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\18" ;; i64.atomic.store
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\18" ;; i64.atomic.store
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\18" ;; i64.atomic.store
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\18" ;; i64.atomic.store
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\18" ;; i64.atomic.store
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\19" ;; i32.atomic.store8
     "\02" ;; Alignment of 2
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\19" ;; i32.atomic.store8
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\19" ;; i32.atomic.store8
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\19" ;; i32.atomic.store8
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\19" ;; i32.atomic.store8
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\19" ;; i32.atomic.store8
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\19" ;; i32.atomic.store8
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\19" ;; i32.atomic.store8
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\19" ;; i32.atomic.store8
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\1a" ;; i32.atomic.store16
     "\02" ;; Alignment of 2
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\1a" ;; i32.atomic.store16
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\1a" ;; i32.atomic.store16
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\1a" ;; i32.atomic.store16
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\1a" ;; i32.atomic.store16
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\1a" ;; i32.atomic.store16
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\1a" ;; i32.atomic.store16
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\1a" ;; i32.atomic.store16
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\1a" ;; i32.atomic.store16
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1b" ;; i64.atomic.store8
     "\02" ;; Alignment of 2
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1b" ;; i64.atomic.store8
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1b" ;; i64.atomic.store8
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1b" ;; i64.atomic.store8
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1b" ;; i64.atomic.store8
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1b" ;; i64.atomic.store8
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1b" ;; i64.atomic.store8
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1b" ;; i64.atomic.store8
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1b" ;; i64.atomic.store8
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1c" ;; i64.atomic.store16
     "\02" ;; Alignment of 2
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1c" ;; i64.atomic.store16
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1c" ;; i64.atomic.store16
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1c" ;; i64.atomic.store16
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1c" ;; i64.atomic.store16
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1c" ;; i64.atomic.store16
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1c" ;; i64.atomic.store16
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1c" ;; i64.atomic.store16
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1c" ;; i64.atomic.store16
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1d" ;; i64.atomic.store32
     "\02" ;; Alignment of 2
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1d" ;; i64.atomic.store32
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1d" ;; i64.atomic.store32
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1d" ;; i64.atomic.store32
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1d" ;; i64.atomic.store32
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1d" ;; i64.atomic.store32
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1d" ;; i64.atomic.store32
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1d" ;; i64.atomic.store32
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1d" ;; i64.atomic.store32
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\1e" ;; i32.atomic.rmw.add
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\1e" ;; i32.atomic.rmw.add
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\1e" ;; i32.atomic.rmw.add
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\1e" ;; i32.atomic.rmw.add
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\1e" ;; i32.atomic.rmw.add
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -1558,8 +1558,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\1e" ;; i32.atomic.rmw.add
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -1567,65 +1567,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\1e" ;; i32.atomic.rmw.add
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\1e" ;; i32.atomic.rmw.add
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\1e" ;; i32.atomic.rmw.add
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1f" ;; i64.atomic.rmw.add
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1f" ;; i64.atomic.rmw.add
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1f" ;; i64.atomic.rmw.add
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1f" ;; i64.atomic.rmw.add
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1f" ;; i64.atomic.rmw.add
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -1633,8 +1633,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1f" ;; i64.atomic.rmw.add
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -1642,65 +1642,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1f" ;; i64.atomic.rmw.add
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1f" ;; i64.atomic.rmw.add
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\1f" ;; i64.atomic.rmw.add
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\20" ;; i32.atomic.rmw8.add_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\20" ;; i32.atomic.rmw8.add_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\20" ;; i32.atomic.rmw8.add_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\20" ;; i32.atomic.rmw8.add_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\20" ;; i32.atomic.rmw8.add_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -1708,8 +1708,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\20" ;; i32.atomic.rmw8.add_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -1717,65 +1717,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\20" ;; i32.atomic.rmw8.add_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\20" ;; i32.atomic.rmw8.add_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\20" ;; i32.atomic.rmw8.add_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\21" ;; i32.atomic.rmw16.add_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\21" ;; i32.atomic.rmw16.add_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\21" ;; i32.atomic.rmw16.add_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\21" ;; i32.atomic.rmw16.add_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\21" ;; i32.atomic.rmw16.add_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -1783,8 +1783,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\21" ;; i32.atomic.rmw16.add_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -1792,65 +1792,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\21" ;; i32.atomic.rmw16.add_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\21" ;; i32.atomic.rmw16.add_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\21" ;; i32.atomic.rmw16.add_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\22" ;; i64.atomic.rmw8.add_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\22" ;; i64.atomic.rmw8.add_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\22" ;; i64.atomic.rmw8.add_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\22" ;; i64.atomic.rmw8.add_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\22" ;; i64.atomic.rmw8.add_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -1858,8 +1858,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\22" ;; i64.atomic.rmw8.add_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -1867,65 +1867,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\22" ;; i64.atomic.rmw8.add_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\22" ;; i64.atomic.rmw8.add_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\22" ;; i64.atomic.rmw8.add_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\23" ;; i64.atomic.rmw16.add_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\23" ;; i64.atomic.rmw16.add_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\23" ;; i64.atomic.rmw16.add_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\23" ;; i64.atomic.rmw16.add_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\23" ;; i64.atomic.rmw16.add_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -1933,8 +1933,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\23" ;; i64.atomic.rmw16.add_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -1942,65 +1942,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\23" ;; i64.atomic.rmw16.add_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\23" ;; i64.atomic.rmw16.add_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\23" ;; i64.atomic.rmw16.add_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\24" ;; i64.atomic.rmw32.add_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\24" ;; i64.atomic.rmw32.add_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\24" ;; i64.atomic.rmw32.add_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\24" ;; i64.atomic.rmw32.add_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\24" ;; i64.atomic.rmw32.add_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2008,8 +2008,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\24" ;; i64.atomic.rmw32.add_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2017,65 +2017,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\24" ;; i64.atomic.rmw32.add_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\24" ;; i64.atomic.rmw32.add_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\24" ;; i64.atomic.rmw32.add_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\25" ;; i32.atomic.rmw.sub
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\25" ;; i32.atomic.rmw.sub
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\25" ;; i32.atomic.rmw.sub
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\25" ;; i32.atomic.rmw.sub
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\25" ;; i32.atomic.rmw.sub
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2083,8 +2083,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\25" ;; i32.atomic.rmw.sub
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2092,65 +2092,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\25" ;; i32.atomic.rmw.sub
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\25" ;; i32.atomic.rmw.sub
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\25" ;; i32.atomic.rmw.sub
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\26" ;; i64.atomic.rmw.sub
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\26" ;; i64.atomic.rmw.sub
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\26" ;; i64.atomic.rmw.sub
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\26" ;; i64.atomic.rmw.sub
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\26" ;; i64.atomic.rmw.sub
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2158,8 +2158,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\26" ;; i64.atomic.rmw.sub
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2167,65 +2167,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\26" ;; i64.atomic.rmw.sub
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\26" ;; i64.atomic.rmw.sub
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\26" ;; i64.atomic.rmw.sub
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\27" ;; i32.atomic.rmw8.sub_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\27" ;; i32.atomic.rmw8.sub_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\27" ;; i32.atomic.rmw8.sub_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\27" ;; i32.atomic.rmw8.sub_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\27" ;; i32.atomic.rmw8.sub_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2233,8 +2233,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\27" ;; i32.atomic.rmw8.sub_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2242,65 +2242,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\27" ;; i32.atomic.rmw8.sub_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\27" ;; i32.atomic.rmw8.sub_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\27" ;; i32.atomic.rmw8.sub_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\28" ;; i32.atomic.rmw16.sub_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\28" ;; i32.atomic.rmw16.sub_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\28" ;; i32.atomic.rmw16.sub_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\28" ;; i32.atomic.rmw16.sub_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\28" ;; i32.atomic.rmw16.sub_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2308,8 +2308,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\28" ;; i32.atomic.rmw16.sub_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2317,65 +2317,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\28" ;; i32.atomic.rmw16.sub_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\28" ;; i32.atomic.rmw16.sub_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\28" ;; i32.atomic.rmw16.sub_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\29" ;; i64.atomic.rmw8.sub_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\29" ;; i64.atomic.rmw8.sub_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\29" ;; i64.atomic.rmw8.sub_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\29" ;; i64.atomic.rmw8.sub_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\29" ;; i64.atomic.rmw8.sub_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2383,8 +2383,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\29" ;; i64.atomic.rmw8.sub_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2392,65 +2392,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\29" ;; i64.atomic.rmw8.sub_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\29" ;; i64.atomic.rmw8.sub_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\29" ;; i64.atomic.rmw8.sub_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2a" ;; i64.atomic.rmw16.sub_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2a" ;; i64.atomic.rmw16.sub_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2a" ;; i64.atomic.rmw16.sub_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2a" ;; i64.atomic.rmw16.sub_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2a" ;; i64.atomic.rmw16.sub_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2458,8 +2458,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2a" ;; i64.atomic.rmw16.sub_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2467,65 +2467,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2a" ;; i64.atomic.rmw16.sub_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2a" ;; i64.atomic.rmw16.sub_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2a" ;; i64.atomic.rmw16.sub_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2b" ;; i64.atomic.rmw32.sub_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2b" ;; i64.atomic.rmw32.sub_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2b" ;; i64.atomic.rmw32.sub_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2b" ;; i64.atomic.rmw32.sub_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2b" ;; i64.atomic.rmw32.sub_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2533,8 +2533,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2b" ;; i64.atomic.rmw32.sub_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2542,65 +2542,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2b" ;; i64.atomic.rmw32.sub_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2b" ;; i64.atomic.rmw32.sub_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2b" ;; i64.atomic.rmw32.sub_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2c" ;; i32.atomic.rmw.and
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2c" ;; i32.atomic.rmw.and
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2c" ;; i32.atomic.rmw.and
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2c" ;; i32.atomic.rmw.and
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2c" ;; i32.atomic.rmw.and
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2608,8 +2608,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2c" ;; i32.atomic.rmw.and
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2617,65 +2617,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2c" ;; i32.atomic.rmw.and
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2c" ;; i32.atomic.rmw.and
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2c" ;; i32.atomic.rmw.and
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2d" ;; i64.atomic.rmw.and
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2d" ;; i64.atomic.rmw.and
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2d" ;; i64.atomic.rmw.and
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2d" ;; i64.atomic.rmw.and
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2d" ;; i64.atomic.rmw.and
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2683,8 +2683,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2d" ;; i64.atomic.rmw.and
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2692,65 +2692,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2d" ;; i64.atomic.rmw.and
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2d" ;; i64.atomic.rmw.and
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\2d" ;; i64.atomic.rmw.and
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2e" ;; i32.atomic.rmw8.and_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2e" ;; i32.atomic.rmw8.and_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2e" ;; i32.atomic.rmw8.and_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2e" ;; i32.atomic.rmw8.and_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2e" ;; i32.atomic.rmw8.and_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2758,8 +2758,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2e" ;; i32.atomic.rmw8.and_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2767,65 +2767,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2e" ;; i32.atomic.rmw8.and_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2e" ;; i32.atomic.rmw8.and_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2e" ;; i32.atomic.rmw8.and_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2f" ;; i32.atomic.rmw16.and_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2f" ;; i32.atomic.rmw16.and_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2f" ;; i32.atomic.rmw16.and_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2f" ;; i32.atomic.rmw16.and_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2f" ;; i32.atomic.rmw16.and_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2833,8 +2833,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2f" ;; i32.atomic.rmw16.and_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2842,65 +2842,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2f" ;; i32.atomic.rmw16.and_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2f" ;; i32.atomic.rmw16.and_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\2f" ;; i32.atomic.rmw16.and_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\30" ;; i64.atomic.rmw8.and_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\30" ;; i64.atomic.rmw8.and_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\30" ;; i64.atomic.rmw8.and_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\30" ;; i64.atomic.rmw8.and_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\30" ;; i64.atomic.rmw8.and_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2908,8 +2908,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\30" ;; i64.atomic.rmw8.and_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2917,65 +2917,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\30" ;; i64.atomic.rmw8.and_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\30" ;; i64.atomic.rmw8.and_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\30" ;; i64.atomic.rmw8.and_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\31" ;; i64.atomic.rmw16.and_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\31" ;; i64.atomic.rmw16.and_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\31" ;; i64.atomic.rmw16.and_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\31" ;; i64.atomic.rmw16.and_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\31" ;; i64.atomic.rmw16.and_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2983,8 +2983,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\31" ;; i64.atomic.rmw16.and_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -2992,65 +2992,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\31" ;; i64.atomic.rmw16.and_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\31" ;; i64.atomic.rmw16.and_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\31" ;; i64.atomic.rmw16.and_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\32" ;; i64.atomic.rmw32.and_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\32" ;; i64.atomic.rmw32.and_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\32" ;; i64.atomic.rmw32.and_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\32" ;; i64.atomic.rmw32.and_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\32" ;; i64.atomic.rmw32.and_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3058,8 +3058,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\32" ;; i64.atomic.rmw32.and_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3067,65 +3067,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\32" ;; i64.atomic.rmw32.and_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\32" ;; i64.atomic.rmw32.and_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\32" ;; i64.atomic.rmw32.and_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\33" ;; i32.atomic.rmw.or
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\33" ;; i32.atomic.rmw.or
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\33" ;; i32.atomic.rmw.or
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\33" ;; i32.atomic.rmw.or
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\33" ;; i32.atomic.rmw.or
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3133,8 +3133,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\33" ;; i32.atomic.rmw.or
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3142,65 +3142,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\33" ;; i32.atomic.rmw.or
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\33" ;; i32.atomic.rmw.or
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\33" ;; i32.atomic.rmw.or
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\34" ;; i64.atomic.rmw.or
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\34" ;; i64.atomic.rmw.or
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\34" ;; i64.atomic.rmw.or
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\34" ;; i64.atomic.rmw.or
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\34" ;; i64.atomic.rmw.or
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3208,8 +3208,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\34" ;; i64.atomic.rmw.or
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3217,65 +3217,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\34" ;; i64.atomic.rmw.or
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\34" ;; i64.atomic.rmw.or
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\34" ;; i64.atomic.rmw.or
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\35" ;; i32.atomic.rmw8.or_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\35" ;; i32.atomic.rmw8.or_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\35" ;; i32.atomic.rmw8.or_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\35" ;; i32.atomic.rmw8.or_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\35" ;; i32.atomic.rmw8.or_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3283,8 +3283,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\35" ;; i32.atomic.rmw8.or_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3292,65 +3292,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\35" ;; i32.atomic.rmw8.or_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\35" ;; i32.atomic.rmw8.or_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\35" ;; i32.atomic.rmw8.or_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\36" ;; i32.atomic.rmw16.or_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\36" ;; i32.atomic.rmw16.or_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\36" ;; i32.atomic.rmw16.or_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\36" ;; i32.atomic.rmw16.or_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\36" ;; i32.atomic.rmw16.or_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3358,8 +3358,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\36" ;; i32.atomic.rmw16.or_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3367,65 +3367,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\36" ;; i32.atomic.rmw16.or_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\36" ;; i32.atomic.rmw16.or_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\36" ;; i32.atomic.rmw16.or_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\37" ;; i64.atomic.rmw8.or_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\37" ;; i64.atomic.rmw8.or_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\37" ;; i64.atomic.rmw8.or_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\37" ;; i64.atomic.rmw8.or_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\37" ;; i64.atomic.rmw8.or_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3433,8 +3433,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\37" ;; i64.atomic.rmw8.or_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3442,65 +3442,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\37" ;; i64.atomic.rmw8.or_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\37" ;; i64.atomic.rmw8.or_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\37" ;; i64.atomic.rmw8.or_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\38" ;; i64.atomic.rmw16.or_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\38" ;; i64.atomic.rmw16.or_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\38" ;; i64.atomic.rmw16.or_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\38" ;; i64.atomic.rmw16.or_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\38" ;; i64.atomic.rmw16.or_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3508,8 +3508,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\38" ;; i64.atomic.rmw16.or_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3517,65 +3517,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\38" ;; i64.atomic.rmw16.or_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\38" ;; i64.atomic.rmw16.or_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\38" ;; i64.atomic.rmw16.or_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\39" ;; i64.atomic.rmw32.or_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\39" ;; i64.atomic.rmw32.or_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\39" ;; i64.atomic.rmw32.or_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\39" ;; i64.atomic.rmw32.or_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\39" ;; i64.atomic.rmw32.or_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3583,8 +3583,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\39" ;; i64.atomic.rmw32.or_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3592,65 +3592,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\39" ;; i64.atomic.rmw32.or_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\39" ;; i64.atomic.rmw32.or_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\39" ;; i64.atomic.rmw32.or_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3a" ;; i32.atomic.rmw.xor
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3a" ;; i32.atomic.rmw.xor
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3a" ;; i32.atomic.rmw.xor
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3a" ;; i32.atomic.rmw.xor
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3a" ;; i32.atomic.rmw.xor
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3658,8 +3658,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3a" ;; i32.atomic.rmw.xor
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3667,65 +3667,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3a" ;; i32.atomic.rmw.xor
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3a" ;; i32.atomic.rmw.xor
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3a" ;; i32.atomic.rmw.xor
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3b" ;; i64.atomic.rmw.xor
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3b" ;; i64.atomic.rmw.xor
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3b" ;; i64.atomic.rmw.xor
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3b" ;; i64.atomic.rmw.xor
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3b" ;; i64.atomic.rmw.xor
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3733,8 +3733,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3b" ;; i64.atomic.rmw.xor
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3742,65 +3742,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3b" ;; i64.atomic.rmw.xor
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3b" ;; i64.atomic.rmw.xor
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3b" ;; i64.atomic.rmw.xor
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3c" ;; i32.atomic.rmw8.xor_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3c" ;; i32.atomic.rmw8.xor_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3c" ;; i32.atomic.rmw8.xor_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3c" ;; i32.atomic.rmw8.xor_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3c" ;; i32.atomic.rmw8.xor_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3808,8 +3808,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3c" ;; i32.atomic.rmw8.xor_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3817,65 +3817,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3c" ;; i32.atomic.rmw8.xor_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3c" ;; i32.atomic.rmw8.xor_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3c" ;; i32.atomic.rmw8.xor_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3d" ;; i32.atomic.rmw16.xor_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3d" ;; i32.atomic.rmw16.xor_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3d" ;; i32.atomic.rmw16.xor_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3d" ;; i32.atomic.rmw16.xor_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3d" ;; i32.atomic.rmw16.xor_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3883,8 +3883,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3d" ;; i32.atomic.rmw16.xor_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3892,65 +3892,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3d" ;; i32.atomic.rmw16.xor_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3d" ;; i32.atomic.rmw16.xor_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\3d" ;; i32.atomic.rmw16.xor_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3e" ;; i64.atomic.rmw8.xor_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3e" ;; i64.atomic.rmw8.xor_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3e" ;; i64.atomic.rmw8.xor_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3e" ;; i64.atomic.rmw8.xor_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3e" ;; i64.atomic.rmw8.xor_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3958,8 +3958,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3e" ;; i64.atomic.rmw8.xor_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -3967,65 +3967,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3e" ;; i64.atomic.rmw8.xor_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3e" ;; i64.atomic.rmw8.xor_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3e" ;; i64.atomic.rmw8.xor_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3f" ;; i64.atomic.rmw16.xor_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3f" ;; i64.atomic.rmw16.xor_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3f" ;; i64.atomic.rmw16.xor_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3f" ;; i64.atomic.rmw16.xor_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3f" ;; i64.atomic.rmw16.xor_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4033,8 +4033,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3f" ;; i64.atomic.rmw16.xor_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4042,65 +4042,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3f" ;; i64.atomic.rmw16.xor_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3f" ;; i64.atomic.rmw16.xor_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\3f" ;; i64.atomic.rmw16.xor_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\40" ;; i64.atomic.rmw32.xor_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\40" ;; i64.atomic.rmw32.xor_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\40" ;; i64.atomic.rmw32.xor_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\40" ;; i64.atomic.rmw32.xor_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\40" ;; i64.atomic.rmw32.xor_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4108,8 +4108,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\40" ;; i64.atomic.rmw32.xor_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4117,65 +4117,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\40" ;; i64.atomic.rmw32.xor_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\40" ;; i64.atomic.rmw32.xor_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\40" ;; i64.atomic.rmw32.xor_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\41" ;; i32.atomic.rmw.xchg
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\41" ;; i32.atomic.rmw.xchg
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\41" ;; i32.atomic.rmw.xchg
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\41" ;; i32.atomic.rmw.xchg
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\41" ;; i32.atomic.rmw.xchg
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4183,8 +4183,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\41" ;; i32.atomic.rmw.xchg
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4192,65 +4192,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\41" ;; i32.atomic.rmw.xchg
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\41" ;; i32.atomic.rmw.xchg
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\41" ;; i32.atomic.rmw.xchg
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\42" ;; i64.atomic.rmw.xchg
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\42" ;; i64.atomic.rmw.xchg
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\42" ;; i64.atomic.rmw.xchg
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\42" ;; i64.atomic.rmw.xchg
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\42" ;; i64.atomic.rmw.xchg
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4258,8 +4258,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\42" ;; i64.atomic.rmw.xchg
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4267,65 +4267,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\42" ;; i64.atomic.rmw.xchg
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\42" ;; i64.atomic.rmw.xchg
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\42" ;; i64.atomic.rmw.xchg
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\43" ;; i32.atomic.rmw8.xchg_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\43" ;; i32.atomic.rmw8.xchg_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\43" ;; i32.atomic.rmw8.xchg_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\43" ;; i32.atomic.rmw8.xchg_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\43" ;; i32.atomic.rmw8.xchg_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4333,8 +4333,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\43" ;; i32.atomic.rmw8.xchg_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4342,65 +4342,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\43" ;; i32.atomic.rmw8.xchg_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\43" ;; i32.atomic.rmw8.xchg_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\43" ;; i32.atomic.rmw8.xchg_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\44" ;; i32.atomic.rmw16.xchg_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\44" ;; i32.atomic.rmw16.xchg_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\44" ;; i32.atomic.rmw16.xchg_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\44" ;; i32.atomic.rmw16.xchg_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\44" ;; i32.atomic.rmw16.xchg_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4408,8 +4408,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\44" ;; i32.atomic.rmw16.xchg_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4417,65 +4417,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\44" ;; i32.atomic.rmw16.xchg_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\44" ;; i32.atomic.rmw16.xchg_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
     "\fe\44" ;; i32.atomic.rmw16.xchg_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\45" ;; i64.atomic.rmw8.xchg_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\45" ;; i64.atomic.rmw8.xchg_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\45" ;; i64.atomic.rmw8.xchg_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\45" ;; i64.atomic.rmw8.xchg_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\45" ;; i64.atomic.rmw8.xchg_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4483,8 +4483,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\45" ;; i64.atomic.rmw8.xchg_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4492,65 +4492,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\45" ;; i64.atomic.rmw8.xchg_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\45" ;; i64.atomic.rmw8.xchg_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\45" ;; i64.atomic.rmw8.xchg_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\46" ;; i64.atomic.rmw16.xchg_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\46" ;; i64.atomic.rmw16.xchg_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\46" ;; i64.atomic.rmw16.xchg_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\46" ;; i64.atomic.rmw16.xchg_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\46" ;; i64.atomic.rmw16.xchg_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4558,8 +4558,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\46" ;; i64.atomic.rmw16.xchg_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4567,65 +4567,65 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\46" ;; i64.atomic.rmw16.xchg_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\46" ;; i64.atomic.rmw16.xchg_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\46" ;; i64.atomic.rmw16.xchg_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\47" ;; i64.atomic.rmw32.xchg_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\47" ;; i64.atomic.rmw32.xchg_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\47" ;; i64.atomic.rmw32.xchg_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\47" ;; i64.atomic.rmw32.xchg_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\47" ;; i64.atomic.rmw32.xchg_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4633,8 +4633,8 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\47" ;; i64.atomic.rmw32.xchg_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4642,70 +4642,70 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\47" ;; i64.atomic.rmw32.xchg_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\47" ;; i64.atomic.rmw32.xchg_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
     "\fe\47" ;; i64.atomic.rmw32.xchg_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\48" ;; i32.atomic.rmw.cmpxchg
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\48" ;; i32.atomic.rmw.cmpxchg
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\48" ;; i32.atomic.rmw.cmpxchg
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\48" ;; i32.atomic.rmw.cmpxchg
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\48" ;; i32.atomic.rmw.cmpxchg
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4713,9 +4713,9 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\48" ;; i32.atomic.rmw.cmpxchg
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4723,73 +4723,73 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\48" ;; i32.atomic.rmw.cmpxchg
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\48" ;; i32.atomic.rmw.cmpxchg
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\48" ;; i32.atomic.rmw.cmpxchg
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\49" ;; i64.atomic.rmw.cmpxchg
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\49" ;; i64.atomic.rmw.cmpxchg
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\49" ;; i64.atomic.rmw.cmpxchg
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\49" ;; i64.atomic.rmw.cmpxchg
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\49" ;; i64.atomic.rmw.cmpxchg
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4797,9 +4797,9 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\49" ;; i64.atomic.rmw.cmpxchg
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4807,73 +4807,73 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\49" ;; i64.atomic.rmw.cmpxchg
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\49" ;; i64.atomic.rmw.cmpxchg
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\49" ;; i64.atomic.rmw.cmpxchg
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\4a" ;; i32.atomic.rmw8.cmpxchg_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\4a" ;; i32.atomic.rmw8.cmpxchg_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\4a" ;; i32.atomic.rmw8.cmpxchg_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\4a" ;; i32.atomic.rmw8.cmpxchg_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\4a" ;; i32.atomic.rmw8.cmpxchg_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4881,9 +4881,9 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\4a" ;; i32.atomic.rmw8.cmpxchg_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4891,73 +4891,73 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\4a" ;; i32.atomic.rmw8.cmpxchg_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\4a" ;; i32.atomic.rmw8.cmpxchg_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\4a" ;; i32.atomic.rmw8.cmpxchg_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\4b" ;; i32.atomic.rmw16.cmpxchg_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\4b" ;; i32.atomic.rmw16.cmpxchg_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\4b" ;; i32.atomic.rmw16.cmpxchg_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\4b" ;; i32.atomic.rmw16.cmpxchg_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\4b" ;; i32.atomic.rmw16.cmpxchg_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4965,9 +4965,9 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\4b" ;; i32.atomic.rmw16.cmpxchg_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -4975,73 +4975,73 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\4b" ;; i32.atomic.rmw16.cmpxchg_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\4b" ;; i32.atomic.rmw16.cmpxchg_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\41\33" ;; (i32.const 51)
-    "\41\33" ;; (i32.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 51)
+    "\41\00" ;; (i32.const 51)
     "\fe\4b" ;; i32.atomic.rmw16.cmpxchg_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4c" ;; i64.atomic.rmw8.cmpxchg_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4c" ;; i64.atomic.rmw8.cmpxchg_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4c" ;; i64.atomic.rmw8.cmpxchg_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4c" ;; i64.atomic.rmw8.cmpxchg_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4c" ;; i64.atomic.rmw8.cmpxchg_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -5049,9 +5049,9 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4c" ;; i64.atomic.rmw8.cmpxchg_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -5059,73 +5059,73 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4c" ;; i64.atomic.rmw8.cmpxchg_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4c" ;; i64.atomic.rmw8.cmpxchg_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4c" ;; i64.atomic.rmw8.cmpxchg_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4d" ;; i64.atomic.rmw16.cmpxchg_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4d" ;; i64.atomic.rmw16.cmpxchg_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4d" ;; i64.atomic.rmw16.cmpxchg_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4d" ;; i64.atomic.rmw16.cmpxchg_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4d" ;; i64.atomic.rmw16.cmpxchg_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -5133,9 +5133,9 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4d" ;; i64.atomic.rmw16.cmpxchg_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -5143,73 +5143,73 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4d" ;; i64.atomic.rmw16.cmpxchg_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4d" ;; i64.atomic.rmw16.cmpxchg_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4d" ;; i64.atomic.rmw16.cmpxchg_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4e" ;; i64.atomic.rmw32.cmpxchg_u
     "\02" ;; Alignment of 2
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4e" ;; i64.atomic.rmw32.cmpxchg_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4e" ;; i64.atomic.rmw32.cmpxchg_u
     "\22" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4e" ;; i64.atomic.rmw32.cmpxchg_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4e" ;; i64.atomic.rmw32.cmpxchg_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -5217,9 +5217,9 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\41\33" ;; (i32.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\41\00" ;; (i32.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4e" ;; i64.atomic.rmw32.cmpxchg_u
     "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
@@ -5227,30 +5227,30 @@
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4e" ;; i64.atomic.rmw32.cmpxchg_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4e" ;; i64.atomic.rmw32.cmpxchg_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
-    "\42\33" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 0)
+    "\42\00" ;; (i64.const 51)
+    "\42\00" ;; (i64.const 51)
     "\fe\4e" ;; i64.atomic.rmw32.cmpxchg_u
-    "\62" ;; Alignment of 2 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\63" ;; Alignment of 3 with bit 5 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset


### PR DESCRIPTION
Atomic memory accesses trap when unaligned, so these tests wouldn't execute successfully (although nothing is executed today, these are only parsed). Change the test to always read from address 0 with the natural alignment of the instruction (2 for i32, 3 for i64).

Part of #8165.