### PR TITLE
Fix sign extension of i32 addresses in interpreter memory access

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -5151,7 +5151,7 @@ protected:
   Address
   getFinalAddress(LS* curr, Literal ptr, Index bytes, Address memorySize) {
     Address memorySizeBytes = memorySize * Memory::kPageSize;
-    uint64_t addr = ptr.type == Type::i32 ? ptr.geti32() : ptr.geti64();
+    uint64_t addr = ptr.getUnsigned();
     trapIfGt(curr->offset, memorySizeBytes, "offset > memory");
     trapIfGt(addr, memorySizeBytes - curr->offset, "final > memory");
     addr += curr->offset;
@@ -5167,7 +5167,7 @@ protected:
 
   Address
   getFinalAddressWithoutOffset(Literal ptr, Index bytes, Address memorySize) {
-    uint64_t addr = ptr.type == Type::i32 ? ptr.geti32() : ptr.geti64();
+    uint64_t addr = ptr.getUnsigned();
     checkLoadAddress(addr, bytes, memorySize);
     return addr;
   }

--- a/test/lit/exec/simd-load-lane-oob.wast
+++ b/test/lit/exec/simd-load-lane-oob.wast
@@ -10,7 +10,7 @@
   (global $g (mut i32) (i32.const 0))
 
   ;; CHECK:      [fuzz-exec] calling oob
-  ;; CHECK-NEXT: [trap final > memory: 18446744073709551615 > 65536]
+  ;; CHECK-NEXT: [trap final > memory: 4294967295 > 65536]
   (func $oob (export "oob")
     (drop
       ;; This should trap, but not until after setting the global.
@@ -34,7 +34,7 @@
   )
 )
 ;; CHECK:      [fuzz-exec] calling oob
-;; CHECK-NEXT: [trap final > memory: 18446744073709551615 > 65536]
+;; CHECK-NEXT: [trap final > memory: 4294967295 > 65536]
 
 ;; CHECK:      [fuzz-exec] calling get
 ;; CHECK-NEXT: [fuzz-exec] note result: get => 1

--- a/test/passes/fuzz-exec_O.txt
+++ b/test/passes/fuzz-exec_O.txt
@@ -1,7 +1,7 @@
 [fuzz-exec] calling func_0
-[trap final > memory: 18446744073709551615 > 65514]
+[trap final > memory: 4294967295 > 65514]
 [fuzz-exec] calling func_1
-[trap final > memory: 18446744073709551615 > 65514]
+[trap final > memory: 4294967295 > 65514]
 (module
  (type $0 (func (result i64)))
  (type $1 (func (result i32)))
@@ -25,9 +25,9 @@
  )
 )
 [fuzz-exec] calling func_0
-[trap final > memory: 18446744073709551615 > 65514]
+[trap final > memory: 4294967295 > 65514]
 [fuzz-exec] calling func_1
-[trap final > memory: 18446744073709551615 > 65514]
+[trap final > memory: 4294967295 > 65514]
 [fuzz-exec] comparing func_0
 [fuzz-exec] comparing func_1
 [fuzz-exec] calling div

--- a/test/passes/fuzz-exec_all-features.txt
+++ b/test/passes/fuzz-exec_all-features.txt
@@ -68,7 +68,7 @@
 [fuzz-exec] calling wrap_cmpxchg
 [LoggingExternalInterface logging 42]
 [fuzz-exec] calling oob_notify
-[trap final > memory: 18446744073709551512 > 65514]
+[trap final > memory: 4294967192 > 65514]
 (module
  (type $0 (func (result i32)))
  (type $1 (func (param i32)))
@@ -137,7 +137,7 @@
 [fuzz-exec] calling wrap_cmpxchg
 [LoggingExternalInterface logging 42]
 [fuzz-exec] calling oob_notify
-[trap final > memory: 18446744073709551512 > 65514]
+[trap final > memory: 4294967192 > 65514]
 [fuzz-exec] comparing aligned_for_size
 [fuzz-exec] comparing oob_notify
 [fuzz-exec] comparing unaligned_load


### PR DESCRIPTION
## Summary

- Fix implicit sign extension of i32 addresses in `getFinalAddress` and `getFinalAddressWithoutOffset` in the interpreter
- `ptr.geti32()` returns `int32_t`, which gets sign-extended to `int64_t` via C++ ternary promotion rules before being stored as `uint64_t`
- For i32 addresses >= `0x80000000`, this produces incorrect 64-bit values (e.g., `0xFFFFFFFF80000000` instead of `0x80000000`), causing spurious out-of-bounds traps
- Fix by casting through `uint32_t` first to zero-extend instead of sign-extend

## Test plan

- [x] All 309 unit tests pass (`binaryen-unittests`)
- [x] Build succeeds with no warnings