### PR TITLE
Use C++20 requires clauses in TypeNameGeneratorBase

### DIFF
--- a/src/wasm-type-printing.h
+++ b/src/wasm-type-printing.h
@@ -17,6 +17,7 @@
 #ifndef wasm_wasm_type_printing_h
 #define wasm_wasm_type_printing_h
 
+#include <concepts>
 #include <cstddef>
 #include <iostream>
 #include <unordered_map>
@@ -34,9 +35,6 @@ namespace wasm {
 template<typename Subclass> struct TypeNameGeneratorBase {
   TypeNameGeneratorBase() { assertValidUsage(); }
 
-  TypeNames getNames(HeapType type) {
-    WASM_UNREACHABLE("Derived class must implement getNames");
-  }
   HeapType::Printed operator()(HeapType type) {
     return type.print(
       [&](HeapType ht) { return static_cast<Subclass*>(this)->getNames(ht); });
@@ -48,16 +46,10 @@ template<typename Subclass> struct TypeNameGeneratorBase {
 
 private:
   constexpr void assertValidUsage() {
-    // This check current causes a crash on MSVC
-    // TODO: Convert to C++20 requires check
-#if !defined(_MSC_VER) && (!defined(__GNUC__) || __GNUC__ >= 14)
-    // Check that the subclass provides `getNames` with the correct type.
-    using Self = TypeNameGeneratorBase<Subclass>;
     static_assert(
-      static_cast<TypeNames (Self::*)(HeapType)>(&Self::getNames) !=
-        static_cast<TypeNames (Self::*)(HeapType)>(&Subclass::getNames),
-      "Derived class must implement getNames");
-#endif
+      requires(Subclass& s, HeapType ht) {
+        { s.getNames(ht) } -> std::same_as<TypeNames>;
+      }, "Derived class must implement getNames");
   }
 };
 
@@ -123,11 +115,8 @@ struct ModuleTypeNameGenerator
   ModuleTypeNameGenerator(const Module& wasm, FallbackGenerator& fallback)
     : wasm(wasm), fallback(fallback) {}
 
-  // TODO: Use C++20 `requires` to clean this up.
-  template<class T = FallbackGenerator>
-  ModuleTypeNameGenerator(
-    const Module& wasm,
-    std::enable_if_t<std::is_same_v<T, DefaultTypeNameGenerator>>* = nullptr)
+  ModuleTypeNameGenerator(const Module& wasm)
+    requires std::is_same_v<FallbackGenerator, DefaultTypeNameGenerator>
     : ModuleTypeNameGenerator(wasm, defaultGenerator) {}
 
   TypeNames getNames(HeapType type) {


### PR DESCRIPTION
This addresses the TODOs in src/wasm-type-printing.h by utilizing C++20 concepts and requires clauses.

- Replaced the manual SFINAE/macro-based check in TypeNameGeneratorBase with a static_assert(requires { ... }) to ensure subclasses implement getNames correctly. This is cleaner and more robust.
- Updated the ModuleTypeNameGenerator constructor to use a requires clause instead of std::enable_if_t for its default constructor, improving readability.
- Added #include <concepts> as required.

Verfied locally by remove a `getNames` impl:

```
/usr/local/google/home/sbc/dev/wasm/binaryen/src/wasm-type-printing.h: In instantiation of ‘constexpr void wasm::TypeNameGeneratorBase<Subclass>::assertValidUsage() [with Subclass = wasm::PrintSExpression::TypePrinter]’:
/usr/local/google/home/sbc/dev/wasm/binaryen/src/wasm-type-printing.h:36:29:   required from ‘wasm::TypeNameGeneratorBase<Subclass>::TypeNameGeneratorBase() [with Subclass = wasm::PrintSExpression::TypePrinter]’
   36 |   TypeNameGeneratorBase() { assertValidUsage(); }
      |                             ^~~~~~~~~~~~~~~~
/usr/local/google/home/sbc/dev/wasm/binaryen/src/passes/Print.cpp:179:22:   required from here
  179 |       : parent(parent) {
      |                      ^
/usr/local/google/home/sbc/dev/wasm/binaryen/src/wasm-type-printing.h:50:7: error: static assertion failed: Derived class must implement getNames
   50 |       requires(Subclass& s, HeapType ht) {
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   51 |         { s.getNames(ht) } -> std::same_as<TypeNames>;
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   52 |       }, "Derived class must implement getNames");
      |       ~
/usr/local/google/home/sbc/dev/wasm/binaryen/src/wasm-type-printing.h:50:7: note: ‘false’ evaluates to false
```