### PR TITLE
SimplifyGlobals: Do not assume the effect of reading/writing globals implies global.get/set

### DIFF
--- a/src/passes/SimplifyGlobals.cpp
+++ b/src/passes/SimplifyGlobals.cpp
@@ -178,7 +178,14 @@ struct GlobalUseScanner : public WalkerPass<PostWalker<GlobalUseScanner>> {
     // ones exist. (In other words, we cannot take the shortcut of assuming that
     // the effect "writes global $foo" means we actually have a global.set $foo
     // here.)
-    if (FindAll<GlobalSet>(code).list.empty()) {
+    auto found = false;
+    for (auto* set : FindAll<GlobalSet>(code).list) {
+      if (set->name == writtenGlobal) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
       return Name();
     }
 
@@ -189,7 +196,14 @@ struct GlobalUseScanner : public WalkerPass<PostWalker<GlobalUseScanner>> {
     }
     // As above, confirm we see an actual global.get, and not a call to one with
     // computed effects.
-    if (FindAll<GlobalGet>(condition).list.empty()) {
+    found = false;
+    for (auto* get : FindAll<GlobalGet>(condition).list) {
+      if (get->name == writtenGlobal) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
       return Name();
     }
 

--- a/test/lit/passes/simplify-globals_func-effects.wast
+++ b/test/lit/passes/simplify-globals_func-effects.wast
@@ -343,3 +343,74 @@
  )
 )
 
+;; As above, but with a second global.
+(module
+ ;; CHECK:      (type $0 (func))
+
+ ;; CHECK:      (type $1 (func (result i32)))
+
+ ;; CHECK:      (global $global (mut i32) (i32.const 0))
+ (global $global (mut i32) (i32.const 0))
+
+ ;; CHECK:      (global $other i32 (i32.const 0))
+ (global $other (mut i32) (i32.const 0))
+
+ ;; CHECK:      (export "read-only-to-write" (func $read-only-to-write))
+
+ ;; CHECK:      (export "set" (func $set))
+
+ ;; CHECK:      (export "get" (func $get))
+
+ ;; CHECK:      (func $read-only-to-write
+ ;; CHECK-NEXT:  (if
+ ;; CHECK-NEXT:   (block (result i32)
+ ;; CHECK-NEXT:    (drop
+ ;; CHECK-NEXT:     (call $get)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (i32.const 0)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (then
+ ;; CHECK-NEXT:    (global.set $global
+ ;; CHECK-NEXT:     (i32.const 0)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $read-only-to-write (export "read-only-to-write")
+  ;; We *do* have a global.get here, but it is of the wrong global, $other, so
+  ;; we should not optimize $global (we can optimize $other to be immutable,
+  ;; though, and apply its value of 0 here).
+  (if
+   (block (result i32)
+    (drop
+     (call $get)
+    )
+    (global.get $other)
+   )
+   (then
+    (global.set $global
+     (i32.const 0)
+    )
+   )
+  )
+ )
+
+ ;; CHECK:      (func $set
+ ;; CHECK-NEXT:  (global.set $global
+ ;; CHECK-NEXT:   (i32.const 1)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $set (export "set")
+  (global.set $global
+   (i32.const 1)
+  )
+ )
+
+ ;; CHECK:      (func $get (result i32)
+ ;; CHECK-NEXT:  (global.get $global)
+ ;; CHECK-NEXT: )
+ (func $get (export "get") (result i32)
+  (global.get $global)
+ )
+)
+


### PR DESCRIPTION
This pass counts global.get/sets carefully, to figure out when all gets and
sets are accounted for in the "reads only to write" pattern. However, it
could miscount due to function effects: we could find the effect of a read/
write without an actual global.get/set, if we had a call to a function with
such contents, and we computed global effects for it.