### PR TITLE
Interpreter support for waitqueue

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -2237,13 +2237,38 @@ public:
   }
 
   Flow visitStructWait(StructWait* curr) {
-    WASM_UNREACHABLE("struct.wait not implemented");
-    return Flow();
+    VISIT(ref, curr->ref)
+    VISIT(expected, curr->expected)
+    VISIT(timeout, curr->timeout)
+
+    auto data = ref.getSingleValue().getGCData();
+    if (!data) {
+      trap("null ref");
+    }
+    auto& field = data->values[curr->index];
+    if (field.geti32() != expected.getSingleValue().geti32()) {
+      return Literal(int32_t{1}); // not equal
+    }
+    // TODO: Add threads support. For now, report a host limit here, as there
+    //       are no other threads that can wake us up. Without such threads,
+    //       we'd hang if there is no timeout, and even if there is a timeout
+    //       then we can hang for a long time if it is in a loop. The only
+    //       timeout value we allow here for now is 0.
+    if (timeout.getSingleValue().geti64() != 0) {
+      hostLimit("threads support");
+      return Flow();
+    }
+    return Literal(int32_t{2}); // Timed out
   }
 
   Flow visitStructNotify(StructNotify* curr) {
-    WASM_UNREACHABLE("struct.notify not implemented");
-    return Flow();
+    VISIT(ref, curr->ref)
+    VISIT(count, curr->count)
+    auto data = ref.getSingleValue().getGCData();
+    if (!data) {
+      trap("null ref");
+    }
+    return Literal(int32_t{0}); // none woken up
   }
 
   // Arbitrary deterministic limit on size. If we need to allocate a Literals
@@ -4127,7 +4152,7 @@ public:
                                               memorySizeBytes,
                                               MemoryOrder::SeqCst);
     if (loaded != expected.getSingleValue()) {
-      return Literal(int32_t(1)); // not equal
+      return Literal(int32_t{1}); // not equal
     }
     // TODO: Add threads support. For now, report a host limit here, as there
     //       are no other threads that can wake us up. Without such threads,
@@ -4137,7 +4162,7 @@ public:
     if (timeout.getSingleValue().getInteger() != 0) {
       hostLimit("threads support");
     }
-    return Literal(int32_t(2)); // Timed out
+    return Literal(int32_t{2}); // Timed out
   }
   Flow visitAtomicNotify(AtomicNotify* curr) {
     VISIT(ptr, curr->ptr)
@@ -4148,7 +4173,7 @@ public:
       curr, ptr.getSingleValue(), 4, memorySizeBytes);
     // Just check TODO actual threads support
     info.instance->checkAtomicAddress(addr, 4, memorySizeBytes);
-    return Literal(int32_t(0)); // none woken up
+    return Literal(int32_t{0}); // none woken up
   }
   Flow visitSIMDLoad(SIMDLoad* curr) {
     switch (curr->op) {

--- a/test/spec/waitqueue.wast
+++ b/test/spec/waitqueue.wast
@@ -78,7 +78,11 @@
 (module
   (type $t (struct (field (mut waitqueue))))
 
-  (global $g (ref null $t) (struct.new $t (i32.const 0)))
+  (global $g (mut (ref null $t)) (struct.new $t (i32.const 0)))
+
+  (func (export "setToNull")
+    (global.set $g (ref.null $t))
+  )
 
   (func (export "struct.wait") (param $expected i32) (param $timeout i64) (result i32)
     (struct.wait $t 0 (global.get $g) (local.get $expected) (local.get $timeout))
@@ -92,7 +96,24 @@
     (struct.set $t 0 (global.get $g) (i32.const 1))
   )
 
-  (func (export "struct.get") (param $count i32) (result i32)
+  (func (export "struct.get") (result i32)
     (struct.get $t 0 (global.get $g))
   )
 )
+
+(invoke "struct.set" (i32.const 1))
+(assert_return (invoke "struct.get") (i32.const 1))
+
+;; Control word didn't match, don't wait and return 1.
+(assert_return (invoke "struct.wait" (i32.const 0) (i64.const 100)) (i32.const 1))
+
+;; Control word matched, wait 0ns and return 2.
+(assert_return (invoke "struct.wait" (i32.const 1) (i64.const 0)) (i32.const 2))
+
+;; Try to wake up 1 thread, but no-one was waiting.
+(assert_return (invoke "struct.notify" (i32.const 1)) (i32.const 0))
+
+(invoke "setToNull")
+
+(assert_trap (invoke "struct.wait" (i32.const 0) (i64.const 0)) "null ref")
+(assert_trap (invoke "struct.notify" (i32.const 0)) "null ref")


### PR DESCRIPTION
Part of #8315. We only support non-blocking cases where the timeout is 0 or the control word doesn't match, similar to memory.atomic.wait / memory.atomic.notify: [link](https://github.com/WebAssembly/binaryen/blob/a76d270ac6402f3a5ec268d22a2ccca3d0fb6680/src/wasm-interpreter.h#L4114-L4152).

Small drive-by fix to use brace-initialization instead of functional casts for int constants.