### PR TITLE
Reject empty quoted identifiers in parser

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -422,7 +422,6 @@ SPEC_TESTSUITE_TESTS_TO_SKIP = [
     'linking.wast',  # Missing function type validation on instantiation
     'proposals/threads/memory.wast',  # Missing memory type validation on instantiation
     'annotations.wast',  # String annotations IDs should be allowed
-    'id.wast',       # Empty IDs should be disallowed
     'instance.wast',  # Requires support for table default elements
     'table64.wast',   # Requires validations for table size
     'tag.wast',      # Non-empty tag results allowed by stack switching

--- a/src/parser/lexer.cpp
+++ b/src/parser/lexer.cpp
@@ -866,10 +866,17 @@ std::optional<LexIdResult> ident(std::string_view in) {
   if (!ctx.takePrefix("$"sv)) {
     return {};
   }
+  // Quoted identifier e.g. $"foo"
   if (auto s = str(ctx.next())) {
     if (!String::isUTF8(s->getStr())) {
       return {};
     }
+
+    // empty names, including $"" are not allowed.
+    if (s->span == "\"\"") {
+      return {};
+    }
+
     ctx.isStr = true;
     ctx.str = s->str;
     ctx.take(*s);

--- a/test/gtest/wat-lexer.cpp
+++ b/test/gtest/wat-lexer.cpp
@@ -888,7 +888,7 @@ TEST(LexerTest, LexIdent) {
   EXPECT_FALSE(Lexer("$"sv).takeID());
 
   // String IDs
-  EXPECT_EQ(Lexer("$\"\""sv).takeID(), wasm::Name(""sv));
+  EXPECT_EQ(Lexer("$\"\""sv).takeID(), std::nullopt);
   EXPECT_EQ(Lexer("$\"hello\""sv).takeID(), wasm::Name("hello"sv));
   // _$_£_€_𐍈_
   EXPECT_EQ(Lexer("$\"_\\u{24}_\\u{00a3}_\\u{20AC}_\\u{10348}_\""sv).takeID(),

--- a/test/lit/basic/imported-params.wast
+++ b/test/lit/basic/imported-params.wast
@@ -7,7 +7,7 @@
 (module
  (import "" "" (func (param i32 i64) (param $x i32) (param $y i64) (param f32 f64)))
  (import "" "" (func (param $x i32) (param f32 f64) (param $y i64)))
- (import "" "" (func (param $"" i32)))
+ (import "" "" (func (param $"\tfoo" i32)))
 )
 ;; CHECK:      (type $0 (func (param i32 i64 i32 i64 f32 f64)))
 
@@ -19,4 +19,4 @@
 
 ;; CHECK:      (import "" "" (func $fimport$1 (param $x i32) (param f32 f64) (param $y i64)))
 
-;; CHECK:      (import "" "" (func $fimport$2 (param $"" i32)))
+;; CHECK:      (import "" "" (func $fimport$2 (param $"\tfoo" i32)))


### PR DESCRIPTION
Part of #8261. `""` previously parsed successfully as a name which doesn't match the spec. Change the code to fail to parse this case. Fixes id.wast spec test.