### PR TITLE
Trap on atomic.wait on an unshared memory

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -4213,6 +4213,9 @@ public:
     VISIT(timeout, curr->timeout)
     auto bytes = curr->expectedType.getByteSize();
     auto info = getMemoryInstanceInfo(curr->memory);
+    if (!info.instance->wasm.getMemory(info.name)->shared) {
+      trap("cannot atomic.wait a non-shared memory");
+    }
     auto memorySizeBytes = info.instance->getMemorySizeBytes(info.name);
     auto addr = info.instance->getFinalAddress(
       curr, ptr.getSingleValue(), bytes, memorySizeBytes);

--- a/test/lit/exec/atomic.wast
+++ b/test/lit/exec/atomic.wast
@@ -5,15 +5,29 @@
 (module
  (import "fuzzing-support" "log-i32" (func $log (param i32)))
 
- (memory $0 23 256 shared)
+ (memory $shared 23 256 shared)
+ (memory $unshared 10 20)
 
  ;; CHECK:      [fuzz-exec] export wait_and_log
  ;; CHECK-NEXT: [LoggingExternalInterface logging 2]
  (func $wait_and_log (export "wait_and_log")
   (call $log
-   (memory.atomic.wait64
+   (memory.atomic.wait64 $shared
     (i32.const 0)
     (i64.const 0)
+    (i64.const 0)
+   )
+  )
+ )
+
+ ;; CHECK:      [fuzz-exec] export wait_unshared
+ ;; CHECK-NEXT: [trap cannot atomic.wait a non-shared memory]
+ (func $wait_unshared (export "wait_unshared")
+  ;; Waiting on an unshared memory traps.
+  (drop
+   (memory.atomic.wait32 $unshared
+    (i32.const 0)
+    (i32.const 0)
     (i64.const 0)
    )
   )


### PR DESCRIPTION
This matches VM behavior