### PR TITLE
Reject null in `(assert_return ... (ref.<non null>))`

### DIFF
--- a/src/tools/wasm-shell.cpp
+++ b/src/tools/wasm-shell.cpp
@@ -368,7 +368,8 @@ struct Shell {
       }
     } else if (auto* ref = std::get_if<RefResult>(&expected)) {
       if (!val.type.isRef() ||
-          !HeapType::isSubType(val.type.getHeapType(), ref->type)) {
+          !HeapType::isSubType(val.type.getHeapType(), ref->type) ||
+          val.isNull()) {
         err << ref->type;
         return AlternativeErr{err.str()};
       }

--- a/test/lit/basic/ref.wast
+++ b/test/lit/basic/ref.wast
@@ -1,0 +1,10 @@
+;; RUN: not wasm-shell %s 2>&1 | filecheck %s
+
+(module
+  (func (export "f") (result (ref null i31))
+    (ref.null i31)
+  )
+)
+
+;; CHECK: expected i31, got nullref
+(assert_return (invoke "f") (ref.i31))


### PR DESCRIPTION
The added test would previously pass wrongly.