### PR TITLE
Fix implicitTrap and trap effects in struct.wait + struct.notify

### DIFF
--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -951,10 +951,15 @@ private:
       parent.isAtomic = true;
     }
     void visitStructWait(StructWait* curr) {
+      if (curr->ref->type.isNull()) {
+        parent.trap = true;
+        return;
+      }
       parent.isAtomic = true;
 
-      // If the ref is null.
-      parent.implicitTrap = true;
+      if (curr->ref->type.isNullable()) {
+        parent.implicitTrap = true;
+      }
 
       // If the timeout is negative and no-one wakes us.
       parent.mayNotReturn = true;
@@ -984,10 +989,15 @@ private:
                                      .mutable_ == Mutable;
     }
     void visitStructNotify(StructNotify* curr) {
+      if (curr->ref->type.isNull()) {
+        parent.trap = true;
+        return;
+      }
       parent.isAtomic = true;
 
-      // If the ref is null.
-      parent.implicitTrap = true;
+      if (curr->ref->type.isNullable()) {
+        parent.implicitTrap = true;
+      }
 
       // struct.notify mutates an opaque waiter queue which isn't visible in
       // user code. Model this as a struct write which prevents reorderings


### PR DESCRIPTION
Followup to https://github.com/WebAssembly/binaryen/pull/8402#discussion_r2874846281. Will wait for #8402 before merging.