### PR TITLE
Improve binaryenjs testing

### DIFF
--- a/scripts/test/binaryenjs.py
+++ b/scripts/test/binaryenjs.py
@@ -28,8 +28,8 @@ var binaryen = await Binaryen()
 // avoid stdout/stderr ordering issues in some js shells - use just stdout
 console.warn = console.error = console.log;
 
-function assert(x) {{
-    if (!x) throw Error('Test assertion failed');
+function assert(cond, msg='') {{
+    if (!cond) throw Error('Test assertion failed: ' + msg);
 }}
 '''
 

--- a/scripts/test/support.py
+++ b/scripts/test/support.py
@@ -16,6 +16,7 @@ import filecmp
 import io
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -224,13 +225,17 @@ def run_command(cmd, expected_status=0, stdout=None, stderr=None,
     out, err, code = _subprocess_run(cmd, stdout=subprocess.PIPE, stderr=stderr, encoding='UTF-8')
 
     if expected_status is not None and code != expected_status:
-        raise Exception(f"run_command `{' '.join(cmd)}` failed ({code}) {err or ''}")
+        if out:
+            print(out)
+        if err:
+            print(out, file=sys.stderr)
+        raise subprocess.CalledProcessError(f"run_command `{shlex.join(cmd)}` failed ({code})")
     if expected_err is not None:
         if err_ignore is not None:
             err = "\n".join([line for line in err.split('\n') if err_ignore not in line])
         err_correct = expected_err in err if err_contains else expected_err == err
         if not err_correct:
-            raise Exception(f"run_command unexpected stderr. Expected '{expected_err}', actual '{err}'")
+            raise subprocess.CalledProcessError(f"run_command unexpected stderr. Expected '{expected_err}', actual '{err}'")
     return out
 
 

--- a/test/binaryen.js/errors.js
+++ b/test/binaryen.js/errors.js
@@ -11,7 +11,7 @@ try {
   assert(e.message === '3:16: error: unrecognized instruction');
   caughtAsExpected = true;
 }
-assert(caughtAsExpected);
+assert(caughtAsExpected, 'no exception caught');
 
 console.log('success.');
 


### PR DESCRIPTION
- Add optional message to assert helper
- When a subprocess fails we should show both its stdout and stderr.  In the case when stderr was being captured we were not showing it at all. I think it makes sense to simply forward this rather than embed it in the thrown exception.