### PR TITLE
Fix dangling Instance references in interpreter store

### DIFF
--- a/src/interpreter/store.h
+++ b/src/interpreter/store.h
@@ -18,6 +18,7 @@
 #define interpreter_store_h
 
 #include <cassert>
+#include <deque>
 #include <vector>
 
 #include "expression-iterator.h"
@@ -65,7 +66,10 @@ struct WasmStore {
   // TODO: Storage for memories, tables, globals, heap objects, etc.
   // TODO: Map instances and import names to other instances to find imports.
   std::vector<Frame> callStack;
-  std::vector<Instance> instances;
+  // Use std::deque so that references to existing Instance objects are not
+  // invalidated when new instances are added.  Frame holds Instance& and would
+  // become dangling if a std::vector reallocated its storage.
+  std::deque<Instance> instances;
 
   Frame& getFrame() {
     assert(!callStack.empty());

--- a/test/gtest/interpreter.cpp
+++ b/test/gtest/interpreter.cpp
@@ -17,6 +17,7 @@
 // TODO: Replace this test file with spec tests as soon as possible.
 
 #include "interpreter/interpreter.h"
+#include "interpreter/store.h"
 #include "literal.h"
 #include "wasm-ir-builder.h"
 #include "wasm.h"
@@ -968,4 +969,32 @@ TEST(InterpreterTest, GlobalInitI32) {
   std::vector<Literal> expected{Literal(int32_t(5))};
 
   EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, InstanceReferenceStability) {
+  using namespace interpreter;
+
+  auto module = std::make_shared<Module>();
+
+  WasmStore store;
+  store.instances.emplace_back(module);
+  store.instances[0].globalValues["x"] = Literal(int32_t(42));
+
+  Instance* addrBefore = &store.instances[0];
+
+  ExpressionIterator emptyIter;
+  store.callStack.emplace_back(store.instances[0], std::move(emptyIter));
+
+  // Add many more instances to exercise container growth.
+  for (int i = 0; i < 100; ++i) {
+    store.instances.emplace_back(module);
+  }
+
+  // With std::deque, existing elements are never relocated.
+  Instance* addrAfter = &store.instances[0];
+  EXPECT_EQ(addrBefore, addrAfter);
+
+  // The frame's Instance& reference is still valid.
+  EXPECT_EQ(store.callStack.back().instance.globalValues["x"],
+            Literal(int32_t(42)));
 }


### PR DESCRIPTION
## Summary

- `WasmStore::instances` was a `std::vector<Instance>`, but `Frame` holds `Instance&` references. Vector reallocation when adding new instances invalidates all frame references, leading to use-after-free.
- Changed `instances` to `std::deque<Instance>`, which guarantees that references to existing elements are not invalidated by `push_back`/`emplace_back`.
- Added a test that verifies Instance addresses remain stable after adding many instances while a frame holds a reference.

## Test plan

- [x] `InterpreterTest.InstanceReferenceStability` — verifies that adding 100 instances does not relocate existing instances or invalidate frame references
- [x] All 55 interpreter tests pass