### PR TITLE
[NFC] Fix logging functions in tests

### DIFF
--- a/test/lit/exec/cont_export.wast
+++ b/test/lit/exec/cont_export.wast
@@ -6,7 +6,7 @@
   (type $none (func))
   (type $cont (cont $none))
 
-  (import "fuzzing-support" "log" (func $log (param i32)))
+  (import "fuzzing-support" "log-i32" (func $log (param i32)))
 
   (import "fuzzing-support" "call-export" (func $call-export (param i32 i32)))
 

--- a/test/lit/exec/cont_return_call.wast
+++ b/test/lit/exec/cont_return_call.wast
@@ -11,7 +11,7 @@
  (type $cont (cont $i32))
  (type $none (func))
 
- (import "fuzzing-support" "log" (func $log (param i32)))
+ (import "fuzzing-support" "log-i32" (func $log (param i32)))
 
  (tag $tag (type $none))
 

--- a/test/lit/exec/cont_simple.wast
+++ b/test/lit/exec/cont_simple.wast
@@ -12,7 +12,7 @@
   (type $f-get-i32 (func (param i32)))
   (type $k-get-i32 (cont $f-get-i32))
 
-  (import "fuzzing-support" "log" (func $log (param i32)))
+  (import "fuzzing-support" "log-i32" (func $log (param i32)))
 
   (tag $more)
   (tag $more-i32 (result i32))


### PR DESCRIPTION
Only the proper names are recognized in our JS glue.