### PR TITLE
Use real RuntimeTables for non-imported tables in ctor-eval

### DIFF
--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -206,7 +206,8 @@ public:
           instanceInitialized,
           wasm,
           [this](Name name, Type type) { return makeFuncData(name, type); }),
-        linkedInstances_) {}
+        linkedInstances_),
+      instanceInitialized(instanceInitialized) {}
 
   Flow visitGlobalGet(GlobalGet* curr) {
     // Error on reads of imported globals.
@@ -230,6 +231,14 @@ public:
     throw FailToEvalException("TODO: table.set");
   }
 
+  Flow visitTableInit(TableInit* curr) {
+    if (instanceInitialized) {
+      throw FailToEvalException("TODO: table.init");
+    }
+
+    return ModuleRunnerBase<EvallingModuleRunner>::visitTableInit(curr);
+  }
+
   bool allowContNew = true;
 
   Flow visitContNew(ContNew* curr) {
@@ -250,6 +259,9 @@ public:
 #endif
     return Literal(allocation, type);
   }
+
+private:
+  const bool& instanceInitialized;
 };
 
 // Build an artificial `env` module based on a module's imports, so that the

--- a/test/lit/ctor-eval/table.init.wat
+++ b/test/lit/ctor-eval/table.init.wat
@@ -11,6 +11,7 @@
  ;; CHECK:      (elem $init (i32.const 0) $nop)
  (elem $init (i32.const 0) $nop)
 
+ ;; CHECK:      (elem $later func $trap)
  (elem $later $trap)
 
  (export "run" (func $run))
@@ -42,11 +43,19 @@
   (nop)
  )
 
+ ;; CHECK:      (func $trap (type $none_=>_none)
+ ;; CHECK-NEXT:  (unreachable)
+ ;; CHECK-NEXT: )
  (func $trap (type $none_=>_none)
   (unreachable)
  )
 )
 ;; CHECK:      (func $run_3 (type $none_=>_none)
+;; CHECK-NEXT:  (table.init $table $later
+;; CHECK-NEXT:   (i32.const 0)
+;; CHECK-NEXT:   (i32.const 0)
+;; CHECK-NEXT:   (i32.const 1)
+;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (call_indirect $table (type $none_=>_none)
 ;; CHECK-NEXT:   (i32.const 0)
 ;; CHECK-NEXT:  )


### PR DESCRIPTION
Followup to https://github.com/WebAssembly/binaryen/pull/8194#discussion_r2710732168.

Removes some complexity in wasm-interpeter.h since we no longer need to inject a factory function for creating tables (we instead always create a RealRuntimeTable). Also potentially allows more optimizations on non-imported tables in ctor-eval.

visitTableSet and visitTableInit throw FailToEvalException after instantiation like the code before [the RuntimeTable refactoring](https://github.com/WebAssembly/binaryen/blob/181b356dc5de0fb581b2afed71386034b8641ec3/src/tools/wasm-ctor-eval.cpp#L377).