### PR TITLE
[NFC] Improve SimplifyLocals compile-time performance

### DIFF
--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -86,10 +86,97 @@ struct SimplifyLocals
   };
 
   // a list of sinkables in a linear execution trace
-  using Sinkables = std::map<Index, SinkableInfo>;
+  using Sinkables = std::unordered_map<Index, SinkableInfo>;
 
   // locals in current linear execution trace, which we try to sink
   Sinkables sinkables;
+
+  // Reverse index: for each local L, tracks which sinkable keys have effects
+  // that read L. Used to find read-write conflicts when the current expression
+  // writes L.
+  std::unordered_map<Index, std::unordered_set<Index>> localReadBySinkable;
+
+  // Reverse index: for each local L, tracks which sinkable keys have effects
+  // that write L. A sinkable at key K always writes K, but may also write
+  // other locals if its value contains nested local.sets.
+  std::unordered_map<Index, std::unordered_set<Index>> localWrittenBySinkable;
+
+  // Sinkable keys whose effects include transfersControlFlow(). These must
+  // be invalidated whenever the current expression has side effects (including
+  // local writes), due to the asymmetric check in orderedBefore:
+  //   sinkable.transfersControlFlow() && current.hasSideEffects()
+  // This set is usually empty since sinkables rarely transfer control flow.
+  std::unordered_set<Index> controlFlowSinkables;
+
+  void registerSinkable(Index key) {
+    auto& effects = sinkables.at(key).effects;
+    for (auto L : effects.localsRead) {
+      localReadBySinkable[L].insert(key);
+    }
+    for (auto L : effects.localsWritten) {
+      localWrittenBySinkable[L].insert(key);
+    }
+    if (effects.transfersControlFlow()) {
+      controlFlowSinkables.insert(key);
+    }
+  }
+
+  void unregisterSinkable(Index key) {
+    auto it = sinkables.find(key);
+    if (it == sinkables.end()) {
+      return;
+    }
+    auto& effects = it->second.effects;
+    for (auto L : effects.localsRead) {
+      auto mapIt = localReadBySinkable.find(L);
+      if (mapIt != localReadBySinkable.end()) {
+        mapIt->second.erase(key);
+        if (mapIt->second.empty()) {
+          localReadBySinkable.erase(mapIt);
+        }
+      }
+    }
+    for (auto L : effects.localsWritten) {
+      auto mapIt = localWrittenBySinkable.find(L);
+      if (mapIt != localWrittenBySinkable.end()) {
+        mapIt->second.erase(key);
+        if (mapIt->second.empty()) {
+          localWrittenBySinkable.erase(mapIt);
+        }
+      }
+    }
+    controlFlowSinkables.erase(key);
+  }
+
+  void clearSinkables() {
+    sinkables.clear();
+    localReadBySinkable.clear();
+    localWrittenBySinkable.clear();
+    controlFlowSinkables.clear();
+  }
+
+  Sinkables takeSinkables() {
+    localReadBySinkable.clear();
+    localWrittenBySinkable.clear();
+    controlFlowSinkables.clear();
+    return std::move(sinkables);
+  }
+
+  void eraseSinkable(typename Sinkables::iterator it) {
+    unregisterSinkable(it->first);
+    sinkables.erase(it);
+  }
+
+  void eraseSinkable(Index key) {
+    unregisterSinkable(key);
+    sinkables.erase(key);
+  }
+
+  void addSinkable(Index key, Expression** currp) {
+    sinkables.emplace(std::pair{
+      key, SinkableInfo(currp, this->getPassOptions(), *this->getModule())});
+    registerSinkable(key);
+  }
 
   // Information about an exit from a block: the break, and the
   // sinkables. For the final exit from a block (falling off)
@@ -135,8 +222,7 @@ struct SimplifyLocals
         // value means the block already has a return value
         self->unoptimizableBlocks.insert(br->name);
       } else {
-        self->blockBreaks[br->name].push_back(
-          {currp, std::move(self->sinkables)});
+        self->blockBreaks[br->name].push_back({currp, self->takeSinkables()});
       }
     } else if (curr->is<Block>()) {
       return; // handled in visitBlock
@@ -153,7 +239,7 @@ struct SimplifyLocals
       }
       // TODO: we could use this info to stop gathering data on these blocks
     }
-    self->sinkables.clear();
+    self->clearSinkables();
   }
 
   static void doNoteIfCondition(
@@ -161,7 +247,7 @@ struct SimplifyLocals
     Expression** currp) {
     // we processed the condition of this if-else, and now control flow branches
     // into either the true or the false sides
-    self->sinkables.clear();
+    self->clearSinkables();
   }
 
   static void
@@ -170,13 +256,13 @@ struct SimplifyLocals
     auto* iff = (*currp)->cast<If>();
     if (iff->ifFalse) {
       // We processed the ifTrue side of this if-else, save it on the stack.
-      self->ifStack.push_back(std::move(self->sinkables));
+      self->ifStack.push_back(self->takeSinkables());
     } else {
       // This is an if without an else.
       if (allowStructure) {
         self->optimizeIfReturn(iff, currp);
       }
-      self->sinkables.clear();
+      self->clearSinkables();
     }
   }
 
@@ -191,7 +277,7 @@ struct SimplifyLocals
       self->optimizeIfElseReturn(iff, currp, self->ifStack.back());
     }
     self->ifStack.pop_back();
-    self->sinkables.clear();
+    self->clearSinkables();
   }
 
   void visitBlock(Block* curr) {
@@ -204,13 +290,13 @@ struct SimplifyLocals
     // post-block cleanups
     if (curr->name.is()) {
       if (unoptimizableBlocks.contains(curr->name)) {
-        sinkables.clear();
+        clearSinkables();
         unoptimizableBlocks.erase(curr->name);
       }
 
       if (hasBreaks) {
         // more than one path to here, so nonlinear
-        sinkables.clear();
+        clearSinkables();
         blockBreaks.erase(curr->name);
       }
     }
@@ -284,7 +370,7 @@ struct SimplifyLocals
       // reuse the local.get that is dying
       *found->second.item = curr;
       ExpressionManipulator::nop(curr);
-      sinkables.erase(found);
+      eraseSinkable(found);
       anotherCycle = true;
     }
   }
@@ -300,7 +386,65 @@ struct SimplifyLocals
   }
 
   void checkInvalidations(EffectAnalyzer& effects) {
-    // TODO: this is O(bad)
+    // Fast path: if the current expression only accesses locals (no memory,
+    // calls, globals, traps, control flow, etc.), we can use reverse indices
+    // to find conflicting sinkables in O(|locals touched|) instead of
+    // iterating all sinkables.
+    //
+    // Each condition below corresponds to a non-local conflict category in
+    // EffectAnalyzer::orderedBefore. When all are false, the only remaining
+    // conflict paths are through local variable read/write pairs, PLUS the
+    // asymmetric check: sinkable.transfersControlFlow() &&
+    // current.hasSideEffects(). The latter is handled via
+    // controlFlowSinkables below.
+    if (!effects.transfersControlFlow() && !effects.writesGlobalState() &&
+        !effects.readsMutableGlobalState() && !effects.danglingPop &&
+        !effects.trap && !effects.hasSynchronization() &&
+        !effects.mayNotReturn) {
+      std::unordered_set<Index> candidates;
+      // When the current expression reads local L, any sinkable that writes L
+      // has a write-read conflict.
+      for (auto L : effects.localsRead) {
+        auto it = localWrittenBySinkable.find(L);
+        if (it != localWrittenBySinkable.end()) {
+          candidates.insert(it->second.begin(), it->second.end());
+        }
+      }
+      // When the current expression writes local L, any sinkable that reads L
+      // (read-write conflict) or writes L (write-write conflict) is a
+      // candidate.
+      for (auto L : effects.localsWritten) {
+        auto it = localReadBySinkable.find(L);
+        if (it != localReadBySinkable.end()) {
+          candidates.insert(it->second.begin(), it->second.end());
+        }
+        auto it2 = localWrittenBySinkable.find(L);
+        if (it2 != localWrittenBySinkable.end()) {
+          candidates.insert(it2->second.begin(), it2->second.end());
+        }
+      }
+      // Handle the asymmetric orderedBefore check: a sinkable that transfers
+      // control flow conflicts with any expression that has side effects
+      // (which includes local writes). This set is usually empty.
+      if (effects.hasSideEffects() && !controlFlowSinkables.empty()) {
+        candidates.insert(controlFlowSinkables.begin(),
+                          controlFlowSinkables.end());
+      }
+      std::vector<Index> invalidated;
+      for (auto key : candidates) {
+        auto it = sinkables.find(key);
+        if (it != sinkables.end() && effects.orderedAfter(it->second.effects)) {
+          invalidated.push_back(key);
+        }
+      }
+      for (auto key : invalidated) {
+        eraseSinkable(key);
+      }
+      return;
+    }
+
+    // Slow path: the expression has non-local effects, so we must check all
+    // sinkables.
     std::vector<Index> invalidated;
     for (auto& [index, info] : sinkables) {
       if (effects.orderedAfter(info.effects)) {
@@ -308,7 +452,7 @@ struct SimplifyLocals
       }
     }
     for (auto index : invalidated) {
-      sinkables.erase(index);
+      eraseSinkable(index);
     }
   }
 
@@ -334,7 +478,7 @@ struct SimplifyLocals
         }
       }
       for (auto index : invalidated) {
-        self->sinkables.erase(index);
+        self->eraseSinkable(index);
       }
     }
 
@@ -419,7 +563,7 @@ struct SimplifyLocals
         Drop* drop = ExpressionManipulator::convert<LocalSet, Drop>(previous);
         drop->value = previousValue;
         drop->finalize();
-        self->sinkables.erase(found);
+        self->eraseSinkable(found);
         self->anotherCycle = true;
       }
     }
@@ -432,9 +576,7 @@ struct SimplifyLocals
     if (set && self->canSink(set)) {
       Index index = set->index;
       assert(!self->sinkables.contains(index));
-      self->sinkables.emplace(std::pair{
-        index,
-        SinkableInfo(currp, self->getPassOptions(), *self->getModule())});
+      self->addSinkable(index, currp);
     }
 
     if (!allowNesting) {
@@ -476,7 +618,13 @@ struct SimplifyLocals
     if (sinkables.empty()) {
       return;
     }
-    Index goodIndex = sinkables.begin()->first;
+    // Pick the lowest-index sinkable for deterministic output.
+    Index goodIndex = std::min_element(sinkables.begin(),
+                                       sinkables.end(),
+                                       [](const auto& a, const auto& b) {
+                                         return a.first < b.first;
+                                       })
+                        ->first;
     // Ensure we have a place to write the return values for, if not, we
     // need another cycle.
     auto* block = loop->body->dynCast<Block>();
@@ -498,7 +646,7 @@ struct SimplifyLocals
     this->replaceCurrent(set);
     // We moved things around, clear all tracking; we'll do another cycle
     // anyhow.
-    sinkables.clear();
+    clearSinkables();
     anotherCycle = true;
   }
 
@@ -515,7 +663,8 @@ struct SimplifyLocals
     // block does not already have a return value (if one break has one, they
     // all do)
     assert(!(*breaks[0].brp)->template cast<Break>()->value);
-    // look for a local.set that is present in them all
+    // look for a local.set that is present in them all.
+    // Pick the lowest index for deterministic output.
     bool found = false;
     Index sharedIndex = -1;
     for (auto& [index, _] : sinkables) {
@@ -526,10 +675,9 @@ struct SimplifyLocals
           break;
         }
       }
-      if (inAll) {
+      if (inAll && (!found || index < sharedIndex)) {
         sharedIndex = index;
         found = true;
-        break;
       }
     }
     if (!found) {
@@ -624,7 +772,7 @@ struct SimplifyLocals
     auto* newLocalSet =
       Builder(*this->getModule()).makeLocalSet(sharedIndex, block);
     this->replaceCurrent(newLocalSet);
-    sinkables.clear();
+    clearSinkables();
     anotherCycle = true;
     block->finalize();
   }
@@ -656,27 +804,35 @@ struct SimplifyLocals
     Sinkables& ifFalse = sinkables;
     Index goodIndex = -1;
     bool found = false;
+    auto pickLowest = [](Sinkables& s) {
+      return std::min_element(
+               s.begin(),
+               s.end(),
+               [](const auto& a, const auto& b) { return a.first < b.first; })
+        ->first;
+    };
     if (iff->ifTrue->type == Type::unreachable) {
       // since the if type is none
       assert(iff->ifFalse->type != Type::unreachable);
       if (!ifFalse.empty()) {
-        goodIndex = ifFalse.begin()->first;
+        goodIndex = pickLowest(ifFalse);
         found = true;
       }
     } else if (iff->ifFalse->type == Type::unreachable) {
       // since the if type is none
       assert(iff->ifTrue->type != Type::unreachable);
       if (!ifTrue.empty()) {
-        goodIndex = ifTrue.begin()->first;
+        goodIndex = pickLowest(ifTrue);
         found = true;
       }
     } else {
-      // Look for a shared index.
+      // Look for a shared index (pick the lowest for determinism).
       for (auto& [index, _] : ifTrue) {
         if (ifFalse.contains(index)) {
-          goodIndex = index;
-          found = true;
-          break;
+          if (!found || index < goodIndex) {
+            goodIndex = index;
+            found = true;
+          }
         }
       }
     }
@@ -799,7 +955,13 @@ struct SimplifyLocals
     // element).
     //
     // TODO investigate more
-    Index goodIndex = sinkables.begin()->first;
+    // Pick the lowest-index sinkable for deterministic output.
+    Index goodIndex = std::min_element(sinkables.begin(),
+                                       sinkables.end(),
+                                       [](const auto& a, const auto& b) {
+                                         return a.first < b.first;
+                                       })
+                        ->first;
     auto localType = this->getFunction()->getLocalType(goodIndex);
     if (!localType.isDefaultable()) {
       return;
@@ -973,7 +1135,7 @@ struct SimplifyLocals
       anotherCycle = true;
     }
     // clean up
-    sinkables.clear();
+    clearSinkables();
     blockBreaks.clear();
     unoptimizableBlocks.clear();
     return anotherCycle;

--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -54,6 +54,7 @@
 #include <ir/local-utils.h>
 #include <ir/manipulation.h>
 #include <ir/utils.h>
+#include <optional>
 #include <pass.h>
 #include <wasm-builder.h>
 #include <wasm-traversal.h>
@@ -90,6 +91,74 @@ struct SimplifyLocals
 
   // locals in current linear execution trace, which we try to sink
   Sinkables sinkables;
+
+  // Effects seen since the last full invalidation flush. We merge them and
+  // defer scanning all sinkables until a point where we must inspect or move
+  // the full sinkable set.
+  std::optional<EffectAnalyzer> pendingInvalidations;
+
+  void clearSinkables() {
+    sinkables.clear();
+    pendingInvalidations.reset();
+  }
+
+  Sinkables takeSinkables() {
+    flushPendingInvalidations();
+    pendingInvalidations.reset();
+    return std::move(sinkables);
+  }
+
+  void eraseSinkable(typename Sinkables::iterator it) {
+    sinkables.erase(it);
+    if (sinkables.empty()) {
+      pendingInvalidations.reset();
+    }
+  }
+
+  void eraseSinkable(Index key) {
+    sinkables.erase(key);
+    if (sinkables.empty()) {
+      pendingInvalidations.reset();
+    }
+  }
+
+  void mergePendingInvalidations(const EffectAnalyzer& effects) {
+    if (sinkables.empty()) {
+      pendingInvalidations.reset();
+      return;
+    }
+    if (!pendingInvalidations) {
+      pendingInvalidations.emplace(this->getPassOptions(), *this->getModule());
+    }
+    pendingInvalidations->mergeIn(effects);
+  }
+
+  void resolvePendingInvalidations(Index index) {
+    if (!pendingInvalidations) {
+      return;
+    }
+    auto it = sinkables.find(index);
+    if (it != sinkables.end() &&
+        pendingInvalidations->orderedAfter(it->second.effects)) {
+      eraseSinkable(it);
+    }
+  }
+
+  void flushPendingInvalidations() {
+    if (!pendingInvalidations) {
+      return;
+    }
+    if (!sinkables.empty()) {
+      checkInvalidations(*pendingInvalidations);
+    }
+    pendingInvalidations.reset();
+  }
+
+  void addSinkable(Index key, Expression** currp) {
+    flushPendingInvalidations();
+    sinkables.emplace(std::pair{
+      key, SinkableInfo(currp, this->getPassOptions(), *this->getModule())});
+  }
 
   // Information about an exit from a block: the break, and the
   // sinkables. For the final exit from a block (falling off)
@@ -135,8 +204,7 @@ struct SimplifyLocals
         // value means the block already has a return value
         self->unoptimizableBlocks.insert(br->name);
       } else {
-        self->blockBreaks[br->name].push_back(
-          {currp, std::move(self->sinkables)});
+        self->blockBreaks[br->name].push_back({currp, self->takeSinkables()});
       }
     } else if (curr->is<Block>()) {
       return; // handled in visitBlock
@@ -153,7 +221,7 @@ struct SimplifyLocals
       }
       // TODO: we could use this info to stop gathering data on these blocks
     }
-    self->sinkables.clear();
+    self->clearSinkables();
   }
 
   static void doNoteIfCondition(
@@ -161,7 +229,7 @@ struct SimplifyLocals
     Expression** currp) {
     // we processed the condition of this if-else, and now control flow branches
     // into either the true or the false sides
-    self->sinkables.clear();
+    self->clearSinkables();
   }
 
   static void
@@ -170,13 +238,13 @@ struct SimplifyLocals
     auto* iff = (*currp)->cast<If>();
     if (iff->ifFalse) {
       // We processed the ifTrue side of this if-else, save it on the stack.
-      self->ifStack.push_back(std::move(self->sinkables));
+      self->ifStack.push_back(self->takeSinkables());
     } else {
       // This is an if without an else.
       if (allowStructure) {
         self->optimizeIfReturn(iff, currp);
       }
-      self->sinkables.clear();
+      self->clearSinkables();
     }
   }
 
@@ -191,10 +259,12 @@ struct SimplifyLocals
       self->optimizeIfElseReturn(iff, currp, self->ifStack.back());
     }
     self->ifStack.pop_back();
-    self->sinkables.clear();
+    self->clearSinkables();
   }
 
   void visitBlock(Block* curr) {
+    flushPendingInvalidations();
+
     bool hasBreaks = curr->name.is() && blockBreaks[curr->name].size() > 0;
 
     if (allowStructure) {
@@ -204,25 +274,29 @@ struct SimplifyLocals
     // post-block cleanups
     if (curr->name.is()) {
       if (unoptimizableBlocks.contains(curr->name)) {
-        sinkables.clear();
+        clearSinkables();
         unoptimizableBlocks.erase(curr->name);
       }
 
       if (hasBreaks) {
         // more than one path to here, so nonlinear
-        sinkables.clear();
+        clearSinkables();
         blockBreaks.erase(curr->name);
       }
     }
   }
 
   void visitLoop(Loop* curr) {
+    flushPendingInvalidations();
+
     if (allowStructure) {
       optimizeLoopReturn(curr);
     }
   }
 
   void optimizeLocalGet(LocalGet* curr) {
+    resolvePendingInvalidations(curr->index);
+
     auto found = sinkables.find(curr->index);
     if (found != sinkables.end()) {
       auto* set = (*found->second.item)
@@ -284,7 +358,7 @@ struct SimplifyLocals
       // reuse the local.get that is dying
       *found->second.item = curr;
       ExpressionManipulator::nop(curr);
-      sinkables.erase(found);
+      eraseSinkable(found);
       anotherCycle = true;
     }
   }
@@ -300,6 +374,10 @@ struct SimplifyLocals
   }
 
   void checkInvalidations(EffectAnalyzer& effects) {
+    if (sinkables.empty()) {
+      return;
+    }
+
     // TODO: this is O(bad)
     std::vector<Index> invalidated;
     for (auto& [index, info] : sinkables) {
@@ -308,7 +386,7 @@ struct SimplifyLocals
       }
     }
     for (auto index : invalidated) {
-      sinkables.erase(index);
+      eraseSinkable(index);
     }
   }
 
@@ -321,9 +399,17 @@ struct SimplifyLocals
            Expression** currp) {
     Expression* curr = *currp;
 
+    if (self->sinkables.empty()) {
+      if (!allowNesting) {
+        self->expressionStack.push_back(curr);
+      }
+      return;
+    }
+
     // Certain expressions cannot be sinked into 'try'/'try_table', and so at
     // the start of 'try'/'try_table' we forget about them.
     if (curr->is<Try>() || curr->is<TryTable>()) {
+      self->flushPendingInvalidations();
       std::vector<Index> invalidated;
       for (auto& [index, info] : self->sinkables) {
         // Expressions that may throw cannot be moved into a try (which might
@@ -334,13 +420,13 @@ struct SimplifyLocals
         }
       }
       for (auto index : invalidated) {
-        self->sinkables.erase(index);
+        self->eraseSinkable(index);
       }
     }
 
     EffectAnalyzer effects(self->getPassOptions(), *self->getModule());
     if (effects.checkPre(curr)) {
-      self->checkInvalidations(effects);
+      self->mergePendingInvalidations(effects);
     }
 
     if (!allowNesting) {
@@ -409,6 +495,8 @@ struct SimplifyLocals
     auto* set = (*currp)->dynCast<LocalSet>();
 
     if (set) {
+      self->resolvePendingInvalidations(set->index);
+
       // if we see a set that was already potentially-sinkable, then the
       // previous store is dead, leave just the value
       auto found = self->sinkables.find(set->index);
@@ -419,22 +507,20 @@ struct SimplifyLocals
         Drop* drop = ExpressionManipulator::convert<LocalSet, Drop>(previous);
         drop->value = previousValue;
         drop->finalize();
-        self->sinkables.erase(found);
+        self->eraseSinkable(found);
         self->anotherCycle = true;
       }
     }
 
     EffectAnalyzer effects(self->getPassOptions(), *self->getModule());
     if (effects.checkPost(original)) {
-      self->checkInvalidations(effects);
+      self->mergePendingInvalidations(effects);
     }
 
     if (set && self->canSink(set)) {
       Index index = set->index;
       assert(!self->sinkables.contains(index));
-      self->sinkables.emplace(std::pair{
-        index,
-        SinkableInfo(currp, self->getPassOptions(), *self->getModule())});
+      self->addSinkable(index, currp);
     }
 
     if (!allowNesting) {
@@ -468,6 +554,8 @@ struct SimplifyLocals
   std::vector<Loop*> loopsToEnlarge;
 
   void optimizeLoopReturn(Loop* loop) {
+    flushPendingInvalidations();
+
     // If there is a sinkable thing in an eligible loop, we can optimize
     // it in a trivial way to the outside of the loop.
     if (loop->type != Type::none) {
@@ -498,11 +586,13 @@ struct SimplifyLocals
     this->replaceCurrent(set);
     // We moved things around, clear all tracking; we'll do another cycle
     // anyhow.
-    sinkables.clear();
+    clearSinkables();
     anotherCycle = true;
   }
 
   void optimizeBlockReturn(Block* block) {
+    flushPendingInvalidations();
+
     if (!block->name.is() || unoptimizableBlocks.contains(block->name)) {
       return;
     }
@@ -624,13 +714,15 @@ struct SimplifyLocals
     auto* newLocalSet =
       Builder(*this->getModule()).makeLocalSet(sharedIndex, block);
     this->replaceCurrent(newLocalSet);
-    sinkables.clear();
+    clearSinkables();
     anotherCycle = true;
     block->finalize();
   }
 
   // optimize local.sets from both sides of an if into a return value
   void optimizeIfElseReturn(If* iff, Expression** currp, Sinkables& ifTrue) {
+    flushPendingInvalidations();
+
     assert(iff->ifFalse);
     // if this if already has a result, or is unreachable code, we have
     // nothing to do
@@ -753,6 +845,8 @@ struct SimplifyLocals
   // that happens, other passes can "undo" this by turning an if with a copy
   // arm into a one-sided if.
   void optimizeIfReturn(If* iff, Expression** currp) {
+    flushPendingInvalidations();
+
     // If this if is unreachable code, we have nothing to do.
     if (iff->type != Type::none || iff->ifTrue->type != Type::none) {
       return;
@@ -973,7 +1067,7 @@ struct SimplifyLocals
       anotherCycle = true;
     }
     // clean up
-    sinkables.clear();
+    clearSinkables();
     blockBreaks.clear();
     unoptimizableBlocks.clear();
     return anotherCycle;


### PR DESCRIPTION
The `checkInvalidations` function in SimplifyLocals had O(N × S) complexity, iterating all sinkables for every visited expression. This PR adds reverse indices (`localReadBySinkable_`, `localWrittenBySinkable_`, `heavySinkables_`) so that `checkInvalidations` only examines sinkables whose effects actually conflict with the current expression. The `Sinkables` map and `localsRead`/`localsWritten` sets are also changed from ordered to unordered containers for faster lookups. A new `hasNonLocalOrderingEffects()` helper is added to `EffectAnalyzer` (composing existing helpers like `writesGlobalState()` and `readsMutableGlobalState()`) so the classification stays in sync automatically when new effect types are added.

Benchmark data
Use the wasm file in
https://github.com/WebAssembly/binaryen/issues/7319#issuecomment-2678393304

Note: don't run benchmark with `-Oz`, use `--simplify-locals` can save time.
Before this PR
```shell
time ./build/bin/wasm-opt --simplify-locals --enable-bulk-memory --enable-multivalue --enable-reference-types --enable-gc --enable-tail-call --enable-exception-handling  -o /dev/null ./test3.wasm

real    0m42.423s
user    9m45.063s
sys     0m44.099s
```

In this PR
```shell
time ./build/bin/wasm-opt --simplify-locals --enable-
bulk-memory --enable-multivalue --enable-reference-types --enable-gc --enable-tail-call --enable-e
xception-handling  -o /dev/null ./test3.wasm

real    0m29.725s
user    6m25.124s
sys     0m30.590s
```