### PR TITLE
Fix Stack::compare ignoring element results for different-sized stacks

### DIFF
--- a/src/analysis/lattices/stack.h
+++ b/src/analysis/lattices/stack.h
@@ -120,12 +120,15 @@ template<Lattice L> struct Stack {
       if (itA == a.rend()) {
         // The rest of A's elements are bottom, but B has a non-bottom element
         // because of our invariant that the base of the materialized stack must
-        // not be bottom.
-        return LESS;
+        // not be bottom. If we previously found A > B for some element, the
+        // overall result is incomparable.
+        return result == GREATER ? NO_RELATION : LESS;
       }
       if (itB == b.rend()) {
         // The rest of B's elements are bottom, but A has a non-bottom element.
-        return GREATER;
+        // If we previously found A < B for some element, the overall result is
+        // incomparable.
+        return result == LESS ? NO_RELATION : GREATER;
       }
       switch (lattice.compare(*itA, *itB)) {
         case NO_RELATION:

--- a/test/gtest/lattices.cpp
+++ b/test/gtest/lattices.cpp
@@ -749,6 +749,22 @@ TEST(StackLattice, Join) {
                   {flat.get(0u), flat.getTop()});
 }
 
+TEST(StackLattice, CompareDifferentSizeConflict) {
+  analysis::Stack stack{analysis::Bool{}};
+
+  // a=[true, false]: base=true (valid, not bottom=false), top=false
+  // b=[true]: base=true (valid), top=true
+  //
+  // Comparison from the top of stack (rbegin):
+  //   false vs true -> LESS, then b is exhausted while a has extra elements.
+  //   The size difference implies GREATER, but the element comparison found
+  //   LESS, so the stacks are incomparable.
+  analysis::Stack<analysis::Bool>::Element a = {true, false};
+  analysis::Stack<analysis::Bool>::Element b = {true};
+  EXPECT_EQ(stack.compare(a, b), analysis::NO_RELATION);
+  EXPECT_EQ(stack.compare(b, a), analysis::NO_RELATION);
+}
+
 using OddEvenInt = analysis::Flat<uint32_t>;
 using OddEvenBool = analysis::Flat<bool>;
 struct OddEvenAbstraction


### PR DESCRIPTION
## Summary

When comparing stacks of different sizes, `Stack::compare` iterated from the top matching elements pairwise, accumulating a comparison result. However, when one stack was exhausted, it returned `LESS` or `GREATER` based solely on which stack was taller, **ignoring any contradicting result** from the element-wise comparisons.

For example, with `Stack<Bool>` comparing `[true, false]` against `[true]`:
- Top elements: `false` vs `true` → `LESS`
- Then `b` is exhausted, `a` has extra non-bottom elements → code returned `GREATER`
- Correct answer: `NO_RELATION` (the element ordering conflicts with the size ordering)

The fix checks the accumulated `result` before returning at the size-difference branches, returning `NO_RELATION` when there is a conflict.

Note: This bug was not caught by the lattice fuzzer because `Stack` is not included in the fuzz variants in `wasm-fuzz-lattices.cpp`.

## Test plan

- [x] Added `StackLattice.CompareDifferentSizeConflict` test case
- [x] All existing lattice tests still pass
- [x] Full unit test suite passes (304 tests)