### PR TITLE
Fix array.init_elem to use source offset when reading segment data

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -4597,7 +4597,8 @@ public:
       // of references in the table! ArrayNew suffers the same problem.
       // Fixing it will require changing how we represent segments, at least
       // in the interpreter.
-      data->values[indexVal + i] = self()->visit(seg->data[i]).getSingleValue();
+      data->values[indexVal + i] =
+        self()->visit(seg->data[offsetVal + i]).getSingleValue();
     }
     return {};
   }


### PR DESCRIPTION
## Summary
- Fixed a bug in the interpreter's `visitArrayInitElem` where the source offset parameter was ignored when reading from the element segment
- The loop used `seg->data[i]` instead of `seg->data[offsetVal + i]`, always reading from the start of the segment regardless of the specified offset
- The offset was already correctly computed and validated in the bounds check but not used in the actual data access, now consistent with `visitArrayInitData`

## Test plan
- [x] Builds successfully
- [x] All 309 unit tests pass (`binaryen-unittests`)