### PR TITLE
Fix dead visitor guards in LLVMMemoryCopyFillLowering

### DIFF
--- a/src/passes/LLVMMemoryCopyFillLowering.cpp
+++ b/src/passes/LLVMMemoryCopyFillLowering.cpp
@@ -246,11 +246,11 @@ struct LLVMMemoryCopyFillLowering
     module->getFunction(memFillFuncName)->body = body;
   }
 
-  void VisitTableCopy(TableCopy* curr) {
+  void visitTableCopy(TableCopy* curr) {
     Fatal() << "table.copy instruction found. Memory copy lowering is not "
                "designed to work on modules with bulk table operations";
   }
-  void VisitTableFill(TableCopy* curr) {
+  void visitTableFill(TableFill* curr) {
     Fatal() << "table.fill instruction found. Memory copy lowering is not "
                "designed to work on modules with bulk table operations";
   }

--- a/test/lit/passes/memory-copy-fill-lowering-table-error.wast
+++ b/test/lit/passes/memory-copy-fill-lowering-table-error.wast
@@ -1,0 +1,14 @@
+;; The llvm-memory-copy-fill-lowering pass should Fatal() when a module
+;; contains table.copy, since it does not support bulk table operations.
+
+;; RUN: not wasm-opt --enable-bulk-memory %s --llvm-memory-copy-fill-lowering 2>&1 | filecheck %s
+;; CHECK: table.copy instruction found
+
+(module
+ (memory 0)
+ (table $t 1 funcref)
+ (func $test
+  (memory.copy (i32.const 0) (i32.const 0) (i32.const 0))
+  (table.copy $t $t (i32.const 0) (i32.const 0) (i32.const 0))
+ )
+)

--- a/test/lit/passes/memory-copy-fill-lowering-table-fill-error.wast
+++ b/test/lit/passes/memory-copy-fill-lowering-table-fill-error.wast
@@ -1,0 +1,14 @@
+;; The llvm-memory-copy-fill-lowering pass should Fatal() when a module
+;; contains table.fill, since it does not support bulk table operations.
+
+;; RUN: not wasm-opt --enable-bulk-memory --enable-reference-types %s --llvm-memory-copy-fill-lowering 2>&1 | filecheck %s
+;; CHECK: table.fill instruction found
+
+(module
+ (memory 0)
+ (table $t 1 funcref)
+ (func $test
+  (memory.copy (i32.const 0) (i32.const 0) (i32.const 0))
+  (table.fill $t (i32.const 0) (ref.null func) (i32.const 0))
+ )
+)


### PR DESCRIPTION
The `visitTableCopy` and `visitTableFill` guards in `LLVMMemoryCopyFillLowering` were defined with an uppercase `V` (`VisitTableCopy`, `VisitTableFill`). The PostWalker dispatches to lowercase `visit*` methods, so these guards were never called. Additionally, `VisitTableFill` had the wrong parameter type (`TableCopy*` instead of `TableFill*`).

This means a module containing `table.copy` or `table.fill` would not get the intended `Fatal()` error from this pass.

Three changes:
- `VisitTableCopy` -> `visitTableCopy`
- `VisitTableFill` -> `visitTableFill`
- `TableCopy*` -> `TableFill*` in `visitTableFill`'s parameter

Tests: added two lit tests that verify the pass now Fatal()s on `table.copy` and `table.fill`.