### PR TITLE
Remove coverage builder from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,44 +384,6 @@ jobs:
       run: cmake --build out
 
   # Duplicates build-asan.  Please keep in sync
-  build-gcov:
-    name: coverage
-    runs-on: ubuntu-latest
-    env:
-      COMPILER_FLAGS: "-fprofile-arcs -ftest-coverage"
-      CC: "gcc"
-      CXX: "g++"
-    steps:
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.x'
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - name: install ninja
-      run: sudo apt-get install ninja-build
-    - name: install v8
-      run: |
-        npm install jsvu -g
-        jsvu --os=default --engines=v8
-    - name: install Python dev dependencies
-      run: pip3 install -r requirements-dev.txt
-    - name: cmake
-      run: |
-        mkdir -p out
-        cmake -S . -B out -G Ninja -DCMAKE_INSTALL_PREFIX=out/install -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" -DCMAKE_C_FLAGS="$COMPILER_FLAGS" -DCMAKE_CXX_FLAGS="$COMPILER_FLAGS -DCMAKE_BUILD_TYPE=Debug"
-    - name: build
-      run: cmake --build out
-    - name: test
-      run: |
-        python check.py --binaryen-bin=out/bin lit
-        python check.py --binaryen-bin=out/bin gtest
-    - name: upload coverage
-      uses: codecov/codecov-action@v3
-      with:
-        gcov: true
-
-  # Duplicates build-asan.  Please keep in sync
   build-cxx20:
     name: c++20
     # Make sure we can still build on older Ubuntu


### PR DESCRIPTION
The coverage uploader has been running into rate limits and no one has complained. Clearly we are not using or benefiting from this builder in practice, so simply remove it.
