### PR TITLE
Fix determinism bug in type name updating

### DIFF
--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -352,8 +352,8 @@ void GlobalTypeRewriter::mapTypeNamesAndIndices(const TypeMap& oldToNewTypes) {
       auto deduped = Names::getValidName(
         names.name, [&](Name test) { return !seenTypeNames.count(test); });
       names.name = deduped;
-      // Do not overwrite the entry for the old type if it has already appeared
-      // as a new type.
+      // Use `insert` to avoid overwriting the entry for the old type if it has
+      // already appeared as a new type.
       if (newTypeNames.insert({old, names}).second) {
         seenTypeNames.insert(names.name);
       }


### PR DESCRIPTION
There was previously a determinism bug where the result of updating type
names could depend on the iteration order of the oldToNewTypes map. The
bug occurred when the new types were a shuffling of the old types. The
update loop updated the module's type names in-place for the new types,
and those in-place updates could affect later results if the updated new
types were later visited as old types.

Fix the bug by collecting all changes to apply before applying them to the module's types and indices. This does not affect any existing tests,
but it will unbreak CI for #8217.
