### PR TITLE
Fix updateSymbol calls misplaced inside loop in copyFunctionWithoutAdd

### DIFF
--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -93,9 +93,9 @@ copyFunctionWithoutAdd(Function* func,
             (*symbolNameIndexMap)[*(iter.second->symbolNameIndex)];
         }
       }
-      updateSymbol(ret->prologLocation, *symbolNameIndexMap);
-      updateSymbol(ret->epilogLocation, *symbolNameIndexMap);
     }
+    updateSymbol(ret->prologLocation, *symbolNameIndexMap);
+    updateSymbol(ret->epilogLocation, *symbolNameIndexMap);
   }
   ret->module = func->module;
   ret->base = func->base;


### PR DESCRIPTION
## Summary
- Move `updateSymbol` calls for `prologLocation`/`epilogLocation` outside the `debugLocations` loop in `copyFunctionWithoutAdd`, matching the pattern of the `updateLocation` calls in the `fileIndexMap` block above

The `updateSymbol` calls were a copy-paste error from the `fileIndexMap` block. Being inside the loop caused two issues:
1. When `debugLocations` is empty, the loop never executes and `prologLocation`/`epilogLocation` symbol indices are never remapped
2. When `debugLocations` has multiple entries, the indices are double-remapped (or cause OOB access)

## Test plan
- Added two tests to `source-map.cpp`:
  - `UpdateSymbolOutsideLoop`: verifies remapping works when `debugLocations` is empty
  - `UpdateSymbolNotDoubleRemapped`: verifies remapping happens exactly once with multiple debug locations
- Both tests fail before the fix and pass after