### PR TITLE
Fix missing unreachable checks in Heap2Local visitStructRMW/visitStructCmpxchg

### DIFF
--- a/src/passes/Heap2Local.cpp
+++ b/src/passes/Heap2Local.cpp
@@ -1038,6 +1038,11 @@ struct Struct2Local : PostWalker<Struct2Local> {
       return;
     }
 
+    if (curr->type == Type::unreachable) {
+      // As with RefGetDesc and StructGet, above.
+      return;
+    }
+
     [[maybe_unused]] auto& field = fields[curr->index];
     auto type = curr->type;
     assert(type == field.type);
@@ -1105,6 +1110,11 @@ struct Struct2Local : PostWalker<Struct2Local> {
       // anything because we would still be performing the cmpxchg on a real
       // struct. We only need to replace the cmpxchg if the ref is being
       // replaced with locals.
+      return;
+    }
+
+    if (curr->type == Type::unreachable) {
+      // As with RefGetDesc and StructGet, above.
       return;
     }
 

--- a/test/lit/passes/heap2local-rmw.wast
+++ b/test/lit/passes/heap2local-rmw.wast
@@ -693,4 +693,61 @@
       (i32.const 2)
     )
   )
+
+  ;; CHECK:      (func $rmw-unreachable-value (type $1) (result i32)
+  ;; CHECK-NEXT:  (local $0 i32)
+  ;; CHECK-NEXT:  (block ;; (replaces unreachable StructRMW we can't emit)
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (block (result nullref)
+  ;; CHECK-NEXT:     (local.set $0
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (ref.null none)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (unreachable)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (unreachable)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $rmw-unreachable-value (result i32)
+    ;; When the value is unreachable, the whole expression is unreachable.
+    ;; We should not attempt to optimize this (it would hit an assertion
+    ;; on type == field.type since unreachable != i32).
+    (struct.atomic.rmw.add $i32 0
+      (struct.new_default $i32)
+      (unreachable)
+    )
+  )
+
+  ;; CHECK:      (func $cmpxchg-unreachable-expected (type $1) (result i32)
+  ;; CHECK-NEXT:  (local $0 i32)
+  ;; CHECK-NEXT:  (block ;; (replaces unreachable StructCmpxchg we can't emit)
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (block (result nullref)
+  ;; CHECK-NEXT:     (local.set $0
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (ref.null none)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (unreachable)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (unreachable)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $cmpxchg-unreachable-expected (result i32)
+    ;; When the expected operand is unreachable, the whole expression is
+    ;; unreachable. We should not attempt to optimize this.
+    (struct.atomic.rmw.cmpxchg $i32 0
+      (struct.new_default $i32)
+      (unreachable)
+      (i32.const 1)
+    )
+  )
 )


### PR DESCRIPTION
## Summary

`visitStructRMW` and `visitStructCmpxchg` in `Struct2Local` are missing the `Type::unreachable` guard that all sibling visitor methods have (`visitRefGetDesc`, `visitStructGet`, `visitRefIsNull`, `visitRefEq`). When a `struct.atomic.rmw` or `struct.atomic.rmw.cmpxchg` has an unreachable operand (e.g., unreachable value), the expression type is `unreachable` but the code asserts it equals the concrete field type, causing an assertion failure:

```
Assertion failed: (type == field.type), function visitStructRMW, file Heap2Local.cpp, line 1043.
```

This is the same bug pattern that was fixed in #8283 for `visitRefGetDesc` — it was just missed in these two methods.

## Fix

Add the same early-return guard for `Type::unreachable` to both `visitStructRMW` and `visitStructCmpxchg`.

## Test plan

- Added test cases for `struct.atomic.rmw.add` and `struct.atomic.rmw.cmpxchg` with unreachable operands to `test/lit/passes/heap2local-rmw.wast`
- Verified the crash reproduces without the fix and passes with it
- All lit tests pass