### PR TITLE
Initial support for (thread ...) and (wait ...) in WAST

### DIFF
--- a/check.py
+++ b/check.py
@@ -200,7 +200,10 @@ def check_expected(actual, expected, stdout=None):
 
 UNSPLITTABLE_TESTS = [Path(x) for x in [
     "spec/testsuite/instance.wast",
-    "spec/instance.wast"]]
+    "spec/instance.wast",
+
+    # TODO: support module splitting for (thread ...) blocks
+    "spec/threads/*"]]
 
 
 def is_splittable(wast: Path):

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -394,6 +394,15 @@ SPEC_TESTS_TO_SKIP = [
 
     # Test invalid
     'elem.wast',
+
+    # Requires wast `either` support
+    'threads/thread.wast',
+
+    # Requires better support for multi-threaded tests
+    'threads/wait_notify.wast',
+
+    # Non-natural alignment is invalid for atomic operations
+    'threads/atomic.wast',
 ]
 SPEC_TESTSUITE_PROPOSALS_TO_SKIP = [
     'custom-page-sizes',

--- a/src/parser/wast-parser.cpp
+++ b/src/parser/wast-parser.cpp
@@ -25,6 +25,8 @@ using namespace std::string_view_literals;
 
 namespace {
 
+Result<WASTCommand> command(Lexer& in);
+
 Result<Literal> const_(Lexer& in) {
   if (in.takeSExprStart("ref.extern"sv)) {
     auto n = in.takeI32();
@@ -496,9 +498,76 @@ MaybeResult<ModuleInstantiation> instantiation(Lexer& in) {
   return ModuleInstantiation{moduleId, instanceId};
 }
 
-// instantiate | module | register | action | assertion
+// (thread name (shared (module name))? command*)
+MaybeResult<ThreadBlock> threadBlock(Lexer& in) {
+  if (!in.takeSExprStart("thread"sv)) {
+    return {};
+  }
+
+  auto name = in.takeID();
+  if (!name) {
+    return in.err("expected thread name");
+  }
+
+  std::optional<Name> sharedModule;
+  if (in.takeSExprStart("shared"sv)) {
+    if (!in.takeSExprStart("module"sv)) {
+      return in.err("expected module keyword in (shared ...) block");
+    }
+
+    auto modName = in.takeID();
+    if (!modName) {
+      return in.err("expected module name after (shared (module ...))");
+    }
+    sharedModule = *modName;
+
+    if (!in.takeRParen()) {
+      return in.err("expected end of shared module");
+    }
+    if (!in.takeRParen()) {
+      return in.err("expected end of (shared ...) expression");
+    }
+  }
+
+  std::vector<ScriptEntry> commands;
+  while (!in.peekRParen() && !in.empty()) {
+    size_t line = in.position().line;
+    auto cmd = command(in);
+    CHECK_ERR(cmd);
+    commands.push_back({std::move(*cmd), line});
+  }
+  if (!in.takeRParen()) {
+    return in.err("expected end of thread");
+  }
+  return ThreadBlock{*name, sharedModule, std::move(commands)};
+}
+
+// (wait name)
+MaybeResult<Wait> wait(Lexer& in) {
+  if (!in.takeSExprStart("wait"sv)) {
+    return {};
+  }
+  auto name = in.takeID();
+  if (!name) {
+    return in.err("expected thread name in wait");
+  }
+  if (!in.takeRParen()) {
+    return in.err("expected end of wait");
+  }
+  return Wait{*name};
+}
+
+// instantiate | module | register | action | assertion | thread | wait
 Result<WASTCommand> command(Lexer& in) {
   if (auto cmd = register_(in)) {
+    CHECK_ERR(cmd);
+    return *cmd;
+  }
+  if (auto cmd = threadBlock(in)) {
+    CHECK_ERR(cmd);
+    return *cmd;
+  }
+  if (auto cmd = wait(in)) {
     CHECK_ERR(cmd);
     return *cmd;
   }

--- a/src/parser/wat-parser.h
+++ b/src/parser/wat-parser.h
@@ -128,15 +128,31 @@ struct ModuleInstantiation {
   std::optional<Name> instanceName;
 };
 
-using WASTCommand =
-  std::variant<WASTModule, Register, Action, Assertion, ModuleInstantiation>;
+struct ScriptEntry;
+using WASTScript = std::vector<ScriptEntry>;
+
+struct ThreadBlock {
+  Name name;
+  std::optional<Name> sharedModule;
+  WASTScript commands;
+};
+
+struct Wait {
+  Name thread;
+};
+
+using WASTCommand = std::variant<WASTModule,
+                                 Register,
+                                 Action,
+                                 Assertion,
+                                 ModuleInstantiation,
+                                 ThreadBlock,
+                                 Wait>;
 
 struct ScriptEntry {
   WASTCommand cmd;
   size_t line;
 };
-
-using WASTScript = std::vector<ScriptEntry>;
 
 Result<WASTScript> parseScript(std::string_view in);
 

--- a/src/tools/wasm-shell.cpp
+++ b/src/tools/wasm-shell.cpp
@@ -93,10 +93,20 @@ struct Shell {
     } else if (auto* instantiateModule =
                  std::get_if<ModuleInstantiation>(&cmd)) {
       return doInstantiate(*instantiateModule);
+    } else if (auto* thread = std::get_if<ThreadBlock>(&cmd)) {
+      return doThread(*thread);
+    } else if (auto* wait = std::get_if<Wait>(&cmd)) {
+      return doWait(*wait);
     } else {
       WASM_UNREACHABLE("unexpected command");
     }
   }
+
+  // Run threads in a blocking manner for now.
+  // TODO: yield on blocking instructions e.g. memory.atomic.wait32.
+  Result<> doThread(ThreadBlock& thread) { return run(thread.commands); }
+
+  Result<> doWait(Wait& wait) { return Ok{}; }
 
   Result<std::shared_ptr<Module>> makeModule(WASTModule& mod) {
     std::shared_ptr<Module> wasm;

--- a/test/spec/threads/LB.wast
+++ b/test/spec/threads/LB.wast
@@ -1,0 +1,63 @@
+(module $Mem
+  (memory (export "shared") 1 1 shared)
+)
+(register "mem")
+
+(thread $T1 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run")
+      (local i32)
+      (i32.load (i32.const 4))
+      (local.set 0)
+      (i32.store (i32.const 0) (i32.const 1))
+
+      ;; store results for checking
+      (i32.store (i32.const 24) (local.get 0))
+    )
+  )
+  (invoke "run")
+)
+
+(thread $T2 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run")
+      (local i32)
+      (i32.load (i32.const 0))
+      (local.set 0)
+      (i32.store (i32.const 4) (i32.const 1))
+
+      ;; store results for checking
+      (i32.store (i32.const 32) (local.get 0))
+    )
+  )
+
+  (invoke "run")
+)
+
+(wait $T1)
+(wait $T2)
+
+(module $Check
+  (memory (import "mem" "shared") 1 1 shared)
+
+  (func (export "check") (result i32)
+    (local i32 i32)
+    (i32.load (i32.const 24))
+    (local.set 0)
+    (i32.load (i32.const 32))
+    (local.set 1)
+
+    ;; allowed results: (L_0 = 0 || L_0 = 1) && (L_1 = 0 || L_1 = 1)
+
+    (i32.or (i32.eq (local.get 0) (i32.const 1)) (i32.eq (local.get 0) (i32.const 0)))
+    (i32.or (i32.eq (local.get 1) (i32.const 1)) (i32.eq (local.get 1) (i32.const 0)))
+    (i32.and)
+    (return)
+  )
+)
+
+(assert_return (invoke $Check "check") (i32.const 1))

--- a/test/spec/threads/LB_atomic.wast
+++ b/test/spec/threads/LB_atomic.wast
@@ -1,0 +1,65 @@
+(module $Mem
+  (memory (export "shared") 1 1 shared)
+)
+(register "mem")
+
+(thread $T1 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run")
+      (local i32)
+      (i32.atomic.load (i32.const 4))
+      (local.set 0)
+      (i32.atomic.store (i32.const 0) (i32.const 1))
+
+      ;; store results for checking
+      (i32.store (i32.const 24) (local.get 0))
+    )
+  )
+  (invoke "run")
+)
+
+(thread $T2 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run")
+      (local i32)
+      (i32.atomic.load (i32.const 0))
+      (local.set 0)
+      (i32.atomic.store (i32.const 4) (i32.const 1))
+
+      ;; store results for checking
+      (i32.store (i32.const 32) (local.get 0))
+    )
+  )
+
+  (invoke "run")
+)
+
+(wait $T1)
+(wait $T2)
+
+(module $Check
+  (memory (import "mem" "shared") 1 1 shared)
+
+  (func (export "check") (result i32)
+    (local i32 i32)
+    (i32.load (i32.const 24))
+    (local.set 0)
+    (i32.load (i32.const 32))
+    (local.set 1)
+
+    ;; allowed results: (L_0 = 0 && L_1 = 0) || (L_0 = 0 && L_1 = 1) || (L_0 = 1 && L_1 = 0)
+
+    (i32.and (i32.eq (local.get 0) (i32.const 0)) (i32.eq (local.get 1) (i32.const 0)))
+    (i32.and (i32.eq (local.get 0) (i32.const 0)) (i32.eq (local.get 1) (i32.const 1)))
+    (i32.and (i32.eq (local.get 0) (i32.const 1)) (i32.eq (local.get 1) (i32.const 0)))
+    (i32.or)
+    (i32.or)
+    (return)
+  )
+)
+
+(assert_return (invoke $Check "check") (i32.const 1))

--- a/test/spec/threads/MP.wast
+++ b/test/spec/threads/MP.wast
@@ -1,0 +1,60 @@
+(module $Mem
+  (memory (export "shared") 1 1 shared)
+)
+(register "mem")
+
+(thread $T1 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run")
+      (i32.store (i32.const 0) (i32.const 42))
+      (i32.store (i32.const 4) (i32.const 1))
+    )
+  )
+  (invoke "run")
+)
+
+(thread $T2 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run")
+      (local i32 i32)
+      (i32.load (i32.const 4))
+      (local.set 0)
+      (i32.load (i32.const 0))
+      (local.set 1)
+
+      ;; store results for checking
+      (i32.store (i32.const 24) (local.get 0))
+      (i32.store (i32.const 32) (local.get 1))
+    )
+  )
+
+  (invoke "run")
+)
+
+(wait $T1)
+(wait $T2)
+
+(module $Check
+  (memory (import "mem" "shared") 1 1 shared)
+
+  (func (export "check") (result i32)
+    (local i32 i32)
+    (i32.load (i32.const 24))
+    (local.set 0)
+    (i32.load (i32.const 32))
+    (local.set 1)
+
+    ;; allowed results: (L_0 = 0 || L_0 = 1) && (L_1 = 0 || L_1 = 42)
+
+    (i32.or (i32.eq (local.get 0) (i32.const 1)) (i32.eq (local.get 0) (i32.const 0)))
+    (i32.or (i32.eq (local.get 1) (i32.const 42)) (i32.eq (local.get 1) (i32.const 0)))
+    (i32.and)
+    (return)
+  )
+)
+
+(assert_return (invoke $Check "check") (i32.const 1))

--- a/test/spec/threads/MP_atomic.wast
+++ b/test/spec/threads/MP_atomic.wast
@@ -1,0 +1,62 @@
+(module $Mem
+  (memory (export "shared") 1 1 shared)
+)
+(register "mem")
+
+(thread $T1 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run")
+      (i32.atomic.store (i32.const 0) (i32.const 42))
+      (i32.atomic.store (i32.const 4) (i32.const 1))
+    )
+  )
+  (invoke "run")
+)
+
+(thread $T2 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run")
+      (local i32 i32)
+      (i32.atomic.load (i32.const 4))
+      (local.set 0)
+      (i32.atomic.load (i32.const 0))
+      (local.set 1)
+
+      ;; store results for checking
+      (i32.store (i32.const 24) (local.get 0))
+      (i32.store (i32.const 32) (local.get 1))
+    )
+  )
+
+  (invoke "run")
+)
+
+(wait $T1)
+(wait $T2)
+
+(module $Check
+  (memory (import "mem" "shared") 1 1 shared)
+
+  (func (export "check") (result i32)
+    (local i32 i32)
+    (i32.load (i32.const 24))
+    (local.set 0)
+    (i32.load (i32.const 32))
+    (local.set 1)
+
+    ;; allowed results: (L_0 = 1 && L_1 = 42) || (L_0 = 0 && L_1 = 0) || (L_0 = 0 && L_1 = 42)
+
+    (i32.and (i32.eq (local.get 0) (i32.const 1)) (i32.eq (local.get 1) (i32.const 42)))
+    (i32.and (i32.eq (local.get 0) (i32.const 0)) (i32.eq (local.get 1) (i32.const 0)))
+    (i32.and (i32.eq (local.get 0) (i32.const 0)) (i32.eq (local.get 1) (i32.const 42)))
+    (i32.or)
+    (i32.or)
+    (return)
+  )
+)
+
+(assert_return (invoke $Check "check") (i32.const 1))

--- a/test/spec/threads/SB.wast
+++ b/test/spec/threads/SB.wast
@@ -1,0 +1,63 @@
+(module $Mem
+  (memory (export "shared") 1 1 shared)
+)
+(register "mem")
+
+(thread $T1 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run")
+      (local i32)
+      (i32.store (i32.const 0) (i32.const 1))
+      (i32.load (i32.const 4))
+      (local.set 0)
+
+      ;; store results for checking
+      (i32.store (i32.const 24) (local.get 0))
+    )
+  )
+  (invoke "run")
+)
+
+(thread $T2 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run")
+      (local i32)
+      (i32.store (i32.const 4) (i32.const 1))
+      (i32.load (i32.const 0))
+      (local.set 0)
+
+      ;; store results for checking
+      (i32.store (i32.const 32) (local.get 0))
+    )
+  )
+
+  (invoke "run")
+)
+
+(wait $T1)
+(wait $T2)
+
+(module $Check
+  (memory (import "mem" "shared") 1 1 shared)
+
+  (func (export "check") (result i32)
+    (local i32 i32)
+    (i32.load (i32.const 24))
+    (local.set 0)
+    (i32.load (i32.const 32))
+    (local.set 1)
+
+    ;; allowed results: (L_0 = 0 || L_0 = 1) && (L_1 = 0 || L_1 = 1)
+
+    (i32.or (i32.eq (local.get 0) (i32.const 1)) (i32.eq (local.get 0) (i32.const 0)))
+    (i32.or (i32.eq (local.get 1) (i32.const 1)) (i32.eq (local.get 1) (i32.const 0)))
+    (i32.and)
+    (return)
+  )
+)
+
+(assert_return (invoke $Check "check") (i32.const 1))

--- a/test/spec/threads/SB_atomic.wast
+++ b/test/spec/threads/SB_atomic.wast
@@ -1,0 +1,65 @@
+(module $Mem
+  (memory (export "shared") 1 1 shared)
+)
+(register "mem")
+
+(thread $T1 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run")
+      (local i32)
+      (i32.atomic.store (i32.const 0) (i32.const 1))
+      (i32.atomic.load (i32.const 4))
+      (local.set 0)
+
+      ;; store results for checking
+      (i32.store (i32.const 24) (local.get 0))
+    )
+  )
+  (invoke "run")
+)
+
+(thread $T2 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run")
+      (local i32)
+      (i32.atomic.store (i32.const 4) (i32.const 1))
+      (i32.atomic.load (i32.const 0))
+      (local.set 0)
+
+      ;; store results for checking
+      (i32.store (i32.const 32) (local.get 0))
+    )
+  )
+
+  (invoke "run")
+)
+
+(wait $T1)
+(wait $T2)
+
+(module $Check
+  (memory (import "mem" "shared") 1 1 shared)
+
+  (func (export "check") (result i32)
+    (local i32 i32)
+    (i32.load (i32.const 24))
+    (local.set 0)
+    (i32.load (i32.const 32))
+    (local.set 1)
+
+    ;; allowed results: (L_0 = 1 && L_1 = 1) || (L_0 = 0 && L_1 = 1) || (L_0 = 1 && L_1 = 0)
+
+    (i32.and (i32.eq (local.get 0) (i32.const 1)) (i32.eq (local.get 1) (i32.const 1)))
+    (i32.and (i32.eq (local.get 0) (i32.const 0)) (i32.eq (local.get 1) (i32.const 1)))
+    (i32.and (i32.eq (local.get 0) (i32.const 1)) (i32.eq (local.get 1) (i32.const 0)))
+    (i32.or)
+    (i32.or)
+    (return)
+  )
+)
+
+(assert_return (invoke $Check "check") (i32.const 1))

--- a/test/spec/threads/atomic.wast
+++ b/test/spec/threads/atomic.wast
@@ -1,0 +1,1018 @@
+;; atomic operations
+
+(module
+  (memory 1 1 shared)
+
+  (func (export "init") (param $value i64) (i64.store (i32.const 0) (local.get $value)))
+
+  (func (export "i32.atomic.load") (param $addr i32) (result i32) (i32.atomic.load (local.get $addr)))
+  (func (export "i64.atomic.load") (param $addr i32) (result i64) (i64.atomic.load (local.get $addr)))
+  (func (export "i32.atomic.load8_u") (param $addr i32) (result i32) (i32.atomic.load8_u (local.get $addr)))
+  (func (export "i32.atomic.load16_u") (param $addr i32) (result i32) (i32.atomic.load16_u (local.get $addr)))
+  (func (export "i64.atomic.load8_u") (param $addr i32) (result i64) (i64.atomic.load8_u (local.get $addr)))
+  (func (export "i64.atomic.load16_u") (param $addr i32) (result i64) (i64.atomic.load16_u (local.get $addr)))
+  (func (export "i64.atomic.load32_u") (param $addr i32) (result i64) (i64.atomic.load32_u (local.get $addr)))
+
+  (func (export "i32.atomic.store") (param $addr i32) (param $value i32) (i32.atomic.store (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.store") (param $addr i32) (param $value i64) (i64.atomic.store (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.store8") (param $addr i32) (param $value i32) (i32.atomic.store8 (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.store16") (param $addr i32) (param $value i32) (i32.atomic.store16 (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.store8") (param $addr i32) (param $value i64) (i64.atomic.store8 (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.store16") (param $addr i32) (param $value i64) (i64.atomic.store16 (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.store32") (param $addr i32) (param $value i64) (i64.atomic.store32 (local.get $addr) (local.get $value)))
+
+  (func (export "i32.atomic.rmw.add") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.add (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw.add") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.add (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw8.add_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw8.add_u (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw16.add_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.add_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw8.add_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw8.add_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw16.add_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.add_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw32.add_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.add_u (local.get $addr) (local.get $value)))
+
+  (func (export "i32.atomic.rmw.sub") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.sub (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw.sub") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.sub (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw8.sub_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw8.sub_u (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw16.sub_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.sub_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw8.sub_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw8.sub_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw16.sub_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.sub_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw32.sub_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.sub_u (local.get $addr) (local.get $value)))
+
+  (func (export "i32.atomic.rmw.and") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.and (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw.and") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.and (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw8.and_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw8.and_u (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw16.and_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.and_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw8.and_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw8.and_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw16.and_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.and_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw32.and_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.and_u (local.get $addr) (local.get $value)))
+
+  (func (export "i32.atomic.rmw.or") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.or (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw.or") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.or (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw8.or_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw8.or_u (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw16.or_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.or_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw8.or_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw8.or_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw16.or_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.or_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw32.or_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.or_u (local.get $addr) (local.get $value)))
+
+  (func (export "i32.atomic.rmw.xor") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.xor (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw.xor") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.xor (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw8.xor_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw8.xor_u (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw16.xor_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.xor_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw8.xor_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw8.xor_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw16.xor_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.xor_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw32.xor_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.xor_u (local.get $addr) (local.get $value)))
+
+  (func (export "i32.atomic.rmw.xchg") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.xchg (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw.xchg") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.xchg (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw8.xchg_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw8.xchg_u (local.get $addr) (local.get $value)))
+  (func (export "i32.atomic.rmw16.xchg_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.xchg_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw8.xchg_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw8.xchg_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw16.xchg_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.xchg_u (local.get $addr) (local.get $value)))
+  (func (export "i64.atomic.rmw32.xchg_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.xchg_u (local.get $addr) (local.get $value)))
+
+  (func (export "i32.atomic.rmw.cmpxchg") (param $addr i32) (param $expected i32) (param $value i32) (result i32) (i32.atomic.rmw.cmpxchg (local.get $addr) (local.get $expected) (local.get $value)))
+  (func (export "i64.atomic.rmw.cmpxchg") (param $addr i32) (param $expected i64) (param $value i64) (result i64) (i64.atomic.rmw.cmpxchg (local.get $addr) (local.get $expected) (local.get $value)))
+  (func (export "i32.atomic.rmw8.cmpxchg_u") (param $addr i32) (param $expected i32) (param $value i32) (result i32) (i32.atomic.rmw8.cmpxchg_u (local.get $addr) (local.get $expected) (local.get $value)))
+  (func (export "i32.atomic.rmw16.cmpxchg_u") (param $addr i32) (param $expected i32) (param $value i32) (result i32) (i32.atomic.rmw16.cmpxchg_u (local.get $addr) (local.get $expected) (local.get $value)))
+  (func (export "i64.atomic.rmw8.cmpxchg_u") (param $addr i32) (param $expected i64) (param $value i64) (result i64) (i64.atomic.rmw8.cmpxchg_u (local.get $addr) (local.get $expected) (local.get $value)))
+  (func (export "i64.atomic.rmw16.cmpxchg_u") (param $addr i32) (param $expected i64) (param $value i64) (result i64) (i64.atomic.rmw16.cmpxchg_u (local.get $addr) (local.get $expected) (local.get $value)))
+  (func (export "i64.atomic.rmw32.cmpxchg_u") (param $addr i32) (param $expected i64) (param $value i64) (result i64) (i64.atomic.rmw32.cmpxchg_u (local.get $addr) (local.get $expected) (local.get $value)))
+
+)
+
+;; *.atomic.load*
+
+(invoke "init" (i64.const 0x0706050403020100))
+
+(assert_return (invoke "i32.atomic.load" (i32.const 0)) (i32.const 0x03020100))
+(assert_return (invoke "i32.atomic.load" (i32.const 4)) (i32.const 0x07060504))
+
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0706050403020100))
+
+(assert_return (invoke "i32.atomic.load8_u" (i32.const 0)) (i32.const 0x00))
+(assert_return (invoke "i32.atomic.load8_u" (i32.const 5)) (i32.const 0x05))
+
+(assert_return (invoke "i32.atomic.load16_u" (i32.const 0)) (i32.const 0x0100))
+(assert_return (invoke "i32.atomic.load16_u" (i32.const 6)) (i32.const 0x0706))
+
+(assert_return (invoke "i64.atomic.load8_u" (i32.const 0)) (i64.const 0x00))
+(assert_return (invoke "i64.atomic.load8_u" (i32.const 5)) (i64.const 0x05))
+
+(assert_return (invoke "i64.atomic.load16_u" (i32.const 0)) (i64.const 0x0100))
+(assert_return (invoke "i64.atomic.load16_u" (i32.const 6)) (i64.const 0x0706))
+
+(assert_return (invoke "i64.atomic.load32_u" (i32.const 0)) (i64.const 0x03020100))
+(assert_return (invoke "i64.atomic.load32_u" (i32.const 4)) (i64.const 0x07060504))
+
+;; *.atomic.store*
+
+(invoke "init" (i64.const 0x0000000000000000))
+
+(assert_return (invoke "i32.atomic.store" (i32.const 0) (i32.const 0xffeeddcc)))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x00000000ffeeddcc))
+
+(assert_return (invoke "i64.atomic.store" (i32.const 0) (i64.const 0x0123456789abcdef)))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0123456789abcdef))
+
+(assert_return (invoke "i32.atomic.store8" (i32.const 1) (i32.const 0x42)))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0123456789ab42ef))
+
+(assert_return (invoke "i32.atomic.store16" (i32.const 4) (i32.const 0x8844)))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0123884489ab42ef))
+
+(assert_return (invoke "i64.atomic.store8" (i32.const 1) (i64.const 0x99)))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0123884489ab99ef))
+
+(assert_return (invoke "i64.atomic.store16" (i32.const 4) (i64.const 0xcafe)))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0123cafe89ab99ef))
+
+(assert_return (invoke "i64.atomic.store32" (i32.const 4) (i64.const 0xdeadbeef)))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0xdeadbeef89ab99ef))
+
+;; *.atomic.rmw*.add
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw.add" (i32.const 0) (i32.const 0x12345678)) (i32.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111123456789))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw.add" (i32.const 0) (i64.const 0x0101010102020202)) (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1212121213131313))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.add_u" (i32.const 0) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111111111de))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.add_u" (i32.const 0) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111dc0f))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.add_u" (i32.const 0) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111153))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.add_u" (i32.const 0) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111d000))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.add_u" (i32.const 0) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111dbccb7f6))
+
+;; *.atomic.rmw*.sub
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw.sub" (i32.const 0) (i32.const 0x12345678)) (i32.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111fedcba99))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw.sub" (i32.const 0) (i64.const 0x0101010102020202)) (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x101010100f0f0f0f))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.sub_u" (i32.const 0) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111144))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.sub_u" (i32.const 0) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111114613))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.sub_u" (i32.const 0) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111111111cf))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.sub_u" (i32.const 0) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111115222))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.sub_u" (i32.const 0) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111146556a2c))
+
+;; *.atomic.rmw*.and
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw.and" (i32.const 0) (i32.const 0x12345678)) (i32.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111110101010))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw.and" (i32.const 0) (i64.const 0x0101010102020202)) (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0101010100000000))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.and_u" (i32.const 0) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111101))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.and_u" (i32.const 0) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111110010))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.and_u" (i32.const 0) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111100))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.and_u" (i32.const 0) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111001))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.and_u" (i32.const 0) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111100110001))
+
+;; *.atomic.rmw*.or
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw.or" (i32.const 0) (i32.const 0x12345678)) (i32.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111113355779))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw.or" (i32.const 0) (i64.const 0x0101010102020202)) (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111113131313))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.or_u" (i32.const 0) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111111111dd))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.or_u" (i32.const 0) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111dbff))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.or_u" (i32.const 0) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111153))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.or_u" (i32.const 0) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111bfff))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.or_u" (i32.const 0) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111dbbbb7f5))
+
+;; *.atomic.rmw*.xor
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw.xor" (i32.const 0) (i32.const 0x12345678)) (i32.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111103254769))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw.xor" (i32.const 0) (i64.const 0x0101010102020202)) (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1010101013131313))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.xor_u" (i32.const 0) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111111111dc))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.xor_u" (i32.const 0) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111dbef))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.xor_u" (i32.const 0) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111153))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.xor_u" (i32.const 0) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111affe))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.xor_u" (i32.const 0) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111dbaab7f4))
+
+;; *.atomic.rmw*.xchg
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw.xchg" (i32.const 0) (i32.const 0x12345678)) (i32.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111112345678))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw.xchg" (i32.const 0) (i64.const 0x0101010102020202)) (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0101010102020202))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.xchg_u" (i32.const 0) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111111111cd))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.xchg_u" (i32.const 0) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111cafe))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.xchg_u" (i32.const 0) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111142))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.xchg_u" (i32.const 0) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111beef))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.xchg_u" (i32.const 0) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111cabba6e5))
+
+;; *.atomic.rmw*.cmpxchg (compare false)
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw.cmpxchg" (i32.const 0) (i32.const 0) (i32.const 0x12345678)) (i32.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw.cmpxchg" (i32.const 0) (i64.const 0) (i64.const 0x0101010102020202)) (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.cmpxchg_u" (i32.const 0) (i32.const 0) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.cmpxchg_u" (i32.const 0) (i32.const 0x11111111) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111111111cd))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.cmpxchg_u" (i32.const 0) (i32.const 0) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.cmpxchg_u" (i32.const 0) (i32.const 0x11111111) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111cafe))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.cmpxchg_u" (i32.const 0) (i64.const 0) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.cmpxchg_u" (i32.const 0) (i64.const 0x1111111111111111) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111142))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.cmpxchg_u" (i32.const 0) (i64.const 0) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.cmpxchg_u" (i32.const 0) (i64.const 0x1111111111111111) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111beef))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.cmpxchg_u" (i32.const 0) (i64.const 0) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.cmpxchg_u" (i32.const 0) (i64.const 0x1111111111111111) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111cabba6e5))
+
+;; *.atomic.rmw*.cmpxchg (compare true)
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw.cmpxchg" (i32.const 0) (i32.const 0x11111111) (i32.const 0x12345678)) (i32.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111112345678))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw.cmpxchg" (i32.const 0) (i64.const 0x1111111111111111) (i64.const 0x0101010102020202)) (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x0101010102020202))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.cmpxchg_u" (i32.const 0) (i32.const 0x11) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111111111cd))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.cmpxchg_u" (i32.const 0) (i32.const 0x1111) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111cafe))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.cmpxchg_u" (i32.const 0) (i64.const 0x11) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111142))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.cmpxchg_u" (i32.const 0) (i64.const 0x1111) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x111111111111beef))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.cmpxchg_u" (i32.const 0) (i64.const 0x11111111) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x11111111cabba6e5))
+
+
+;; unaligned accesses
+
+(assert_trap (invoke "i32.atomic.load" (i32.const 1)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.load" (i32.const 1)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.load16_u" (i32.const 1)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.load16_u" (i32.const 1)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.load32_u" (i32.const 1)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.store" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.store" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.store16" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.store16" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.store32" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw.add" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw.add" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw16.add_u" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw16.add_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw32.add_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw.sub" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw.sub" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw16.sub_u" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw16.sub_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw32.sub_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw.and" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw.and" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw16.and_u" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw16.and_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw32.and_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw.or" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw.or" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw16.or_u" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw16.or_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw32.or_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw.xor" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw.xor" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw16.xor_u" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw16.xor_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw32.xor_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw.xchg" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw.xchg" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw16.xchg_u" (i32.const 1) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw16.xchg_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw32.xchg_u" (i32.const 1) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw.cmpxchg" (i32.const 1) (i32.const 0) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw.cmpxchg" (i32.const 1) (i64.const 0)  (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i32.atomic.rmw16.cmpxchg_u" (i32.const 1) (i32.const 0) (i32.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw16.cmpxchg_u" (i32.const 1) (i64.const 0) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "i64.atomic.rmw32.cmpxchg_u" (i32.const 1) (i64.const 0) (i64.const 0)) "unaligned atomic")
+
+;; non-natural alignment
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.load") (param $addr i32) (result i32) (i32.atomic.load align=1 (local.get $addr)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.load") (param $addr i32) (result i64) (i64.atomic.load align=1 (local.get $addr)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.load16_u") (param $addr i32) (result i32) (i32.atomic.load16_u align=1 (local.get $addr)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.load16_u") (param $addr i32) (result i64) (i64.atomic.load16_u align=1 (local.get $addr)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.load32_u") (param $addr i32) (result i64) (i64.atomic.load32_u align=1 (local.get $addr)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.store") (param $addr i32) (param $value i32) (i32.atomic.store align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.store") (param $addr i32) (param $value i64) (i64.atomic.store align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.store16") (param $addr i32) (param $value i32) (i32.atomic.store16 align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.store16") (param $addr i32) (param $value i64) (i64.atomic.store16 align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.store32") (param $addr i32) (param $value i64) (i64.atomic.store32 align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw.add") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.add align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw.add") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.add align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw16.add_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.add_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw16.add_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.add_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw32.add_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.add_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw.sub") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.sub align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw.sub") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.sub align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw16.sub_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.sub_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw16.sub_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.sub_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw32.sub_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.sub_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw.and") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.and align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw.and") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.and align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw16.and_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.and_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw16.and_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.and_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw32.and_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.and_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw.or") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.or align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw.or") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.or align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw16.or_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.or_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw16.or_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.or_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw32.or_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.or_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw.xor") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.xor align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw.xor") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.xor align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw16.xor_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.xor_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw16.xor_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.xor_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw32.xor_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.xor_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw.xchg") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw.xchg align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw.xchg") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw.xchg align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw16.xchg_u") (param $addr i32) (param $value i32) (result i32) (i32.atomic.rmw16.xchg_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw16.xchg_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw16.xchg_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw32.xchg_u") (param $addr i32) (param $value i64) (result i64) (i64.atomic.rmw32.xchg_u align=1 (local.get $addr) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw.cmpxchg") (param $addr i32) (param $expected i32) (param $value i32) (result i32) (i32.atomic.rmw.cmpxchg align=1 (local.get $addr) (local.get $expected) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw.cmpxchg") (param $addr i32) (param $expected i64) (param $value i64) (result i64) (i64.atomic.rmw.cmpxchg align=1 (local.get $addr) (local.get $expected) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i32.atomic.rmw16.cmpxchg_u") (param $addr i32) (param $expected i32) (param $value i32) (result i32) (i32.atomic.rmw16.cmpxchg_u align=1 (local.get $addr) (local.get $expected) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw16.cmpxchg_u") (param $addr i32) (param $expected i64) (param $value i64) (result i64) (i64.atomic.rmw16.cmpxchg_u align=1 (local.get $addr) (local.get $expected) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+(assert_invalid 
+  (module
+    (memory 1 1 shared)
+
+    (func (export "i64.atomic.rmw32.cmpxchg_u") (param $addr i32) (param $expected i64) (param $value i64) (result i64) (i64.atomic.rmw32.cmpxchg_u align=1 (local.get $addr) (local.get $expected) (local.get $value)))
+  )
+  "atomic alignment must be natural"
+)
+
+
+;; wait/notify
+(module
+  (memory 1 1 shared)
+
+  (func (export "init") (param $value i64) (i64.store (i32.const 0) (local.get $value)))
+
+  (func (export "memory.atomic.notify") (param $addr i32) (param $count i32) (result i32)
+      (memory.atomic.notify (local.get 0) (local.get 1)))
+  (func (export "memory.atomic.wait32") (param $addr i32) (param $expected i32) (param $timeout i64) (result i32)
+      (memory.atomic.wait32 (local.get 0) (local.get 1) (local.get 2)))
+  (func (export "memory.atomic.wait64") (param $addr i32) (param $expected i64) (param $timeout i64) (result i32)
+      (memory.atomic.wait64 (local.get 0) (local.get 1) (local.get 2)))
+)
+
+(invoke "init" (i64.const 0xffffffffffff))
+
+;; wait returns immediately if values do not match
+(assert_return (invoke "memory.atomic.wait32" (i32.const 0) (i32.const 0) (i64.const 0)) (i32.const 1))
+(assert_return (invoke "memory.atomic.wait64" (i32.const 0) (i64.const 0) (i64.const 0)) (i32.const 1))
+
+;; notify always returns
+(assert_return (invoke "memory.atomic.notify" (i32.const 0) (i32.const 0)) (i32.const 0))
+
+;; OOB wait and notify always trap
+(assert_trap (invoke "memory.atomic.wait32" (i32.const 65536) (i32.const 0) (i64.const 0)) "out of bounds memory access")
+(assert_trap (invoke "memory.atomic.wait64" (i32.const 65536) (i64.const 0) (i64.const 0)) "out of bounds memory access")
+
+;; in particular, notify always traps even if waking 0 threads
+(assert_trap (invoke "memory.atomic.notify" (i32.const 65536) (i32.const 0)) "out of bounds memory access")
+
+;; similarly, unaligned wait and notify always trap
+(assert_trap (invoke "memory.atomic.wait32" (i32.const 65531) (i32.const 0) (i64.const 0)) "unaligned atomic")
+(assert_trap (invoke "memory.atomic.wait64" (i32.const 65524) (i64.const 0) (i64.const 0)) "unaligned atomic")
+
+(assert_trap (invoke "memory.atomic.notify" (i32.const 65531) (i32.const 0)) "unaligned atomic")
+
+;; atomic.wait traps on unshared memory even if it wouldn't block
+(module
+  (memory 1 1)
+
+  (func (export "init") (param $value i64) (i64.store (i32.const 0) (local.get $value)))
+
+  (func (export "memory.atomic.notify") (param $addr i32) (param $count i32) (result i32)
+      (memory.atomic.notify (local.get 0) (local.get 1)))
+  (func (export "memory.atomic.wait32") (param $addr i32) (param $expected i32) (param $timeout i64) (result i32)
+      (memory.atomic.wait32 (local.get 0) (local.get 1) (local.get 2)))
+  (func (export "memory.atomic.wait64") (param $addr i32) (param $expected i64) (param $timeout i64) (result i32)
+      (memory.atomic.wait64 (local.get 0) (local.get 1) (local.get 2)))
+)
+
+(invoke "init" (i64.const 0xffffffffffff))
+
+(assert_trap (invoke "memory.atomic.wait32" (i32.const 0) (i32.const 0) (i64.const 0)) "expected shared memory")
+(assert_trap (invoke "memory.atomic.wait64" (i32.const 0) (i64.const 0) (i64.const 0)) "expected shared memory")
+
+;; notify still works
+(assert_return (invoke "memory.atomic.notify" (i32.const 0) (i32.const 0)) (i32.const 0))
+
+;; OOB and unaligned notify still trap
+(assert_trap (invoke "memory.atomic.notify" (i32.const 65536) (i32.const 0)) "out of bounds memory access")
+(assert_trap (invoke "memory.atomic.notify" (i32.const 65531) (i32.const 0)) "unaligned atomic")
+
+;; unshared memory is OK
+(module
+  (memory 1 1)
+  (func (drop (memory.atomic.notify (i32.const 0) (i32.const 0))))
+  (func (drop (memory.atomic.wait32 (i32.const 0) (i32.const 0) (i64.const 0))))
+  (func (drop (memory.atomic.wait64 (i32.const 0) (i64.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.load (i32.const 0))))
+  (func (drop (i64.atomic.load (i32.const 0))))
+  (func (drop (i32.atomic.load16_u (i32.const 0))))
+  (func (drop (i64.atomic.load16_u (i32.const 0))))
+  (func (drop (i64.atomic.load32_u (i32.const 0))))
+  (func       (i32.atomic.store (i32.const 0) (i32.const 0)))
+  (func       (i64.atomic.store (i32.const 0) (i64.const 0)))
+  (func       (i32.atomic.store16 (i32.const 0) (i32.const 0)))
+  (func       (i64.atomic.store16 (i32.const 0) (i64.const 0)))
+  (func       (i64.atomic.store32 (i32.const 0) (i64.const 0)))
+  (func (drop (i32.atomic.rmw.add (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw.add (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw16.add_u (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw16.add_u (i32.const 0) (i64.const 0))))
+  (func (drop (i64.atomic.rmw32.add_u (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw.sub (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw.sub (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw16.sub_u (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw16.sub_u (i32.const 0) (i64.const 0))))
+  (func (drop (i64.atomic.rmw32.sub_u (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw.and (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw.and (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw16.and_u (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw16.and_u (i32.const 0) (i64.const 0))))
+  (func (drop (i64.atomic.rmw32.and_u (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw.or (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw.or (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw16.or_u (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw16.or_u (i32.const 0) (i64.const 0))))
+  (func (drop (i64.atomic.rmw32.or_u (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw.xor (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw.xor (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw16.xor_u (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw16.xor_u (i32.const 0) (i64.const 0))))
+  (func (drop (i64.atomic.rmw32.xor_u (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw.xchg (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw.xchg (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw16.xchg_u (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw16.xchg_u (i32.const 0) (i64.const 0))))
+  (func (drop (i64.atomic.rmw32.xchg_u (i32.const 0) (i64.const 0))))
+  (func (drop (i32.atomic.rmw.cmpxchg (i32.const 0) (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw.cmpxchg (i32.const 0) (i64.const 0)  (i64.const 0))))
+  (func (drop (i32.atomic.rmw16.cmpxchg_u (i32.const 0) (i32.const 0) (i32.const 0))))
+  (func (drop (i64.atomic.rmw16.cmpxchg_u (i32.const 0) (i64.const 0) (i64.const 0))))
+  (func (drop (i64.atomic.rmw32.cmpxchg_u (i32.const 0) (i64.const 0) (i64.const 0))))
+)
+
+;; atomic.fence: no memory is ok
+(module
+  (func (export "fence") (atomic.fence))
+)
+
+(assert_return (invoke "fence"))
+
+;; Fails with no memory
+(assert_invalid (module (func (drop (memory.atomic.notify (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (memory.atomic.wait32 (i32.const 0) (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (memory.atomic.wait64 (i32.const 0) (i64.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.load (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.load (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.load16_u (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.load16_u (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.load32_u (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func       (i32.atomic.store (i32.const 0) (i32.const 0)))) "unknown memory")
+(assert_invalid (module (func       (i64.atomic.store (i32.const 0) (i64.const 0)))) "unknown memory")
+(assert_invalid (module (func       (i32.atomic.store16 (i32.const 0) (i32.const 0)))) "unknown memory")
+(assert_invalid (module (func       (i64.atomic.store16 (i32.const 0) (i64.const 0)))) "unknown memory")
+(assert_invalid (module (func       (i64.atomic.store32 (i32.const 0) (i64.const 0)))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw.add (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw.add (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw16.add_u (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw16.add_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw32.add_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw.sub (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw.sub (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw16.sub_u (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw16.sub_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw32.sub_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw.and (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw.and (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw16.and_u (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw16.and_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw32.and_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw.or (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw.or (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw16.or_u (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw16.or_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw32.or_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw.xor (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw.xor (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw16.xor_u (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw16.xor_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw32.xor_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw.xchg (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw.xchg (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw16.xchg_u (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw16.xchg_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw32.xchg_u (i32.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw.cmpxchg (i32.const 0) (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw.cmpxchg (i32.const 0) (i64.const 0)  (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i32.atomic.rmw16.cmpxchg_u (i32.const 0) (i32.const 0) (i32.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw16.cmpxchg_u (i32.const 0) (i64.const 0) (i64.const 0))))) "unknown memory")
+(assert_invalid (module (func (drop (i64.atomic.rmw32.cmpxchg_u (i32.const 0) (i64.const 0) (i64.const 0))))) "unknown memory")

--- a/test/spec/threads/deeply_nested.wast
+++ b/test/spec/threads/deeply_nested.wast
@@ -1,0 +1,93 @@
+(module $Mem
+  (memory (export "shared") 1 1 shared)
+)
+
+(register "mem" $Mem)
+
+
+(thread $T1 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 10 shared)
+    (func (export "run")
+      (local i32)
+      (i32.store (i32.const 0) (i32.const 1))
+      (i32.load (i32.const 4))
+      (local.set 0)
+
+      (i32.store (i32.const 24) (local.get 0))
+    )
+  )
+
+  (thread $T11 (shared (module $Mem))
+    (register "mem" $Mem)
+    (module
+      (memory (import "mem" "shared") 1 1 shared)
+      (func (export "run_inner")
+        (i32.store (i32.const 24) (i32.const 42))
+      )
+    )
+    (invoke "run_inner")
+  )
+
+  (thread $T12 (shared (module $Mem))
+    (register "mem" $Mem)
+    (module
+      (memory (import "mem" "shared") 1 1 shared)
+      (func (export "run_inner")
+        (i32.store (i32.const 32) (i32.const 43))
+      )
+    )
+
+    (thread $T121 (shared (module $Mem))
+      (register "mem" $Mem)
+      (module
+        (memory (import "mem" "shared") 1 1 shared)
+        (func (export "run_innermost")
+          (i32.store (i32.const 24) (i32.const 44))
+        )
+      )
+      (invoke "run_innermost")
+    )
+    (thread $T122 (shared (module $Mem))
+      (register "mem" $Mem)
+      (module
+        (memory (import "mem" "shared") 1 1 shared)
+        (func (export "run_innermost")
+          (i32.store (i32.const 32) (i32.const 45))
+        )
+      )
+      (invoke "run_innermost")
+    )
+
+    (wait $T121)
+    (wait $T122)
+
+    (invoke "run_inner")
+  )
+
+
+  (wait $T11)
+  (wait $T12)
+  (invoke "run")
+)
+
+(thread $T2 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run")
+      (local i32)
+      (i32.store (i32.const 4) (i32.const 1))
+      (i32.load (i32.const 0))
+      (local.set 0)
+
+      (i32.store (i32.const 32) (local.get 0))
+    )
+  )
+
+  (invoke "run")
+)
+
+(wait $T1)
+(wait $T2)

--- a/test/spec/threads/nested.wast
+++ b/test/spec/threads/nested.wast
@@ -1,0 +1,54 @@
+(module $Mem
+  (memory (export "shared") 1 1 shared)
+)
+
+(register "mem" $Mem)
+
+(thread $T1 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run")
+      (local i32)
+      (i32.store (i32.const 0) (i32.load (i32.const 20)))
+      (i32.load (i32.const 4))
+      (local.set 0)
+
+      (i32.store (i32.const 24) (local.get 0))
+    )
+  )
+
+  (thread $T11 (shared (module $Mem))
+    (register "mem" $Mem)
+    (module
+      (memory (import "mem" "shared") 1 1 shared)
+      (func (export "run_inner")
+        (i32.store (i32.const 20) (i32.const 42))
+      )
+    )
+    (invoke "run_inner")
+  )
+
+  (wait $T11)
+  (invoke "run")
+)
+
+(thread $T2 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run")
+      (local i32)
+      (i32.store (i32.const 4) (i32.const 1))
+      (i32.load (i32.const 0))
+      (local.set 0)
+
+      (i32.store (i32.const 32) (local.get 0))
+    )
+  )
+
+  (invoke "run")
+)
+
+(wait $T1)
+(wait $T2)

--- a/test/spec/threads/simple.wast
+++ b/test/spec/threads/simple.wast
@@ -1,0 +1,29 @@
+(module $Mem
+  (memory (export "shared") 1 1 shared)
+)
+(register "mem")
+
+(thread $T1 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run")
+      (i32.atomic.store (i32.const 0) (i32.const 1))
+    )
+  )
+  (invoke "run")
+)
+
+
+(wait $T1)
+
+(module $Check
+  (memory (import "mem" "shared") 1 1 shared)
+
+  (func (export "check") (result i32)
+    (i32.load (i32.const 0))
+    (return)
+  )
+)
+
+(assert_return (invoke $Check "check") (i32.const 1))

--- a/test/spec/threads/thread.wast
+++ b/test/spec/threads/thread.wast
@@ -1,0 +1,48 @@
+(module $Mem
+  (memory (export "shared") 1 1 shared)
+)
+(register "mem_1")
+
+(thread $T1 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run")
+      (i32.store (i32.const 0) (i32.const 42))
+    )
+  )
+  (invoke "run")
+)
+
+(thread $T2 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run") (result i32)
+      (i32.load (i32.const 0))
+    )
+  )
+  (assert_return (invoke "run") (either (i32.const 0) (i32.const 42)))
+)
+
+(wait $T1)
+(wait $T2)
+
+
+(module (memory (import "mem_1" "shared") 1 1 shared))
+
+(assert_unlinkable
+  (module (memory (import "mem" "shared") 1 1 shared))
+  "unknown import"
+)
+
+(register "mem" $Mem)
+
+(thread $T3
+  (assert_unlinkable
+    (module (memory (import "mem" "shared") 1 1 shared))
+    "unknown import"
+  )
+)
+
+(wait $T3)

--- a/test/spec/threads/unlinkable.wast
+++ b/test/spec/threads/unlinkable.wast
@@ -1,0 +1,21 @@
+(module $Mem
+  (memory (export "shared") 1 1 shared)
+)
+
+(thread $T2
+  (assert_unlinkable
+    (module (memory (import "mem" "shared") 1 1 shared))
+    "unknown import"
+  )
+)
+
+(wait $T2)
+
+(thread $T4 (shared (module $Mem))
+  (assert_unlinkable
+    (module (memory (import "mem" "shared") 1 1 shared))
+    "unknown import"
+  )
+)
+
+(wait $T4)

--- a/test/spec/threads/wait_notify.wast
+++ b/test/spec/threads/wait_notify.wast
@@ -1,0 +1,41 @@
+;; test that looping notify eventually unblocks a parallel waiting thread
+(module $Mem
+  (memory (export "shared") 1 1 shared)
+)
+
+(thread $T1 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run") (result i32)
+      (memory.atomic.wait32 (i32.const 0) (i32.const 0) (i64.const -1))
+    )
+  )
+  ;; test that this thread eventually gets unblocked
+  (assert_return (invoke "run") (i32.const 0))
+)
+
+(thread $T2 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "notify-0") (result i32)
+      (memory.atomic.notify (i32.const 0) (i32.const 0))
+    )
+    (func (export "notify-1-while")
+      (loop
+        (i32.const 1)
+        (memory.atomic.notify (i32.const 0) (i32.const 1))
+        (i32.ne)
+        (br_if 0)
+      )
+    )
+  )
+  ;; notifying with a count of 0 will not unblock
+  (assert_return (invoke "notify-0") (i32.const 0))
+  ;; loop until something is notified
+  (assert_return (invoke "notify-1-while"))
+)
+
+(wait $T1)
+(wait $T2)


### PR DESCRIPTION
* Parse `(thread ...)` and `(wait ...)` in spec tests
  * Currently, we just run thread blocks directly, which means that `wait` is also a no-op. In the next PR, we'll add yield points on atomic operations e.g. `memory.atomic.wait32`.
  * We also disable splitting on tests that use `(thread ...)` for now. It should be possible to support this but we need better parsing in the module splitter. I'll add this in a future PR.
* Import threads tests from the [threads repo](https://github.com/WebAssembly/threads/tree/main/test/core/threads). These currently aren't in the testsuite repo because the threads repo is far behind the upstream spec and has some merge conflicts.
* Passes 10/13 new spec tests.

Part of #8315 and #8261.