### PR TITLE
Don't test split modules for tests with (module instance ...)

### DIFF
--- a/check.py
+++ b/check.py
@@ -198,6 +198,13 @@ def check_expected(actual, expected, stdout=None):
             shared.fail(actual, expected)
 
 
+UNSPLITTABLE_TESTS = [Path(x) for x in ["spec/testsuite/instance.wast"]]
+
+
+def is_splittable(wast: Path):
+    return not any(wast.match(unsplittable_test) for unsplittable_test in UNSPLITTABLE_TESTS)
+
+
 def run_one_spec_test(wast: Path, stdout=None):
     test_name = wast.name
 
@@ -223,6 +230,9 @@ def run_one_spec_test(wast: Path, stdout=None):
             raise
 
     check_expected(actual, expected, stdout=stdout)
+
+    if not is_splittable(wast):
+        return
 
     # check binary format. here we can verify execution of the final
     # result, no need for an output verification

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -423,9 +423,7 @@ SPEC_TESTSUITE_TESTS_TO_SKIP = [
     'proposals/threads/memory.wast',  # Missing memory type validation on instantiation
     'annotations.wast',  # String annotations IDs should be allowed
     'id.wast',       # Empty IDs should be disallowed
-    # Requires correct handling of tag imports from different instances of the same module
-    # and splitting for module instances
-    'instance.wast',
+    'instance.wast',  # Requires correct handling of tag imports from different instances of the same module
     'table64.wast',   # Requires validations for table size
     'tag.wast',      # Non-empty tag results allowed by stack switching
     'local_init.wast',  # Requires local validation to respect unnamed blocks


### PR DESCRIPTION
Currently we can't split tests like this. We'd need to optimize module definitions while leaving (module instance ...) statements in-tact. For now, skip splitting for these cases to allow us to run spec tests with the interpreter normally.

Tested with a modified version of `instance.wast` that passes. Part of #8261.