### PR TITLE
Stub out llvm::sys::fs::detail::directory_iterator_destruct for GCC 16

### DIFF
--- a/third_party/llvm-project/Path.cpp
+++ b/third_party/llvm-project/Path.cpp
@@ -1079,6 +1079,14 @@ ErrorOr<perms> getPermissions(const Twine &Path) {
 #if defined(_WIN32)
 #include "Windows/Path.inc"
 #endif
+#else
+// Stub out directory_iterator_destruct, which at least GCC 16 instantiates from
+// llvm/Support/FileSystem.h even though binaryen never uses it:
+namespace llvm { namespace sys { namespace fs { namespace detail {
+std::error_code directory_iterator_destruct(DirIterState &) {
+  return std::error_code();
+}
+}}}}
 #endif
 
 #if 0 // XXX BINARYEN


### PR DESCRIPTION
...which appears to instantiate the llvm::sys::fsdirectory_iterator destructor from llvm/Support/FileSystem.h even when the type is not actively used.  That destructor calls llvm::sys::fs::detail::directory_iterator_destruct, which is defined in Unix/Path.inc, but which is #if'ed out, causing builds to fail with

> [ 87%] Linking CXX shared library lib/libbinaryen.so
> /usr/bin/ld.bfd: third_party/llvm-project/CMakeFiles/llvm_dwarf.dir/DWARFUnit.cpp.o: in function `std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() [clone .part.0]':
> DWARFUnit.cpp:(.text+0x2665): undefined reference to `llvm::sys::fs::detail::directory_iterator_destruct(llvm::sys::fs::detail::DirIterState&)'
> /usr/bin/ld.bfd: DWARFUnit.cpp:(.text+0x2855): undefined reference to `llvm::sys::fs::detail::directory_iterator_destruct(llvm::sys::fs::detail::DirIterState&)'
> /usr/bin/ld.bfd: third_party/llvm-project/CMakeFiles/llvm_dwarf.dir/DWARFUnit.cpp.o: in function `llvm::DWARFUnit::~DWARFUnit()':
> DWARFUnit.cpp:(.text+0x2c13): undefined reference to `llvm::sys::fs::detail::directory_iterator_destruct(llvm::sys::fs::detail::DirIterState&)'
> /usr/bin/ld.bfd: DWARFUnit.cpp:(.text+0x2e2c): undefined reference to `llvm::sys::fs::detail::directory_iterator_destruct(llvm::sys::fs::detail::DirIterState&)'
> /usr/bin/ld.bfd: DWARFUnit.cpp:(.text+0x2ff2): undefined reference to `llvm::sys::fs::detail::directory_iterator_destruct(llvm::sys::fs::detail::DirIterState&)'
> /usr/bin/ld.bfd: third_party/llvm-project/CMakeFiles/llvm_dwarf.dir/DWARFUnit.cpp.o:DWARFUnit.cpp:(.text+0x4d39): more undefined references to `llvm::sys::fs::detail::directory_iterator_destruct(llvm::sys::fs::detail::DirIterState&)' follow

So provide a trivial stub to make the build succeed.