### PR TITLE
[Fuzzing] Do not clusterfuzz multibyte

### DIFF
--- a/scripts/bundle_clusterfuzz.py
+++ b/scripts/bundle_clusterfuzz.py
@@ -102,7 +102,8 @@ else:
     binaryen_lib = shared.options.binaryen_lib
 
 # ClusterFuzz's run.py uses these features. Keep this in sync with that, so that
-# we only bundle initial content that makes sense for it.
+# we only bundle initial content that makes sense for it. Also keep it in sync
+# with fuzz_opt.py's DISALLOWED_FEATURES_IN_V8.
 features = [
     '-all',
     '--disable-shared-everything',
@@ -110,6 +111,7 @@ features = [
     '--disable-strings',
     '--disable-stack-switching',
     '--disable-relaxed-atomics',
+    '--disable-multibyte',
 ]
 
 with tarfile.open(output_file, "w:gz") as tar:

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -62,10 +62,19 @@ given_seed = None
 
 CLOSED_WORLD_FLAG = '--closed-world'
 
-# V8 does not support shared memories when running with
-# shared-everything enabled, so do not fuzz shared-everything
-# for now. The remaining features are not yet implemented in v8.
-DISALLOWED_FEATURES_IN_V8 = ['shared-everything', 'strings', 'stack-switching', 'relaxed-atomics', 'multibyte']
+# V8 does not support shared memories when running with shared-everything
+# enabled, so do not fuzz shared-everything for now. The remaining features are
+# not yet implemented in v8.
+#
+# Keep this in sync with bundle_clusterfuzz.py.
+DISALLOWED_FEATURES_IN_V8 = [
+    'shared-everything',
+    'fp16',
+    'strings',
+    'stack-switching',
+    'relaxed-atomics',
+    'multibyte',
+]
 
 
 # utilities


### PR DESCRIPTION
ClusterFuzz fuzzer in fuzz_opt.py hit this.

Also add fp16 in fuzz_opt.py for overall consistency, but fp16 is disabled
more generally there as well, a few lines above anyhow.