### PR TITLE
[JS API] Throw useful exceptions on parse errors

### DIFF
--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -3264,10 +3264,10 @@ function handleFatalError(func) {
   } catch (e) {
     // C++ exceptions are thrown as pointers (numbers).
     if (typeof e === 'number') {
-      // Fatal errors begin with that prefix. Strip it out.
+      // Fatal errors begin with that prefix. Strip it out, and the newline.
       var [_, message] = getExceptionMessage(e);
       if (message?.startsWith('Fatal: ')) {
-        throw new Error(message.substr(7));
+        throw new Error(message.substr(7).trim());
       }
     }
     // Rethrow anything else.

--- a/test/binaryen.js/atomics.js
+++ b/test/binaryen.js/atomics.js
@@ -1,22 +1,3 @@
-
-
-try {
-  console.log('parsing invalid text...');
-  binaryen.parseText(`(module
-    (func (export "foo") (param $a i32) local.get $a)
-    (func (export "bar") (paXam $b i32) local.get $b)
-  )`)
-  console.log('no error');
-} catch (e) {
-  console.log('outside caught', e);
-  console.log(typeof e)
-  console.log(JSON.stringify(e));
-  console.log(e.message);
-  console.log(JSON.stringify(e.message));
-}
-
-throw 'foo';
-
 var wast = `
 (module
   (memory $0 1 1 shared)

--- a/test/binaryen.js/errors.js
+++ b/test/binaryen.js/errors.js
@@ -1,0 +1,17 @@
+// Parse invalid text and get a JS exception.
+var caughtAsExpected = false;
+try {
+  console.log('parsing invalid text...');
+  binaryen.parseText(`(module
+    ;; error on next line
+    (func $foo (param__error $x i32))
+  )`)
+  console.log('no error - invalid');
+} catch (e) {
+  assert(e.message === '3:16: error: unrecognized instruction');
+  caughtAsExpected = true;
+}
+assert(caughtAsExpected);
+
+console.log('success.');
+

--- a/test/binaryen.js/errors.js.txt
+++ b/test/binaryen.js/errors.js.txt
@@ -1,0 +1,1 @@
+success.


### PR DESCRIPTION
wasm-opt will just fatally error on invalid module inputs, but binaryen.js
is a library and users want to get something they can handle, and see
the actual error. This PR throws a C++ exception instead, and converts
it on the JS side.

Fixes #8256