### PR TITLE
[NFC] Print basic heap types in ModuleType

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -3946,7 +3946,10 @@ std::ostream& operator<<(std::ostream& o, wasm::ModuleType pair) {
 std::ostream& operator<<(std::ostream& o, wasm::ModuleHeapType pair) {
   if (auto it = pair.first.typeNames.find(pair.second);
       it != pair.first.typeNames.end()) {
-    return o << it->second.name;
+    return o << '$' << it->second.name;
+  }
+  if (pair.second.isBasic()) {
+    return o << pair.second;
   }
   return o << "(unnamed)";
 }


### PR DESCRIPTION
They were previously printed as "(unnamed)". Instead, prefix defined
type names with a $ and print basic type names as well. This makes debug
logging output in various passes more informative.
