### PR TITLE
Start emitting struct.new_desc in binaries

### DIFF
--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -2143,10 +2143,9 @@ Result<> IRBuilder::makeStructNew(HeapType type, bool isDesc) {
   if (isDesc && !type.getDescriptorType()) {
     return Err{"struct.new_desc of type without descriptor"};
   }
-  // TODO: Uncomment this after a transition period.
-  // if (!isDesc && type.getDescriptorType()) {
-  //   return Err{"type with descriptor requires struct.new_desc"};
-  // }
+  if (!isDesc && type.getDescriptorType()) {
+    return Err{"type with descriptor requires struct.new_desc"};
+  }
   StructNew curr(wasm.allocator);
   curr.type = Type(type, NonNullable, Exact);
   curr.operands.resize(type.getStruct().fields.size());
@@ -2159,10 +2158,9 @@ Result<> IRBuilder::makeStructNewDefault(HeapType type, bool isDesc) {
   if (isDesc && !type.getDescriptorType()) {
     return Err{"struct.new_default_desc of type without descriptor"};
   }
-  // TODO: Uncomment this after a transition period.
-  // if (!isDesc && type.getDescriptorType()) {
-  //   return Err{"type with descriptor requires struct.new_default_desc"};
-  // }
+  if (!isDesc && type.getDescriptorType()) {
+    return Err{"type with descriptor requires struct.new_default_desc"};
+  }
   StructNew curr(wasm.allocator);
   curr.type = Type(type, NonNullable, Exact);
   CHECK_ERR(visitStructNew(&curr));

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -2418,17 +2418,13 @@ void BinaryInstWriter::visitStructNew(StructNew* curr) {
   o << int8_t(BinaryConsts::GCPrefix);
   if (curr->isWithDefault()) {
     if (curr->desc) {
-      // TODO: Start emitting the new opcode once V8 supports it.
-      // o << U32LEB(BinaryConsts::StructNewDefaultDesc);
-      o << U32LEB(BinaryConsts::StructNewDefault);
+      o << U32LEB(BinaryConsts::StructNewDefaultDesc);
     } else {
       o << U32LEB(BinaryConsts::StructNewDefault);
     }
   } else {
     if (curr->desc) {
-      // TODO: Start emitting the new opcode once V8 supports it.
-      // o << U32LEB(BinaryConsts::StructNewDesc);
-      o << U32LEB(BinaryConsts::StructNew);
+      o << U32LEB(BinaryConsts::StructNewDesc);
     } else {
       o << U32LEB(BinaryConsts::StructNew);
     }


### PR DESCRIPTION
As well as struct.new_default_desc now that V8 has supported these
instructions for a couple of versions. Also newly validate in IRBuilder
that the correct instruction is used.
