### PR TITLE
Add a RandomIteration utility

### DIFF
--- a/src/support/random_iteration.h
+++ b/src/support/random_iteration.h
@@ -24,7 +24,7 @@
 
 namespace wasm {
 
-// Provide RandomIterations and RandomConstIteration templates, which wrap an
+// Provide RandomIteration and RandomConstIteration templates, which wrap an
 // arbitrary collection with an associated `iterator` or `const_iterator` type,
 // respectively, and provide a randomized iteration order over it.
 //


### PR DESCRIPTION
This is a debugging aid for investigating determinism bugs where different iteration orders on unordered containers produce different output. These bugs usually manifest as different systems producing different output for the same input, but it is hard to debug across different systems. Using these utilities to wrap suspect containers can
help reproduce bugs across different executions on the same system.
