### PR TITLE
Fix BinaryenAddTagImport using getGlobalOrNull instead of getTagOrNull

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -5281,7 +5281,7 @@ void BinaryenAddTagImport(BinaryenModuleRef module,
                           const char* externalBaseName,
                           BinaryenType params,
                           BinaryenType results) {
-  auto* tag = ((Module*)module)->getGlobalOrNull(internalName);
+  auto* tag = ((Module*)module)->getTagOrNull(internalName);
   if (tag == nullptr) {
     auto tag = std::make_unique<Tag>();
     tag->name = internalName;


### PR DESCRIPTION
## Summary
- Fix copy-paste bug in `BinaryenAddTagImport` where `getGlobalOrNull` was used instead of `getTagOrNull`

Fixes #8272.