### PR TITLE
Fix spelling typos

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -3868,7 +3868,7 @@ printStackInst(StackInst* inst, std::ostream& o, Function* func) {
       break;
     }
     default:
-      WASM_UNREACHABLE("unexpeted op");
+      WASM_UNREACHABLE("unexpected op");
   }
   return o;
 }
@@ -3961,7 +3961,7 @@ static std::ostream& printStackIR(StackIR* ir, PrintSExpression& printer) {
         break;
       }
       default:
-        WASM_UNREACHABLE("unexpeted op");
+        WASM_UNREACHABLE("unexpected op");
     }
     o << '\n';
   }

--- a/src/passes/Souperify.cpp
+++ b/src/passes/Souperify.cpp
@@ -662,7 +662,7 @@ struct Printer {
       std::cout << ", ";
       printInternal(node->getValue(2));
     } else {
-      WASM_UNREACHABLE("unexecpted node type");
+      WASM_UNREACHABLE("unexpected node type");
     }
   }
 

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -178,7 +178,7 @@ void PassRegistry::registerPasses() {
   registerPass(
     "func-metrics", "reports function metrics", createFunctionMetricsPass);
   registerPass("generate-dyncalls",
-               "generate dynCall fuctions used by emscripten ABI",
+               "generate dynCall functions used by emscripten ABI",
                createGenerateDynCallsPass);
   registerPass(
     "generate-i64-dyncalls",
@@ -367,7 +367,7 @@ void PassRegistry::registerPasses() {
                "pick load signs based on their uses",
                createPickLoadSignsPass);
   registerPass(
-    "poppify", "Tranform Binaryen IR into Poppy IR", createPoppifyPass);
+    "poppify", "Transform Binaryen IR into Poppy IR", createPoppifyPass);
   registerPass("post-emscripten",
                "miscellaneous optimizations for Emscripten-generated code",
                createPostEmscriptenPass);

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -4921,7 +4921,7 @@ Expression* TranslateToFuzzReader::makeAtomic(Type type) {
           bytes = pick(1, 2, 4);
           break;
         default:
-          WASM_UNREACHABLE("invalide value");
+          WASM_UNREACHABLE("invalid value");
       }
       break;
     }
@@ -4940,7 +4940,7 @@ Expression* TranslateToFuzzReader::makeAtomic(Type type) {
           bytes = pick(1, 2, 4, 8);
           break;
         default:
-          WASM_UNREACHABLE("invalide value");
+          WASM_UNREACHABLE("invalid value");
       }
       break;
     }

--- a/src/tools/wasm-fuzz-lattices.cpp
+++ b/src/tools/wasm-fuzz-lattices.cpp
@@ -1067,7 +1067,7 @@ int main(int argc, const char* argv[]) {
 
   Options options("wasm-fuzz-lattices",
                   "Fuzz lattices for reflexivity, transitivity, and "
-                  "anti-symmetry, and tranfer functions for monotonicity.");
+                  "anti-symmetry, and transfer functions for monotonicity.");
 
   std::optional<uint64_t> seed;
   options.add("--seed",

--- a/test/lit/help/wasm-metadce.test
+++ b/test/lit/help/wasm-metadce.test
@@ -163,7 +163,7 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --func-metrics                                reports function metrics
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --generate-dyncalls                           generate dynCall fuctions used
+;; CHECK-NEXT:   --generate-dyncalls                           generate dynCall functions used
 ;; CHECK-NEXT:                                                 by emscripten ABI
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --generate-global-effects                     generate global effect info
@@ -347,7 +347,7 @@
 ;; CHECK-NEXT:   --pick-load-signs                             pick load signs based on their
 ;; CHECK-NEXT:                                                 uses
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --poppify                                     Tranform Binaryen IR into Poppy
+;; CHECK-NEXT:   --poppify                                     Transform Binaryen IR into Poppy
 ;; CHECK-NEXT:                                                 IR
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --post-emscripten                             miscellaneous optimizations for

--- a/test/lit/help/wasm-opt.test
+++ b/test/lit/help/wasm-opt.test
@@ -195,7 +195,7 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --func-metrics                                reports function metrics
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --generate-dyncalls                           generate dynCall fuctions used
+;; CHECK-NEXT:   --generate-dyncalls                           generate dynCall functions used
 ;; CHECK-NEXT:                                                 by emscripten ABI
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --generate-global-effects                     generate global effect info
@@ -379,7 +379,7 @@
 ;; CHECK-NEXT:   --pick-load-signs                             pick load signs based on their
 ;; CHECK-NEXT:                                                 uses
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --poppify                                     Tranform Binaryen IR into Poppy
+;; CHECK-NEXT:   --poppify                                     Transform Binaryen IR into Poppy
 ;; CHECK-NEXT:                                                 IR
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --post-emscripten                             miscellaneous optimizations for

--- a/test/lit/help/wasm2js.test
+++ b/test/lit/help/wasm2js.test
@@ -127,7 +127,7 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --func-metrics                                reports function metrics
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --generate-dyncalls                           generate dynCall fuctions used
+;; CHECK-NEXT:   --generate-dyncalls                           generate dynCall functions used
 ;; CHECK-NEXT:                                                 by emscripten ABI
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --generate-global-effects                     generate global effect info
@@ -311,7 +311,7 @@
 ;; CHECK-NEXT:   --pick-load-signs                             pick load signs based on their
 ;; CHECK-NEXT:                                                 uses
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --poppify                                     Tranform Binaryen IR into Poppy
+;; CHECK-NEXT:   --poppify                                     Transform Binaryen IR into Poppy
 ;; CHECK-NEXT:                                                 IR
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --post-emscripten                             miscellaneous optimizations for


### PR DESCRIPTION
Fix various spelling typos in source and test files, as reported by Debian Lintian.
The changes are limited to non-functional text corrections and do not affect program behavior.