### PR TITLE
standardize `nan` for sqrt

### DIFF
--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -1122,9 +1122,9 @@ Literal Literal::nearbyint() const {
 Literal Literal::sqrt() const {
   switch (type.getBasic()) {
     case Type::f32:
-      return Literal(std::sqrt(getf32()));
+      return standardizeNaN(Literal(std::sqrt(getf32())));
     case Type::f64:
-      return Literal(std::sqrt(getf64()));
+      return standardizeNaN(Literal(std::sqrt(getf64())));
     default:
       WASM_UNREACHABLE("unexpected type");
   }

--- a/test/gtest/interpreter.cpp
+++ b/test/gtest/interpreter.cpp
@@ -685,6 +685,22 @@ TEST(InterpreterTest, SqrtF32) {
   EXPECT_EQ(results, expected);
 }
 
+TEST(InterpreterTest, SqrtF32Neg) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(float(-5.0))).getErr());
+  ASSERT_FALSE(builder.makeUnary(SqrtFloat32).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.runTest(*expr);
+  std::vector<Literal> expected{Literal(std::nanf("0x400000"))};
+
+  EXPECT_EQ(results, expected);
+}
+
 TEST(InterpreterTest, CeilF32) {
   Module wasm;
   IRBuilder builder(wasm);
@@ -848,6 +864,22 @@ TEST(InterpreterTest, SqrtF64) {
 
   auto results = Interpreter{}.runTest(*expr);
   std::vector<Literal> expected{Literal(double(2.23606797749979))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, SqrtF64Neg) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(double(-5.0))).getErr());
+  ASSERT_FALSE(builder.makeUnary(SqrtFloat64).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.runTest(*expr);
+  std::vector<Literal> expected{Literal(std::nan("0x8000000000000"))};
 
   EXPECT_EQ(results, expected);
 }


### PR DESCRIPTION
[std::sqrt](https://en.cppreference.com/w/c/numeric/math/sqrt.html) of negative number can result a nan.
It is different in amd64 (-nan) and aarch64 (+nan). https://godbolt.org/z/3qsGeGvMT
This patch want to standardize them to make sure the same snapshot test result.