### PR TITLE
third_party/setup.py: fix wabt platform detection on Linux

### DIFF
--- a/third_party/setup.py
+++ b/third_party/setup.py
@@ -174,13 +174,13 @@ wabt_bin = os.path.join(wabt_dir, 'bin')
 
 def wabt_determine_platform():
     if sys.platform.startswith('linux'):
-        return 'ubuntu'
+        return 'linux'
     if sys.platform == 'darwin':
         return 'macos'
     if sys.platform == 'win32':
         return 'windows'
-    print('Cannot determine platform, assuming \'ubuntu\'')
-    return 'ubuntu'
+    print('Cannot determine platform, assuming \'linux\'')
+    return 'linux'
 
 
 def wabt_determine_release(platform):


### PR DESCRIPTION
wabt changed its release asset naming convention in version 1.0.39. On Linux, the old name `ubuntu` no longer matches the new names `linux-x64` / `linux-arm64`, causing `setup.py` to silently fail with an empty download URL and crash with `ValueError: unknown url type: ''`.

The fix mirrors the existing style for `macos` and `windows` — returning a prefix that matches the asset name via the existing regex.