### PR TITLE
Validate SIMDTernary features

### DIFF
--- a/test/lit/validation/simd-ternary.wast
+++ b/test/lit/validation/simd-ternary.wast
@@ -1,0 +1,10 @@
+;; RUN: not wasm-opt --enable-simd %s 2>&1 | filecheck %s
+
+;; CHECK: SIMD ternary operation requires additional features, on
+;; CHECK: [--enable-relaxed-simd --enable-fp16]
+
+(module
+  (func $fp16 (param v128 v128 v128)
+    (f16x8.relaxed_madd (local.get 0) (local.get 1) (local.get 2))
+  )
+)


### PR DESCRIPTION
Require relaxed SIMD and fp16 features for those instructions that need
them. This will prevent the fuzzer (and the clusterfuzz fuzzer in
particular) from picking up initial content that uses fp16 operations,
which it does not yet support.
