### PR TITLE
perf: avoid O(N^2) exiting-branch checks in CodeFolding

### DIFF
--- a/src/passes/CodeFolding.cpp
+++ b/src/passes/CodeFolding.cpp
@@ -317,20 +317,21 @@ private:
     if (it != exitingBranchCache.end()) {
       return !it->second.empty();
     }
-    return populateExitingBranchCache(expr);
+    return !populateExitingBranchCache(expr).empty();
   }
 
   // Walk |root| bottom-up computing exiting branches. Name sets are kept
   // transiently (moved from children, erased after merge). Only the root's
   // name set is persisted. Already-cached subtrees are skipped via scan(),
   // and their cached names are merged in precisely.
-  bool populateExitingBranchCache(Expression* root) {
+  // Returns a reference to the root's cached set (which may be empty).
+  const std::unordered_set<Name>& populateExitingBranchCache(Expression* root) {
     struct CachePopulator
       : public PostWalker<CachePopulator,
                           UnifiedExpressionVisitor<CachePopulator>> {
       std::unordered_map<Expression*, std::unordered_set<Name>>& resultCache;
       Expression* root;
-      bool rootResult = false;
+      const std::unordered_set<Name>* rootResult = nullptr;
       std::unordered_map<Expression*, std::unordered_set<Name>> nameSets;
 
       CachePopulator(
@@ -388,17 +389,16 @@ private:
         if (curr == root) {
           auto it = nameSets.find(curr);
           if (it != nameSets.end()) {
-            resultCache[curr] = std::move(it->second);
-            rootResult = true;
+            rootResult = &(resultCache[curr] = std::move(it->second));
           } else {
-            resultCache[curr] = {};
+            rootResult = &(resultCache[curr] = {});
           }
         }
       }
     };
     CachePopulator populator(exitingBranchCache, root);
     populator.walk(root);
-    return populator.rootResult;
+    return *populator.rootResult;
   }
 
   // check if we can move a list of items out of another item. we can't do so

--- a/src/passes/CodeFolding.cpp
+++ b/src/passes/CodeFolding.cpp
@@ -136,11 +136,6 @@ struct CodeFolding
     modifieds; // modified code should not be processed
                // again, wait for next pass
 
-  // Cache of expressions that have branches exiting to targets defined
-  // outside them. Populated lazily on first access via PostWalker.
-  std::unordered_set<Expression*> exitingBranchCache_;
-  bool exitingBranchCachePopulated_ = false;
-
   // walking
 
   void visitExpression(Expression* curr) {
@@ -305,8 +300,8 @@ struct CodeFolding
       returnTails.clear();
       unoptimizables.clear();
       modifieds.clear();
-      exitingBranchCache_.clear();
-      exitingBranchCachePopulated_ = false;
+      exitingBranchCache.clear();
+      exitingBranchCachePopulated = false;
       if (needEHFixups) {
         EHUtils::handleBlockNestedPops(func, *getModule());
       }
@@ -314,19 +309,21 @@ struct CodeFolding
   }
 
 private:
-  // Check if an expression has branches that exit to targets defined outside
-  // it. The cache is populated lazily on first call using a PostWalker for
-  // efficient bottom-up traversal.
+  // Cache of expressions that have branches exiting to targets defined
+  // outside them. Populated lazily on first access via hasExitingBranches().
+  std::unordered_set<Expression*> exitingBranchCache;
+  bool exitingBranchCachePopulated = false;
+
   bool hasExitingBranches(Expression* expr) {
-    if (!exitingBranchCachePopulated_) {
+    if (!exitingBranchCachePopulated) {
       populateExitingBranchCache(getFunction()->body);
-      exitingBranchCachePopulated_ = true;
+      exitingBranchCachePopulated = true;
     }
-    return exitingBranchCache_.count(expr);
+    return exitingBranchCache.count(expr);
   }
 
   // Pre-populate the exiting branch cache for all sub-expressions of root
-  // in a single O(N) bottom-up walk. After this, exitingBranchCache_
+  // in a single O(N) bottom-up walk. After this, exitingBranchCache
   // lookups are O(1).
   void populateExitingBranchCache(Expression* root) {
     struct CachePopulator
@@ -371,7 +368,7 @@ private:
         }
       }
     };
-    CachePopulator populator(exitingBranchCache_);
+    CachePopulator populator(exitingBranchCache);
     populator.walk(root);
   }
 

--- a/src/passes/CodeFolding.cpp
+++ b/src/passes/CodeFolding.cpp
@@ -136,9 +136,10 @@ struct CodeFolding
     modifieds; // modified code should not be processed
                // again, wait for next pass
 
-  // Cache for hasExitingBranches results. Populated by a single bottom-up
-  // walk to avoid O(N^2) repeated tree traversals on nested blocks.
-  std::unordered_map<Expression*, bool> exitingBranchCache_;
+  // Cache of expressions that have branches exiting to targets defined
+  // outside them. Populated lazily on first access via PostWalker.
+  std::unordered_set<Expression*> exitingBranchCache_;
+  bool exitingBranchCachePopulated_ = false;
 
   // walking
 
@@ -305,6 +306,7 @@ struct CodeFolding
       unoptimizables.clear();
       modifieds.clear();
       exitingBranchCache_.clear();
+      exitingBranchCachePopulated_ = false;
       if (needEHFixups) {
         EHUtils::handleBlockNestedPops(func, *getModule());
       }
@@ -312,6 +314,17 @@ struct CodeFolding
   }
 
 private:
+  // Check if an expression has branches that exit to targets defined outside
+  // it. The cache is populated lazily on first call using a PostWalker for
+  // efficient bottom-up traversal.
+  bool hasExitingBranches(Expression* expr) {
+    if (!exitingBranchCachePopulated_) {
+      populateExitingBranchCache(getFunction()->body);
+      exitingBranchCachePopulated_ = true;
+    }
+    return exitingBranchCache_.count(expr);
+  }
+
   // Pre-populate the exiting branch cache for all sub-expressions of root
   // in a single O(N) bottom-up walk. After this, exitingBranchCache_
   // lookups are O(1).
@@ -319,14 +332,13 @@ private:
     struct CachePopulator
       : public PostWalker<CachePopulator,
                           UnifiedExpressionVisitor<CachePopulator>> {
-      std::unordered_map<Expression*, bool>& cache;
+      std::unordered_set<Expression*>& cache;
       // Track unresolved branch targets at each node. We propagate children's
       // targets upward: add uses, remove defs. If any remain, the expression
       // has exiting branches.
       std::unordered_map<Expression*, std::unordered_set<Name>> targetSets;
 
-      CachePopulator(std::unordered_map<Expression*, bool>& cache)
-        : cache(cache) {}
+      CachePopulator(std::unordered_set<Expression*>& cache) : cache(cache) {}
 
       void visitExpression(Expression* curr) {
         std::unordered_set<Name> targets;
@@ -353,8 +365,8 @@ private:
           }
         });
         bool hasExiting = !targets.empty();
-        cache[curr] = hasExiting;
         if (hasExiting) {
+          cache.insert(curr);
           targetSets[curr] = std::move(targets);
         }
       }
@@ -606,11 +618,6 @@ private:
     if (tails.size() < 2) {
       return false;
     }
-    // Pre-populate the cache once at the top level so all subsequent
-    // exitingBranchCache_ lookups are O(1).
-    if (num == 0) {
-      populateExitingBranchCache(getFunction()->body);
-    }
     // remove things that are untoward and cannot be optimized
     tails.erase(
       std::remove_if(tails.begin(),
@@ -699,7 +706,7 @@ private:
                                 // TODO: this should not be a problem in
                                 //       *non*-terminating tails, but
                                 //       double-verify that
-                                if (exitingBranchCache_[newItem]) {
+                                if (hasExitingBranches(newItem)) {
                                   return true;
                                 }
                                 return false;

--- a/src/passes/CodeFolding.cpp
+++ b/src/passes/CodeFolding.cpp
@@ -63,6 +63,7 @@
 #include "ir/effects.h"
 #include "ir/eh-utils.h"
 #include "ir/find_all.h"
+#include "ir/iteration.h"
 #include "ir/label-utils.h"
 #include "ir/utils.h"
 #include "pass.h"
@@ -134,6 +135,10 @@ struct CodeFolding
   std::unordered_set<Expression*>
     modifieds; // modified code should not be processed
                // again, wait for next pass
+
+  // Cache for hasExitingBranches results. Populated by a single bottom-up
+  // walk to avoid O(N^2) repeated tree traversals on nested blocks.
+  std::unordered_map<Expression*, bool> exitingBranchCache_;
 
   // walking
 
@@ -299,6 +304,7 @@ struct CodeFolding
       returnTails.clear();
       unoptimizables.clear();
       modifieds.clear();
+      exitingBranchCache_.clear();
       if (needEHFixups) {
         EHUtils::handleBlockNestedPops(func, *getModule());
       }
@@ -306,6 +312,57 @@ struct CodeFolding
   }
 
 private:
+  // Pre-populate the exiting branch cache for all sub-expressions of root
+  // in a single O(N) bottom-up walk. After this, exitingBranchCache_
+  // lookups are O(1).
+  void populateExitingBranchCache(Expression* root) {
+    struct CachePopulator
+      : public PostWalker<CachePopulator,
+                          UnifiedExpressionVisitor<CachePopulator>> {
+      std::unordered_map<Expression*, bool>& cache;
+      // Track unresolved branch targets at each node. We propagate children's
+      // targets upward: add uses, remove defs. If any remain, the expression
+      // has exiting branches.
+      std::unordered_map<Expression*, std::unordered_set<Name>> targetSets;
+
+      CachePopulator(std::unordered_map<Expression*, bool>& cache)
+        : cache(cache) {}
+
+      void visitExpression(Expression* curr) {
+        std::unordered_set<Name> targets;
+        // Merge children's target sets into ours (move to avoid copies)
+        ChildIterator children(curr);
+        for (auto* child : children) {
+          auto it = targetSets.find(child);
+          if (it != targetSets.end()) {
+            if (targets.empty()) {
+              targets = std::move(it->second);
+            } else {
+              targets.merge(it->second);
+            }
+            targetSets.erase(it);
+          }
+        }
+        // Add branch uses (names this expression branches to)
+        BranchUtils::operateOnScopeNameUses(
+          curr, [&](Name& name) { targets.insert(name); });
+        // Remove branch defs (names this expression defines as targets)
+        BranchUtils::operateOnScopeNameDefs(curr, [&](Name& name) {
+          if (name.is()) {
+            targets.erase(name);
+          }
+        });
+        bool hasExiting = !targets.empty();
+        cache[curr] = hasExiting;
+        if (hasExiting) {
+          targetSets[curr] = std::move(targets);
+        }
+      }
+    };
+    CachePopulator populator(exitingBranchCache_);
+    populator.walk(root);
+  }
+
   // check if we can move a list of items out of another item. we can't do so
   // if one of the items has a branch to something inside outOf that is not
   // inside that item
@@ -549,6 +606,11 @@ private:
     if (tails.size() < 2) {
       return false;
     }
+    // Pre-populate the cache once at the top level so all subsequent
+    // exitingBranchCache_ lookups are O(1).
+    if (num == 0) {
+      populateExitingBranchCache(getFunction()->body);
+    }
     // remove things that are untoward and cannot be optimized
     tails.erase(
       std::remove_if(tails.begin(),
@@ -637,9 +699,7 @@ private:
                                 // TODO: this should not be a problem in
                                 //       *non*-terminating tails, but
                                 //       double-verify that
-                                if (EffectAnalyzer(
-                                      getPassOptions(), *getModule(), newItem)
-                                      .hasExternalBreakTargets()) {
+                                if (exitingBranchCache_[newItem]) {
                                   return true;
                                 }
                                 return false;

--- a/src/passes/CodeFolding.cpp
+++ b/src/passes/CodeFolding.cpp
@@ -56,7 +56,6 @@
 //
 
 #include <iterator>
-#include <optional>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -310,14 +309,13 @@ struct CodeFolding
 
 private:
   // Cache of exiting branch names, populated on demand. Only queried roots
-  // are stored. nullopt means no exiting branches; a set holds the names.
-  std::unordered_map<Expression*, std::optional<std::unordered_set<Name>>>
-    exitingBranchCache;
+  // are stored. An empty set means no exiting branches.
+  std::unordered_map<Expression*, std::unordered_set<Name>> exitingBranchCache;
 
   bool hasExitingBranches(Expression* expr) {
     auto it = exitingBranchCache.find(expr);
     if (it != exitingBranchCache.end()) {
-      return it->second.has_value();
+      return !it->second.empty();
     }
     return populateExitingBranchCache(expr);
   }
@@ -330,16 +328,14 @@ private:
     struct CachePopulator
       : public PostWalker<CachePopulator,
                           UnifiedExpressionVisitor<CachePopulator>> {
-      std::unordered_map<Expression*, std::optional<std::unordered_set<Name>>>&
-        resultCache;
+      std::unordered_map<Expression*, std::unordered_set<Name>>& resultCache;
       Expression* root;
       bool rootResult = false;
       std::unordered_map<Expression*, std::unordered_set<Name>> nameSets;
 
-      CachePopulator(std::unordered_map<
-                       Expression*,
-                       std::optional<std::unordered_set<Name>>>& resultCache,
-                     Expression* root)
+      CachePopulator(
+        std::unordered_map<Expression*, std::unordered_set<Name>>& resultCache,
+        Expression* root)
         : resultCache(resultCache), root(root) {}
 
       static void scan(CachePopulator* self, Expression** currp) {
@@ -367,12 +363,11 @@ private:
           } else {
             // Child was skipped by scan() — merge its cached names.
             auto cacheIt = resultCache.find(child);
-            if (cacheIt != resultCache.end() && cacheIt->second) {
+            if (cacheIt != resultCache.end() && !cacheIt->second.empty()) {
               if (targets.empty()) {
-                targets = *cacheIt->second;
+                targets = cacheIt->second;
               } else {
-                targets.insert(cacheIt->second->begin(),
-                               cacheIt->second->end());
+                targets.insert(cacheIt->second.begin(), cacheIt->second.end());
               }
             }
           }
@@ -396,7 +391,7 @@ private:
             resultCache[curr] = std::move(it->second);
             rootResult = true;
           } else {
-            resultCache[curr] = std::nullopt;
+            resultCache[curr] = {};
           }
         }
       }

--- a/src/passes/CodeFolding.cpp
+++ b/src/passes/CodeFolding.cpp
@@ -56,6 +56,7 @@
 //
 
 #include <iterator>
+#include <optional>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -301,7 +302,6 @@ struct CodeFolding
       unoptimizables.clear();
       modifieds.clear();
       exitingBranchCache.clear();
-      exitingBranchCachePopulated = false;
       if (needEHFixups) {
         EHUtils::handleBlockNestedPops(func, *getModule());
       }
@@ -309,67 +309,101 @@ struct CodeFolding
   }
 
 private:
-  // Cache of expressions that have branches exiting to targets defined
-  // outside them. Populated lazily on first access via hasExitingBranches().
-  std::unordered_set<Expression*> exitingBranchCache;
-  bool exitingBranchCachePopulated = false;
+  // Cache of exiting branch names, populated on demand. Only queried roots
+  // are stored. nullopt means no exiting branches; a set holds the names.
+  std::unordered_map<Expression*, std::optional<std::unordered_set<Name>>>
+    exitingBranchCache;
 
   bool hasExitingBranches(Expression* expr) {
-    if (!exitingBranchCachePopulated) {
-      populateExitingBranchCache(getFunction()->body);
-      exitingBranchCachePopulated = true;
+    auto it = exitingBranchCache.find(expr);
+    if (it != exitingBranchCache.end()) {
+      return it->second.has_value();
     }
-    return exitingBranchCache.count(expr);
+    return populateExitingBranchCache(expr);
   }
 
-  // Pre-populate the exiting branch cache for all sub-expressions of root
-  // in a single O(N) bottom-up walk. After this, exitingBranchCache
-  // lookups are O(1).
-  void populateExitingBranchCache(Expression* root) {
+  // Walk |root| bottom-up computing exiting branches. Name sets are kept
+  // transiently (moved from children, erased after merge). Only the root's
+  // name set is persisted. Already-cached subtrees are skipped via scan(),
+  // and their cached names are merged in precisely.
+  bool populateExitingBranchCache(Expression* root) {
     struct CachePopulator
       : public PostWalker<CachePopulator,
                           UnifiedExpressionVisitor<CachePopulator>> {
-      std::unordered_set<Expression*>& cache;
-      // Track unresolved branch targets at each node. We propagate children's
-      // targets upward: add uses, remove defs. If any remain, the expression
-      // has exiting branches.
-      std::unordered_map<Expression*, std::unordered_set<Name>> targetSets;
+      std::unordered_map<Expression*, std::optional<std::unordered_set<Name>>>&
+        resultCache;
+      Expression* root;
+      bool rootResult = false;
+      std::unordered_map<Expression*, std::unordered_set<Name>> nameSets;
 
-      CachePopulator(std::unordered_set<Expression*>& cache) : cache(cache) {}
+      CachePopulator(std::unordered_map<
+                       Expression*,
+                       std::optional<std::unordered_set<Name>>>& resultCache,
+                     Expression* root)
+        : resultCache(resultCache), root(root) {}
+
+      static void scan(CachePopulator* self, Expression** currp) {
+        auto* curr = *currp;
+        if (self->resultCache.count(curr)) {
+          return;
+        }
+        PostWalker<CachePopulator,
+                   UnifiedExpressionVisitor<CachePopulator>>::scan(self, currp);
+      }
 
       void visitExpression(Expression* curr) {
         std::unordered_set<Name> targets;
-        // Merge children's target sets into ours (move to avoid copies)
+
         ChildIterator children(curr);
         for (auto* child : children) {
-          auto it = targetSets.find(child);
-          if (it != targetSets.end()) {
+          auto it = nameSets.find(child);
+          if (it != nameSets.end()) {
             if (targets.empty()) {
               targets = std::move(it->second);
             } else {
               targets.merge(it->second);
             }
-            targetSets.erase(it);
+            nameSets.erase(it);
+          } else {
+            // Child was skipped by scan() — merge its cached names.
+            auto cacheIt = resultCache.find(child);
+            if (cacheIt != resultCache.end() && cacheIt->second) {
+              if (targets.empty()) {
+                targets = *cacheIt->second;
+              } else {
+                targets.insert(cacheIt->second->begin(),
+                               cacheIt->second->end());
+              }
+            }
           }
         }
-        // Add branch uses (names this expression branches to)
+
         BranchUtils::operateOnScopeNameUses(
           curr, [&](Name& name) { targets.insert(name); });
-        // Remove branch defs (names this expression defines as targets)
+
         BranchUtils::operateOnScopeNameDefs(curr, [&](Name& name) {
           if (name.is()) {
             targets.erase(name);
           }
         });
-        bool hasExiting = !targets.empty();
-        if (hasExiting) {
-          cache.insert(curr);
-          targetSets[curr] = std::move(targets);
+
+        if (!targets.empty()) {
+          nameSets[curr] = std::move(targets);
+        }
+        if (curr == root) {
+          auto it = nameSets.find(curr);
+          if (it != nameSets.end()) {
+            resultCache[curr] = std::move(it->second);
+            rootResult = true;
+          } else {
+            resultCache[curr] = std::nullopt;
+          }
         }
       }
     };
-    CachePopulator populator(exitingBranchCache);
+    CachePopulator populator(exitingBranchCache, root);
     populator.walk(root);
+    return populator.rootResult;
   }
 
   // check if we can move a list of items out of another item. we can't do so

--- a/src/passes/CodeFolding.cpp
+++ b/src/passes/CodeFolding.cpp
@@ -330,14 +330,11 @@ private:
       : public PostWalker<CachePopulator,
                           UnifiedExpressionVisitor<CachePopulator>> {
       std::unordered_map<Expression*, std::unordered_set<Name>>& resultCache;
-      Expression* root;
-      const std::unordered_set<Name>* rootResult = nullptr;
       std::unordered_map<Expression*, std::unordered_set<Name>> nameSets;
 
       CachePopulator(
-        std::unordered_map<Expression*, std::unordered_set<Name>>& resultCache,
-        Expression* root)
-        : resultCache(resultCache), root(root) {}
+        std::unordered_map<Expression*, std::unordered_set<Name>>& resultCache)
+        : resultCache(resultCache) {}
 
       static void scan(CachePopulator* self, Expression** currp) {
         auto* curr = *currp;
@@ -386,19 +383,15 @@ private:
         if (!targets.empty()) {
           nameSets[curr] = std::move(targets);
         }
-        if (curr == root) {
-          auto it = nameSets.find(curr);
-          if (it != nameSets.end()) {
-            rootResult = &(resultCache[curr] = std::move(it->second));
-          } else {
-            rootResult = &(resultCache[curr] = {});
-          }
-        }
       }
     };
-    CachePopulator populator(exitingBranchCache, root);
+    CachePopulator populator(exitingBranchCache);
     populator.walk(root);
-    return *populator.rootResult;
+    auto it = populator.nameSets.find(root);
+    if (it != populator.nameSets.end()) {
+      return exitingBranchCache[root] = std::move(it->second);
+    }
+    return exitingBranchCache[root] = {};
   }
 
   // check if we can move a list of items out of another item. we can't do so


### PR DESCRIPTION
Follow up PR of #8586 to optimize CodeFolding

`optimizeTerminatingTails` calls `EffectAnalyzer` per tail item, each walking the full subtree. On deeply nested blocks this is O(N^2).

Replace the per-item walks with a single O(N) bottom-up `PostWalker` (`populateExitingBranchCache`) that pre-computes exiting-branch results for every node, making subsequent lookups O(1).

Example: AssemblyScript GC compiles `__visit_members` as a `br_table` dispatch over all types, producing ~N nested blocks with ~N tails. The old code walks each tail's subtree separately -- O(N^2) total node visits. With this change, one bottom-up walk covers all nodes, then each tail lookup is O(1).

```
(block $A          ;; depth 4000
  (block $B        ;; depth 3999
    (block $C      ;; depth 3998
      ...
      (br_table $A $B $C ... (local.get $rtid))
    )
    (unreachable)  ;; tail at depth 3999, old code walks 3999 nodes
  )
  (unreachable)    ;; tail at depth 4000, old code walks 4000 nodes
)
```

benchmark data
The test module is from issue #7319
https://github.com/WebAssembly/binaryen/issues/7319#issuecomment-2678393304

In main head
```shell
time ./build/bin/wasm-opt -Oz --enable-bulk-memory --enable-multivalue --enable-reference-types --enable-gc --enable-tail-call --enable-exception-handling  -o /dev/null ./test3.wasm

real    9m16.111s
user    35m33.985s
sys     0m51.000s
```

In the PR
```
time ./build/bin/wasm-opt -Oz --enable-bulk-memory --enable-multivalue --enable-reference-types --enable-gc --enable-tail-call --enable-exception-handling  -o /dev/null ./test3.wasm

real    5m17.170s
user    30m9.198s
sys     0m28.030s
```
