### PR TITLE
Add missing array bounds checks in visitArrayRMW and visitArrayCmpxchg

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -2415,6 +2415,9 @@ public:
       trap("null ref");
     }
     size_t indexVal = index.getSingleValue().getUnsigned();
+    if (indexVal >= data->values.size()) {
+      trap("array oob");
+    }
     auto& field = data->values[indexVal];
     auto oldVal = field;
     auto newVal = value.getSingleValue();
@@ -2451,6 +2454,9 @@ public:
       trap("null ref");
     }
     size_t indexVal = index.getSingleValue().getUnsigned();
+    if (indexVal >= data->values.size()) {
+      trap("array oob");
+    }
     auto& field = data->values[indexVal];
     auto oldVal = field;
     if (field == expected.getSingleValue()) {


### PR DESCRIPTION
## Summary

The interpreter's `visitArrayRMW` and `visitArrayCmpxchg` in `wasm-interpreter.h` access `data->values[indexVal]` without verifying that `indexVal` is within the array's bounds. This can lead to out-of-bounds memory access when the index exceeds the array length.

This PR adds the same bounds check pattern already used by `visitArrayGet` and `visitArraySet`:

```cpp
if (indexVal >= data->values.size()) {
  trap("array oob");
}
```

The check is added in both `visitArrayRMW` and `visitArrayCmpxchg`, immediately after computing `indexVal` and before accessing `data->values[indexVal]`.

## Test plan

- All 309 existing unit tests pass (`binaryen-unittests`).
- The fix follows the exact same pattern as the existing bounds checks in `visitArrayGet` (line 2318) and `visitArraySet` (line 2333), so it is consistent with the rest of the codebase.