### PR TITLE
perf: use unordered containers for Name sets in SimplifyLocals and DuplicateFunctionElimination

### DIFF
--- a/src/passes/DuplicateFunctionElimination.cpp
+++ b/src/passes/DuplicateFunctionElimination.cpp
@@ -64,7 +64,7 @@ struct DuplicateFunctionElimination : public Pass {
       });
       // Find actually equal functions and prepare to replace them
       std::map<Name, Name> replacements;
-      std::set<Name> duplicates;
+      std::unordered_set<Name> duplicates;
       for (auto& [_, group] : hashGroups) {
         Index size = group.size();
         if (size == 1) {

--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -102,11 +102,11 @@ struct SimplifyLocals
   // a list of all sinkable traces that exit a block. the last
   // is falling off the end, others are branches. this is used for
   // block returns
-  std::map<Name, std::vector<BlockBreak>> blockBreaks;
+  std::unordered_map<Name, std::vector<BlockBreak>> blockBreaks;
 
   // blocks that we can't produce a block return value for them.
   // (switch target, or some other reason)
-  std::set<Name> unoptimizableBlocks;
+  std::unordered_set<Name> unoptimizableBlocks;
 
   // A stack of sinkables from the current traversal state. When
   // execution reaches an if-else, it splits, and can then


### PR DESCRIPTION
This PR is proposed by https://github.com/WebAssembly/binaryen/pull/8586#issuecomment-4240228894


Benchmark result shows the benefit is very limited. But since the change is also very small, I would say better than nothing.

