### PR TITLE
Skip continuation types in SignatureRefining

### DIFF
--- a/src/passes/SignatureRefining.cpp
+++ b/src/passes/SignatureRefining.cpp
@@ -168,6 +168,17 @@ struct SignatureRefining : public Pass {
         false;
     }
 
+    // Continuations must not have params refined, because we do not update
+    // their users (e.g. cont.bind, resume) with new types.
+    // TODO: support refining continuations
+    if (module->features.hasStackSwitching()) {
+      for (auto type : ModuleUtils::collectHeapTypes(*module)) {
+        if (type.isContinuation()) {
+          allInfo[type.getContinuation().type].canModifyParams = false;
+        }
+      }
+    }
+
     // Also skip modifying types used in tags, even private tags, since we don't
     // analyze exception handling or stack switching instructions. TODO: Analyze
     // and optimize exception handling and stack switching instructions.

--- a/test/lit/passes/signature-refining.wast
+++ b/test/lit/passes/signature-refining.wast
@@ -1180,3 +1180,79 @@
     )
   )
 )
+
+(module
+  ;; If a signature is used in a continuation, we cannot refine its parameters,
+  ;; as we do not yet support updating continuation instructions with new types.
+  (rec
+    ;; CHECK:      (rec
+    ;; CHECK-NEXT:  (type $cont (cont $sig))
+
+    ;; CHECK:       (type $1 (func))
+
+    ;; CHECK:       (type $other (func (param nullref)))
+
+    ;; CHECK:       (type $sig (func (param anyref)))
+    (type $sig (func (param anyref)))
+    (type $other (func (param anyref)))
+    (type $cont (cont $sig))
+  )
+  ;; CHECK:      (elem declare func $cont $not-cont $other)
+
+  ;; CHECK:      (func $cont (type $sig) (param $0 anyref)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT: )
+  (func $cont (type $sig) (param anyref)
+    (nop)
+  )
+
+  ;; CHECK:      (func $not-cont (type $sig) (param $0 anyref)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT: )
+  (func $not-cont (type $sig) (param anyref)
+    ;; This function cannot be optimized even though it is not used in a
+    ;; continuation. It is enough that it shares a type with a continuation
+    ;;function.
+    (nop)
+  )
+
+  ;; CHECK:      (func $other (type $other) (param $0 nullref)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT: )
+  (func $other (type $other) (param anyref)
+    ;; This function uses a different type, so it can be optimized.
+    (nop)
+  )
+
+
+  ;; CHECK:      (func $test (type $1)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (cont.new $cont
+  ;; CHECK-NEXT:    (ref.func $cont)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (call_ref $sig
+  ;; CHECK-NEXT:   (ref.null none)
+  ;; CHECK-NEXT:   (ref.func $not-cont)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (call_ref $other
+  ;; CHECK-NEXT:   (ref.null none)
+  ;; CHECK-NEXT:   (ref.func $other)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $test
+    (drop
+      (cont.new $cont
+        (ref.func $cont)
+      )
+    )
+    (call_ref $sig
+      (ref.null none)
+      (ref.func $not-cont)
+    )
+    (call_ref $other
+      (ref.null none)
+      (ref.func $other)
+    )
+  )
+)


### PR DESCRIPTION
SignatureRefining has no knowledge of stack switching instructions or
types, so it would go ahead and optimize function types used in stack
switching instructions even if that made the stack switching usage
invalid. Simplify avoid optimizing those types for now.
