### PR TITLE
Fuzzer: Make --fuzz-preserve-imports-and-exports also preserve the start function

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2381,8 +2381,12 @@ void TranslateToFuzzReader::modifyInitialFunctions() {
   }
 
   // Remove a start function - the fuzzing harness expects code to run only
-  // from exports.
-  wasm.start = Name();
+  // from exports. When preserving imports and exports, however, we need to
+  // keep any start method, as it may be important to keep the contract between
+  // the wasm and the outside.
+  if (!preserveImportsAndExports) {
+    wasm.start = Name();
+  }
 }
 
 void TranslateToFuzzReader::dropToLog(Function* func) {

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -206,7 +206,7 @@ For more on how to optimize effectively, see
          [&](Options* o, const std::string& arguments) { fuzzOOB = false; })
     .add("--fuzz-preserve-imports-exports",
          "",
-         "don't add imports and exports in -ttf mode",
+         "don't add imports and exports in -ttf mode, and keep the start",
          WasmOptOption,
          Options::Arguments::Zero,
          [&](Options* o, const std::string& arguments) {

--- a/test/lit/fuzz-preserve-imports-exports.wast
+++ b/test/lit/fuzz-preserve-imports-exports.wast
@@ -18,7 +18,11 @@
 ;; PRESERVE:  (import "a" "f" (func $ifunc
 ;; PRESERVE:  (import "a" "c" (tag $itag
 
+;; The export is preserved.
 ;; PRESERVE:  (export "foo" (func $foo))
+
+;; The start function is preserved.
+;; PRESERVE:  (start $on_load)
 
 ;; And, without the flag, we do generate both imports and exports.
 
@@ -42,8 +46,14 @@
   (import "a" "e" (table $itable 10 20 funcref))
   (import "a" "f" (func $ifunc))
 
+  (start $on_load)
+
   ;; One existing export.
   (func $foo (export "foo")
+  )
+
+  (func $on_load
+    (call $ifunc)
   )
 )
 

--- a/test/lit/help/wasm-opt.test
+++ b/test/lit/help/wasm-opt.test
@@ -70,7 +70,7 @@
 ;; CHECK-NEXT:                                                 fuzzing
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --fuzz-preserve-imports-exports               don't add imports and exports in
-;; CHECK-NEXT:                                                 -ttf mode
+;; CHECK-NEXT:                                                 -ttf mode, and keep the start
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --fuzz-import                                 a module to use as an import in
 ;; CHECK-NEXT:                                                 -ttf mode


### PR DESCRIPTION
This start may be needed for the ABI between the wasm and the outside.
The point of preserve-imports-and-exports is to not break such ABIs, so it
doesn't seem like we need a new option here.