### PR TITLE
LegalizeAndPruneJSInterface: Prune illegal globals

### DIFF
--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -414,7 +414,19 @@ struct LegalizeAndPruneJSInterface : public LegalizeJSInterface {
     ReFinalize().run(getPassRunner(), module);
     ReFinalize().runOnModuleCode(getPassRunner(), module);
 
-    // TODO: globals etc.
+    // Globals.
+    std::vector<Name> illegalExports;
+    for (auto& exp : module->exports) {
+      if (exp->kind == ExternalKind::Global) {
+        auto name = *exp->getInternalName();
+        if (isIllegal(module->getGlobal(name)->type)) {
+          illegalExports.push_back(exp->name);
+        }
+      }
+    }
+    for (auto name : illegalExports) {
+      module->removeExport(name);
+    }
   }
 
   bool isIllegal(Type type) {

--- a/test/lit/passes/legalize-and-prune-js-interface.wast
+++ b/test/lit/passes/legalize-and-prune-js-interface.wast
@@ -245,8 +245,23 @@
   ;; and also prune the export, so it remains neither an import nor an export.
   (export "imported-v128" (func $imported-v128))
 )
+
 ;; CHECK:      (type $0 (func (result v128)))
 
 ;; CHECK:      (func $imported-v128 (type $0) (result v128)
 ;; CHECK-NEXT:  (v128.const i32x4 0x00000000 0x00000000 0x00000000 0x00000000)
 ;; CHECK-NEXT: )
+(module
+ ;; CHECK:      (global $i32 i32 (i32.const 42))
+ (global $i32 i32 (i32.const 42))
+
+ ;; CHECK:      (global $v128 v128 (v128.const i32x4 0x00000000 0x00000000 0x00000000 0x00000000))
+ (global $v128 v128 (v128.const i32x4 0x00000000 0x00000000 0x00000000 0x00000000))
+
+ ;; The illegal export will vanish, but not the legal one.
+
+ (export "illegal" (global $v128))
+ ;; CHECK:      (export "legal" (global $i32))
+ (export "legal" (global $i32))
+)
+


### PR DESCRIPTION
Previously the pass handled only functions.

Handling globals will allow more fuzzing of exported globals.