### PR TITLE
Handle strings when skipping function bodies

### DIFF
--- a/src/parser/context-decls.cpp
+++ b/src/parser/context-decls.cpp
@@ -329,6 +329,11 @@ bool ParseDeclsCtx::skipFunctionBody() {
       }
       continue;
     }
+    // Avoid confusion due to parens inside strings by skipping strings as a
+    // unit.
+    if (in.takeString()) {
+      continue;
+    }
     in.take(1);
     in.advance();
   }

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -5273,4 +5273,11 @@
    )
   )
  )
+
+ (func $paren-in-string
+   ;; We should not be tripped up by an extra close parenthesis inside a string.
+   (drop
+     (string.const ")")
+   )
+ )
 )


### PR DESCRIPTION
Explicitly parse strings in the logic for mostly skipping function bodies in the first parser phase. This avoids parentheses inside strings causing the parser to skip too much or too little of the input.
