### PR TITLE
Use Address instead of size_t for table indicies

### DIFF
--- a/src/ir/runtime-table.cpp
+++ b/src/ir/runtime-table.cpp
@@ -31,7 +31,7 @@ namespace {
 
 } // namespace
 
-void RealRuntimeTable::set(std::size_t i, Literal l) {
+void RealRuntimeTable::set(Address i, Literal l) {
   if (i >= table.size()) {
     trap("RuntimeTable::set out of bounds");
     WASM_UNREACHABLE("trapped");
@@ -40,7 +40,7 @@ void RealRuntimeTable::set(std::size_t i, Literal l) {
   table[i] = std::move(l);
 }
 
-Literal RealRuntimeTable::get(std::size_t i) const {
+Literal RealRuntimeTable::get(Address i) const {
   if (i >= table.size()) {
     trap("out of bounds table access");
     WASM_UNREACHABLE("trapped");
@@ -49,10 +49,10 @@ Literal RealRuntimeTable::get(std::size_t i) const {
   return table[i];
 }
 
-std::optional<std::size_t> RealRuntimeTable::grow(std::size_t delta,
-                                                  Literal fill) {
-  std::size_t newSize;
-  if (std::ckd_add(&newSize, table.size(), delta)) {
+std::optional<Address> RealRuntimeTable::grow(Address delta, Literal fill) {
+  Address newSize;
+  if (std::ckd_add(
+        &newSize.addr, static_cast<Address>(table.size()).addr, delta.addr)) {
     return std::nullopt;
   }
 
@@ -60,7 +60,7 @@ std::optional<std::size_t> RealRuntimeTable::grow(std::size_t delta,
     return std::nullopt;
   }
 
-  std::size_t oldSize = table.size();
+  Address oldSize = table.size();
   table.resize(newSize, fill);
   return oldSize;
 }

--- a/src/ir/runtime-table.h
+++ b/src/ir/runtime-table.h
@@ -33,15 +33,15 @@ public:
   RuntimeTable(Table table) : tableDefinition(table) {}
   virtual ~RuntimeTable() = default;
 
-  virtual void set(std::size_t i, Literal l) = 0;
+  virtual void set(Address i, Literal l) = 0;
 
-  virtual Literal get(std::size_t i) const = 0;
+  virtual Literal get(Address i) const = 0;
 
   // Returns nullopt if the table grew beyond the max possible size.
-  [[nodiscard]] virtual std::optional<std::size_t> grow(std::size_t delta,
-                                                        Literal fill) = 0;
+  [[nodiscard]] virtual std::optional<Address> grow(Address delta,
+                                                    Literal fill) = 0;
 
-  virtual std::size_t size() const = 0;
+  virtual Address size() const = 0;
 
   // True iff this is a subtype of the definition `other`. i.e. This table can
   // be imported with the definition of `other`
@@ -66,13 +66,13 @@ public:
   RealRuntimeTable(const RealRuntimeTable&) = delete;
   RealRuntimeTable& operator=(const RealRuntimeTable&) = delete;
 
-  void set(std::size_t i, Literal l) override;
+  void set(Address i, Literal l) override;
 
-  Literal get(std::size_t i) const override;
+  Literal get(Address i) const override;
 
-  std::optional<std::size_t> grow(std::size_t delta, Literal fill) override;
+  std::optional<Address> grow(Address delta, Literal fill) override;
 
-  std::size_t size() const override { return table.size(); }
+  Address size() const override { return table.size(); }
 
 private:
   std::vector<Literal> table;

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -113,13 +113,13 @@ public:
     : RuntimeTable(table), instanceInitialized(instanceInitialized), wasm(wasm),
       makeFuncData(std::move(makeFuncData)) {}
 
-  void set(std::size_t i, Literal l) override {
+  void set(Address i, Literal l) override {
     if (instanceInitialized) {
       throw FailToEvalException("tableStore after init: TODO");
     }
   }
 
-  Literal get(std::size_t index) const override {
+  Literal get(Address index) const override {
     // Look through the segments and find the value. Segments can overlap,
     // so we want the last one.
     Expression* value = nullptr;
@@ -164,12 +164,12 @@ public:
     return Properties::getLiteral(value);
   }
 
-  [[nodiscard]] virtual std::optional<std::size_t> grow(std::size_t delta,
-                                                        Literal fill) override {
+  [[nodiscard]] virtual std::optional<Address> grow(Address delta,
+                                                    Literal fill) override {
     throw FailToEvalException("grow table");
   }
 
-  std::size_t size() const override {
+  Address size() const override {
     // See set() above, we assume the table is not modified FIXME
     return tableDefinition.initial;
   }


### PR DESCRIPTION
Fixes #8360.

Tested with

```sh
cmake -G Ninja -DCMAKE_CXX_FLAGS="-m32" -DCMAKE_C_FLAGS="-m32" -DCMAKE_BUILD_TYPE=Debug .
ninja
python3 check.py lit
```

(32-bit build) which fails without this PR. There is no 32-bit build in CI FWIW.