### PR TITLE
[test] Don't `--failfast` by default.

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -41,10 +41,10 @@ def parse_args(args):
         '--no-torture', dest='torture', action='store_false',
         help='Disables running the torture testcases.')
     parser.add_argument(
-        '--abort-on-first-failure', '--fail-fast', dest='abort_on_first_failure',
-        action=argparse.BooleanOptionalAction, default=True,
+        '--abort-on-first-failure', '--failfast', dest='abort_on_first_failure',
+        action=argparse.BooleanOptionalAction,
         help=('Specifies whether to halt test suite execution on first test error.'
-              ' Default: true.'))
+              ' Default: false.'))
     parser.add_argument(
         '--binaryen-bin', dest='binaryen_bin', default='',
         help=('Specifies the path to the Binaryen executables in the CMake build'


### PR DESCRIPTION
Normally this option default to false, and it seems like binaryen doesn't have a good reason to differ.

However, this setting (originally called `--abort-on-first-failure`) has always been enabled by default since its was first added back in #771.

Also name the option `--failfast` to match the name it has in the python unittest framework.