### PR TITLE
[test] Remove OrderedDict usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -875,16 +875,20 @@ Non-lit tests can also be automatically updated in most cases. See
 
 ### Setting up dependencies
 
+The Binaryen test suite is written in Python and requires Python >= 3.10.
+
+Additional dependencies (such as the `lit` test runner) are specifed in
+`requirements-dev.txt`.  Run `pip3 install -r requirements-dev.txt` to install
+these. Note that you need to have the location `pip` installs to in your `$PATH`
+(on linux, `~/.local/bin`).
+
 ```bash
 ./third_party/setup.py [mozjs|v8|wabt|all]
 ```
 
-(or `python third_party/setup.py`) installs required dependencies like the SpiderMonkey JS shell, the V8 JS shell
-and WABT in `third_party/`. Other scripts automatically pick these up when installed.
-
-Run `pip3 install -r requirements-dev.txt` to get the requirements for the `lit`
-tests. Note that you need to have the location `pip` installs to in your `$PATH`
-(on linux, `~/.local/bin`).
+(or `python third_party/setup.py`) installs required dependencies like the
+SpiderMonkey JS shell, the V8 JS shell and WABT in `third_party/`. Other scripts
+automatically pick these up when installed.
 
 ### Fuzzing
 

--- a/check.py
+++ b/check.py
@@ -20,12 +20,13 @@ import os
 import subprocess
 import sys
 import unittest
-from collections import OrderedDict
 from contextlib import contextmanager
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
 
 from scripts.test import binaryenjs, lld, shared, support, wasm2js, wasm_opt
+
+assert sys.version_info >= (3, 10), 'requires Python 3.10'
 
 
 def get_changelog_version():
@@ -416,25 +417,25 @@ def run_gtest():
             raise Exception("gtest test failed")
 
 
-TEST_SUITES = OrderedDict([
-    ('version', run_version_tests),
-    ('wasm-opt', wasm_opt.test_wasm_opt),
-    ('wasm-dis', run_wasm_dis_tests),
-    ('crash', run_crash_tests),
-    ('dylink', run_dylink_tests),
-    ('ctor-eval', run_ctor_eval_tests),
-    ('wasm-metadce', run_wasm_metadce_tests),
-    ('wasm-reduce', run_wasm_reduce_tests),
-    ('spec', run_spec_tests),
-    ('lld', lld.test_wasm_emscripten_finalize),
-    ('wasm2js', wasm2js.test_wasm2js),
-    ('validator', run_validator_tests),
-    ('example', run_example_tests),
-    ('unit', run_unittest),
-    ('binaryenjs', binaryenjs.test_binaryen_js),
-    ('lit', run_lit),
-    ('gtest', run_gtest),
-])
+TEST_SUITES = {
+    'version': run_version_tests,
+    'wasm-opt': wasm_opt.test_wasm_opt,
+    'wasm-dis': run_wasm_dis_tests,
+    'crash': run_crash_tests,
+    'dylink': run_dylink_tests,
+    'ctor-eval': run_ctor_eval_tests,
+    'wasm-metadce': run_wasm_metadce_tests,
+    'wasm-reduce': run_wasm_reduce_tests,
+    'spec': run_spec_tests,
+    'lld': lld.test_wasm_emscripten_finalize,
+    'wasm2js': wasm2js.test_wasm2js,
+    'validator': run_validator_tests,
+    'example': run_example_tests,
+    'unit': run_unittest,
+    'binaryenjs': binaryenjs.test_binaryen_js,
+    'lit': run_lit,
+    'gtest': run_gtest,
+}
 
 
 # Run all the tests

--- a/scripts/auto_update_tests.py
+++ b/scripts/auto_update_tests.py
@@ -17,7 +17,6 @@
 import os
 import subprocess
 import sys
-from collections import OrderedDict
 
 from test import binaryenjs, lld, shared, support, wasm2js, wasm_opt
 
@@ -159,19 +158,19 @@ def update_lit_tests():
                              '--binaryen-bin=' + shared.options.binaryen_bin])
 
 
-TEST_SUITES = OrderedDict([
-    ('wasm-opt', wasm_opt.update_wasm_opt_tests),
-    ('wasm-dis', update_wasm_dis_tests),
-    ('example', update_example_tests),
-    ('ctor-eval', update_ctor_eval_tests),
-    ('wasm-metadce', update_metadce_tests),
-    ('wasm-reduce', update_reduce_tests),
-    ('spec', update_spec_tests),
-    ('lld', lld.update_lld_tests),
-    ('wasm2js', wasm2js.update_wasm2js_tests),
-    ('binaryenjs', binaryenjs.update_binaryen_js_tests),
-    ('lit', update_lit_tests),
-])
+TEST_SUITES = {
+    'wasm-opt': wasm_opt.update_wasm_opt_tests,
+    'wasm-dis': update_wasm_dis_tests,
+    'example': update_example_tests,
+    'ctor-eval': update_ctor_eval_tests,
+    'wasm-metadce': update_metadce_tests,
+    'wasm-reduce': update_reduce_tests,
+    'spec': update_spec_tests,
+    'lld': lld.update_lld_tests,
+    'wasm2js': wasm2js.update_wasm2js_tests,
+    'binaryenjs': binaryenjs.update_binaryen_js_tests,
+    'lit': update_lit_tests,
+}
 
 
 def main():

--- a/scripts/gen-s-parser.py
+++ b/scripts/gen-s-parser.py
@@ -16,10 +16,7 @@
 
 import sys
 
-if sys.version_info < (3, 10):  # noqa: UP036
-    print("python 3.10 required")
-    sys.exit(1)
-
+assert sys.version_info >= (3, 10), 'requires Python 3.10'
 
 instructions = [
     ("unreachable",    "makeUnreachable()"),

--- a/third_party/setup.py
+++ b/third_party/setup.py
@@ -215,11 +215,11 @@ def wabt_main():
         print('* Something went wrong :(')
 
 
-TOOLS = collections.OrderedDict([
-    ('mozjs', mozjs_main),
-    ('v8', v8_main),
-    ('wabt', wabt_main),
-])
+TOOLS = {
+    'mozjs': mozjs_main,
+    'v8': v8_main,
+    'wabt': wabt_main,
+}
 
 if __name__ == '__main__':
     if len(sys.argv) < 2 or sys.argv[1] == '--help':


### PR DESCRIPTION
Builtin dicts are guaranteed ordered as of 3.7 and we require 3.10 these days.

Also, document the 3.10 requirement in the README file and make the runtime
checks consistent.