### PR TITLE
[NFC] Make module-level annotations available

### DIFF
--- a/src/parser/contexts.h
+++ b/src/parser/contexts.h
@@ -1430,7 +1430,7 @@ struct ParseModuleTypesCtx : TypeParserCtx<ParseModuleTypesCtx>,
                    TypeUse type,
                    Exactness exact,
                    std::optional<LocalsT> locals,
-                   std::vector<Annotation>&&,
+                   std::vector<Annotation>&& annotations,
                    Index pos) {
     auto& f = wasm.functions[index];
     if (!type.type.isSignature()) {

--- a/src/parser/lexer.h
+++ b/src/parser/lexer.h
@@ -185,7 +185,7 @@ public:
   const std::vector<Annotation> getAnnotations() { return annotations; }
   std::vector<Annotation> takeAnnotations() { return std::move(annotations); }
 
-  void setAnnotations(std::vector<Annotation>&& annotations) {
+  void setAnnotations(std::vector<Annotation> annotations) {
     this->annotations = std::move(annotations);
   }
 

--- a/src/parser/parse-5-defs.cpp
+++ b/src/parser/parse-5-defs.cpp
@@ -45,6 +45,7 @@ Result<> parseDefinitions(
     auto* f = decls.wasm.functions[i].get();
     WithPosition with(ctx, decls.funcDefs[i].pos);
     ctx.setSrcLoc(decls.funcDefs[i].annotations);
+    ctx.in.setAnnotations(std::move(decls.funcDefs[i].annotations));
     if (!f->imported()) {
       CHECK_ERR(ctx.visitFunctionStart(f));
     }

--- a/src/parser/wat-parser-internal.h
+++ b/src/parser/wat-parser-internal.h
@@ -80,6 +80,7 @@ Result<> parseDefs(Ctx& ctx,
   for (auto& def : defs) {
     ctx.index = def.index;
     WithPosition with(ctx, def.pos);
+    ctx.in.setAnnotations(def.annotations);
     if (auto parsed = parser(ctx)) {
       CHECK_ERR(parsed);
     } else {


### PR DESCRIPTION
We already had some code for collecting annotations on top-level module
fields like functions, but they were only passed to the parsing context
in the initial parsing phase. Fix the parser so that the annotations are
passed in all phases. This was tested locally by printing function
annotations, but will not be testable for real until we start doing
something with the annotations.

Fixes #8260.
