### PR TITLE
Skip a testcase with non-utf8 names in it that trips up the fuzzer

### DIFF
--- a/scripts/test/fuzzing.py
+++ b/scripts/test/fuzzing.py
@@ -124,6 +124,8 @@ unfuzzable = [
     'local-cse_idempotent.wast',
     # Not fully implemented.
     'waitqueue.wast',
+    # TODO: fix handling of the non-utf8 names here
+    'name-high-bytes.wast',
 ]
 
 


### PR DESCRIPTION
Works around #8482 for now.