### PR TITLE
Fix missing implicitTrap for ArrayRMW and ArrayCmpxchg

### DIFF
--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -1027,9 +1027,8 @@ private:
       }
       parent.readsArray = true;
       parent.writesArray = true;
-      if (curr->ref->type.isNullable()) {
-        parent.implicitTrap = true;
-      }
+      // traps when the arg is null or the index out of bounds
+      parent.implicitTrap = true;
       assert(curr->order != MemoryOrder::Unordered);
       parent.isAtomic = true;
     }
@@ -1040,9 +1039,8 @@ private:
       }
       parent.readsArray = true;
       parent.writesArray = true;
-      if (curr->ref->type.isNullable()) {
-        parent.implicitTrap = true;
-      }
+      // traps when the arg is null or the index out of bounds
+      parent.implicitTrap = true;
       assert(curr->order != MemoryOrder::Unordered);
       parent.isAtomic = true;
     }


### PR DESCRIPTION
## Summary
- `visitArrayRMW` and `visitArrayCmpxchg` in `EffectAnalyzer` only set `implicitTrap` when the array reference is nullable, missing the out-of-bounds index case.
- All other indexed array operations (`ArrayGet`, `ArraySet`, `ArrayCopy`, `ArrayFill`, `ArrayInitData`, `ArrayInitElem`) correctly set `implicitTrap` unconditionally.
- Changed both to set `implicitTrap = true` unconditionally, matching the pattern of other array operations.

## Test plan
- All existing unit tests pass (309/309).
- The fix is a minimal change aligning `ArrayRMW`/`ArrayCmpxchg` with the existing pattern used by all other array operations.