### PR TITLE
Fuzzer: Remove assert on being in a function context before emitting RefAs

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -3859,7 +3859,6 @@ Expression* TranslateToFuzzReader::makeBasicRef(Type type) {
     case HeapType::noexn: {
       auto null = builder.makeRefNull(heapType.getBasic(share));
       if (!type.isNullable()) {
-        assert(funcContext);
         return builder.makeRefAs(RefAsNonNull, null);
       }
       return null;


### PR DESCRIPTION
We do not want to assert there: if we are in a global, the caller will find
the RefAs and replace the entire value. That is, we have existing
mechanisms to handle that, and the assert was making us crash instead.