### PR TITLE
Add mayNotReturn effect on memory.atomic.wait

### DIFF
--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -626,6 +626,9 @@ private:
       parent.writesMemory = true;
       parent.isAtomic = true;
       parent.implicitTrap = true;
+
+      // If the timeout is negative and no-one wakes us.
+      parent.mayNotReturn = true;
     }
     void visitAtomicNotify(AtomicNotify* curr) {
       // AtomicNotify doesn't strictly write memory, but it does modify the


### PR DESCRIPTION
memory.atomic.wait may not return if its timeout is `-1` and no `memory.atomic.notify` happens. Because mayNotReturn is now true, `hasNonTrapSideEffects` and `hasUnremovableSideEffects` are now true, which affect some passes.

Followup to https://github.com/WebAssembly/binaryen/pull/8346#discussion_r2850978684