### PR TITLE
Fix crash in interpreter when instantiating modules with imported globals

### DIFF
--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -293,6 +293,9 @@ Result<> Interpreter::addInstance(std::shared_ptr<Module> wasm) {
 
 Result<> Interpreter::instantiate(Instance& instance) {
   for (auto& global : instance.wasm->globals) {
+    if (global->imported()) {
+      continue;
+    }
     store.callStack.emplace_back(instance, ExpressionIterator(global->init));
     auto results = run();
     assert(results.size() == 1);


### PR DESCRIPTION
## Summary

- `Interpreter::instantiate()` iterates all globals without checking `imported()`, causing `ExpressionIterator` to be constructed with a null `init` expression for imported globals. This triggers an assertion failure in `PostWalker::walk()` (debug) or a null-pointer dereference (release).
- Added a `global->imported()` check to skip imported globals during instantiation, matching the pattern used by `walkModule()` in `wasm-traversal.h`.
- Added two test cases: one for a module with only imported globals, and one for a module mixing imported and local globals.

## Test plan

- [x] `InterpreterTest.ImportedGlobalI32` — verifies `addInstance` succeeds with an imported global
- [x] `InterpreterTest.MixedImportedAndLocalGlobals` — verifies a local global is correctly initialized when an imported global is also present
- [x] All 56 interpreter tests pass