### PR TITLE
Use table's index type when parsing element segments

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -404,7 +404,6 @@ SPEC_TESTSUITE_PROPOSALS_TO_SKIP = [
 SPEC_TESTSUITE_TESTS_TO_SKIP = [
     'array_new_elem.wast',  # Failure to parse element segment item abbreviation
     'binary.wast',   # Missing data count section validation
-    'call_indirect64.wast',  # Failure to parse element segment abbreviation
     'comments.wast',  # Issue with carriage returns being treated as newlines
     'const.wast',    # Hex float constant not recognized as out of range
     'conversions.wast',  # Promoted NaN should be canonical

--- a/src/parser/context-decls.cpp
+++ b/src/parser/context-decls.cpp
@@ -122,7 +122,7 @@ Result<> ParseDeclsCtx::addImplicitElems(TypeT, ElemListT&& elems) {
   auto& table = *wasm.tables.back();
   auto e = std::make_unique<ElementSegment>();
   e->table = table.name;
-  e->offset = Builder(wasm).makeConstPtr(0, Type::i32);
+  e->offset = Builder(wasm).makeConstPtr(0, table.addressType);
   e->name = Names::getValidElementSegmentName(wasm, "implicit-elem");
   wasm.addElementSegment(std::move(e));
 


### PR DESCRIPTION
Resolves the spec test error in call_indirect64.wast:

```
run_command `/usr/local/google/home/stevenfont/code/binaryen3/bin/wasm-shell /usr/local/google/home/stevenfont/code/binaryen3/test/spec/testsuite/call_indirect64.wast` failed (1) 0 BUILDING MODULE [line: 3]
[wasm-validator error in module] i32 != i64: element segment offset must match table index type, on
(i32.const 0)
failed validation
```

Previously we always assumed a 32-bit index even if the table is 64 bits. Use the index type of the table during parsing.

Part of #8261.