### PR TITLE
NFC: Use the correct memory order in doAtomicLoad

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -4028,7 +4028,7 @@ public:
     auto addr =
       info.instance->getFinalAddress(curr, ptr.getSingleValue(), memorySize);
     auto loaded = info.instance->doAtomicLoad(
-      addr, curr->bytes, curr->type, info.name, memorySize);
+      addr, curr->bytes, curr->type, info.name, memorySize, curr->order);
     auto computed = value.getSingleValue();
     switch (curr->op) {
       case RMWAdd:
@@ -4063,7 +4063,7 @@ public:
       info.instance->getFinalAddress(curr, ptr.getSingleValue(), memorySize);
     expected = Flow(wrapToSmallerSize(expected.getSingleValue(), curr->bytes));
     auto loaded = info.instance->doAtomicLoad(
-      addr, curr->bytes, curr->type, info.name, memorySize);
+      addr, curr->bytes, curr->type, info.name, memorySize, curr->order);
     if (loaded == expected.getSingleValue()) {
       info.instance->doAtomicStore(
         addr, curr->bytes, replacement.getSingleValue(), info.name, memorySize);
@@ -4079,8 +4079,12 @@ public:
     auto memorySize = info.instance->getMemorySize(info.name);
     auto addr = info.instance->getFinalAddress(
       curr, ptr.getSingleValue(), bytes, memorySize);
-    auto loaded = info.instance->doAtomicLoad(
-      addr, bytes, curr->expectedType, info.name, memorySize);
+    auto loaded = info.instance->doAtomicLoad(addr,
+                                              bytes,
+                                              curr->expectedType,
+                                              info.name,
+                                              memorySize,
+                                              MemoryOrder::SeqCst);
     if (loaded != expected.getSingleValue()) {
       return Literal(int32_t(1)); // not equal
     }
@@ -5149,8 +5153,15 @@ protected:
     }
   }
 
-  Literal doAtomicLoad(
-    Address addr, Index bytes, Type type, Name memoryName, Address memorySize) {
+  Literal doAtomicLoad(Address addr,
+                       Index bytes,
+                       Type type,
+                       Name memoryName,
+                       Address memorySize,
+                       MemoryOrder order) {
+    if (order == MemoryOrder::Unordered) {
+      Fatal() << "Expected a non-unordered MemoryOrder in doAtomicLoad";
+    }
     checkAtomicAddress(addr, bytes, memorySize);
     Const ptr;
     ptr.value = Literal(int32_t(addr));
@@ -5161,7 +5172,7 @@ protected:
     // always an unsigned extension.
     load.signed_ = false;
     load.align = bytes;
-    load.order = MemoryOrder::SeqCst;
+    load.order = order;
     load.ptr = &ptr;
     load.type = type;
     load.memory = memoryName;


### PR DESCRIPTION
This doesn't actually do anything because `load.order` is unused in `doAtomicLoad()` + `load()` [1](https://github.com/WebAssembly/binaryen/blob/034ec39d2b8073006e279e5177005e1683a19752/src/wasm-interpreter.h#L5168), [2](https://github.com/WebAssembly/binaryen/blob/034ec39d2b8073006e279e5177005e1683a19752/src/wasm-interpreter.h#L2986). Change the code to ensure that it remains correct in case of future changes.