### PR TITLE
[NFC-for-now] Fix LocalCSE bug in ignoring traps

### DIFF
--- a/src/passes/LocalCSE.cpp
+++ b/src/passes/LocalCSE.cpp
@@ -458,7 +458,9 @@ struct Checker
       // help: the only effect a trap can interact with is a set of global state
       // (the trap could prevent that writing, which would be noticeable) - but
       // LocalCSE does not deduplicate expressions with such effects, as they
-      // must happen twice.
+      // must happen twice. That is, removing trapping from (curr) in the
+      // example above has no effect as (ORIGINAL) never has global write
+      // effects.
       effects.trap = false;
 
       std::vector<Expression*> invalidated;


### PR DESCRIPTION
The code did "trap = false; scan()", but that is wrong, as it wants to remove the
trap after the scan. Reorder and just use a ShallowEffectAnalyzer.

But this logic bug was not actually allowing different behavior, see the
detailed comment - we have no effects atm that can distinguish the two cases.
If we add new effects, we might, though, so this is worth doing.