### PR TITLE
Validate descriptor clause forward references

### DIFF
--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -917,6 +917,8 @@ struct TypeBuilder {
     NonStructDescribes,
     // The described type is an invalid forward reference.
     ForwardDescribesReference,
+    // The descriptor type is an invalid forward reference.
+    ForwardDescriptorReference,
     // The described type does not have this type as a descriptor.
     MismatchedDescribes,
     // A descriptor clause on a non-struct type.

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -1528,6 +1528,8 @@ std::ostream& operator<<(std::ostream& os,
       return os << "Describes clause on a non-struct type";
     case TypeBuilder::ErrorReasonKind::ForwardDescribesReference:
       return os << "Describes clause is a forward reference";
+    case TypeBuilder::ErrorReasonKind::ForwardDescriptorReference:
+      return os << "Descriptor clause is a forward reference";
     case TypeBuilder::ErrorReasonKind::MismatchedDescribes:
       return os << "Described type is not a matching descriptor";
     case TypeBuilder::ErrorReasonKind::NonStructDescriptor:
@@ -2509,7 +2511,6 @@ validateTypeInfo(HeapTypeInfo& info,
     if (info.kind != HeapTypeKind::Struct) {
       return TypeBuilder::ErrorReasonKind::NonStructDescribes;
     }
-    assert(desc->isTemp && "unexpected canonical described type");
     if (!seenTypes.contains(HeapType(uintptr_t(desc)))) {
       return TypeBuilder::ErrorReasonKind::ForwardDescribesReference;
     }
@@ -2654,6 +2655,14 @@ buildRecGroup(std::unique_ptr<RecGroupInfo>&& groupInfo,
           i, TypeBuilder::ErrorReasonKind::ForwardChildReference}};
       }
     }
+    if (auto desc = type.getDescriptorType()) {
+      if (isTemp(*desc) && !seenTypes.contains(*desc)) {
+        return {TypeBuilder::Error{
+          i, TypeBuilder::ErrorReasonKind::ForwardDescriptorReference}};
+      }
+    }
+    // Describes clauses were already checked as we validated each type in the
+    // group.
   }
 
   // The rec group is valid, so we can try to move the group into the global rec

--- a/test/lit/validation/descriptor-forward-reference.wast
+++ b/test/lit/validation/descriptor-forward-reference.wast
@@ -1,0 +1,8 @@
+;; RUN: not wasm-opt -all %s 2>&1 | filecheck %s
+
+(module
+  ;; These types should be in the same rec group!
+  ;; CHECK: invalid type: Descriptor clause is a forward reference
+  (type $Default (descriptor $Default.desc) (struct (field i32)))
+  (type $Default.desc (describes $Default) (struct (field (ref extern))))
+)


### PR DESCRIPTION
When the descriptor clause on a type definition was a forward reference
to a future rec group, we previously failed an assertion that it was
not a temporary type. Replace this assertion with a validation check.

Fixes #8606.
