### PR TITLE
PreserveImportsExportsJS Fuzzer: Fix reduction

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -2152,9 +2152,9 @@ class PreserveImportsExportsJS(TestCaseHandler):
 
         # Make sure the testcase runs by itself - there should be no invalid
         # testcases.
-        original_wasm = 'orig.wasm'
-        run([in_bin('wasm-opt'), wat_file, '-o', original_wasm] + FEATURE_OPTS)
-        D8().run_js(js_file, original_wasm)
+        initial_wasm = 'initial.wasm'
+        run([in_bin('wasm-opt'), wat_file, '-o', initial_wasm] + FEATURE_OPTS)
+        D8().run_js(js_file, initial_wasm)
 
         # Modify the initial wat to get the pre-optimizations wasm.
         pre_wasm = abspath('pre.wasm')

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -2869,7 +2869,12 @@ if __name__ == '__main__':
             # longer working on the original test case but modified one, which
             # is likely to be called within wasm-reduce script itself, so
             # original.wasm and reduce.sh should not be overwritten.
-            if not given_wasm:
+            #
+            # We must also consider the case of BINARYEN_PIEJS_WASM as us being
+            # given a wasm file. We are given one in this case, but only for
+            # that particular fuzzer, hence it is passed in through an env var
+            # and not the usual mechanism.
+            if not given_wasm and not os.environ.get('BINARYEN_PIEJS_WASM'):
                 # We can't do this if a.wasm doesn't exist, which can be the
                 # case if we failed to even generate the wasm.
                 if not os.path.exists('a.wasm'):
@@ -2895,6 +2900,7 @@ on valid wasm files.)
                 # the side, so that we can autoreduce using the name "a.wasm"
                 # which we use internally)
                 original_wasm = abspath('original.wasm')
+                print(f'copying a.wasm to original for reduction: {original_wasm}')
                 shutil.copyfile('a.wasm', original_wasm)
                 # write out a useful reduce.sh
                 auto_init = ''

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -2107,8 +2107,9 @@ class PreserveImportsExportsRandom(TestCaseHandler):
 # This reads wasm+js combinations from the test/js_wasm directory, so as new
 # testcases are added there, this will fuzz them.
 #
-# Note that bugs found by this fuzzer require BINARYEN_TRUST_GIVEN_WASM=1 in the
-# env for reduction. TODO: simplify this
+# Note that bugs found by this fuzzer require BINARYEN_PIEJS_WASM=1 in the
+# env for reduction. TODO: simplify this, and show it when the fuzzer prints out
+# the command to reduce.
 class PreserveImportsExportsJS(TestCaseHandler):
     frequency = 1
 
@@ -2116,9 +2117,9 @@ class PreserveImportsExportsJS(TestCaseHandler):
         try:
             self.do_handle_pair(input, before_wasm, after_wasm, opts)
         except Exception as e:
-            if not os.environ.get('BINARYEN_TRUST_GIVEN_WASM'):
-                # We errored, and we were not given a wasm file to trust as we
-                # reduce, so this is the first time we hit an error. Save the
+            if not os.environ.get('BINARYEN_PIEJS_WASM'):
+                # We errored, and we were not in the middle of reducing a given
+                # file, so this is the first time we hit an error. Save the
                 # pre wasm file, the one we began with, as `before_wasm`, so
                 # that the reducer will make us proceed exactly from there.
                 shutil.copyfile(self.pre_wasm, before_wasm)
@@ -2172,9 +2173,10 @@ class PreserveImportsExportsJS(TestCaseHandler):
         # If we were given a wasm file, use that instead of all the above. We
         # do this now, after creating pre_wasm, because we still need to consume
         # all the randomness normally.
-        if os.environ.get('BINARYEN_TRUST_GIVEN_WASM'):
-            print('using given wasm', before_wasm)
-            pre_wasm = before_wasm
+        given_wasm = os.environ.get('BINARYEN_PIEJS_WASM')
+        if given_wasm:
+            print('using BINARYEN_PIEJS_WASM', given_wasm)
+            pre_wasm = given_wasm
 
         # Pick a vm and run before we optimize the wasm.
         vms = [
@@ -2913,14 +2915,21 @@ echo "  " $?
 
 echo "The following value should be >0:"
 
-if [ -z "$BINARYEN_FIRST_WASM" ]; then
-  # run the command normally
-  ./scripts/fuzz_opt.py {auto_init} --binaryen-bin {binaryen_bin} {seed} {temp_wasm} > o 2> e
-else
-  # BINARYEN_FIRST_WASM was provided so we should actually reduce the *second*
+if [ -n "$BINARYEN_FIRST_WASM" ]; then
+  # BINARYEN_FIRST_WASM was provided, so we should actually reduce the *second*
   # file. pass the first one in as the main file, and use the env var for the
   # second.
   BINARYEN_SECOND_WASM={temp_wasm} ./scripts/fuzz_opt.py {auto_init} --binaryen-bin {binaryen_bin} {seed} $BINARYEN_FIRST_WASM > o 2> e
+#elif [ -n "$BINARYEN_PIEJS_WASM" ]; then
+  # BINARYEN_PIEJS_WASM was provided, so we want to give that fuzzer the actual
+  # file we are reducing. All other fuzzers should *not* be given this file, as
+  # it may not even be valid for them (that fuzzer uses special js/wasm
+  # combinations. We therefore provide the temp wasm file to BINARYEN_PIEJS_WASM
+  # and *not* as a Python argument after the seed.
+  BINARYEN_PIEJS_WASM={temp_wasm} ./scripts/fuzz_opt.py {auto_init} --binaryen-bin {binaryen_bin} {seed} > o 2> e
+#else
+  # run the command normally
+  ./scripts/fuzz_opt.py {auto_init} --binaryen-bin {binaryen_bin} {seed} {temp_wasm} > o 2> e
 fi
 
 echo "  " $?
@@ -2948,8 +2957,7 @@ echo "  " $?
 #
 # You may also need to add  --timeout 5  or such if the testcase is a slow one.
 #
-# If the testcase handler uses a second wasm file, you may be able to reduce it
-# using BINARYEN_SECOND_WASM.
+# For reducing Two and PreserveImportsExportsJS, see the comments there.
 #
 ''')
 

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -2920,7 +2920,7 @@ if [ -n "$BINARYEN_FIRST_WASM" ]; then
   # file. pass the first one in as the main file, and use the env var for the
   # second.
   BINARYEN_SECOND_WASM={temp_wasm} ./scripts/fuzz_opt.py {auto_init} --binaryen-bin {binaryen_bin} {seed} $BINARYEN_FIRST_WASM > o 2> e
-#elif [ -n "$BINARYEN_PIEJS_WASM" ]; then
+elif [ -n "$BINARYEN_PIEJS_WASM" ]; then
   # BINARYEN_PIEJS_WASM was provided, so we want to give that fuzzer the actual
   # file we are reducing. All other fuzzers should *not* be given this file, as
   # it may not even be valid for them (that fuzzer uses special js/wasm

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -2927,7 +2927,7 @@ elif [ -n "$BINARYEN_PIEJS_WASM" ]; then
   # combinations. We therefore provide the temp wasm file to BINARYEN_PIEJS_WASM
   # and *not* as a Python argument after the seed.
   BINARYEN_PIEJS_WASM={temp_wasm} ./scripts/fuzz_opt.py {auto_init} --binaryen-bin {binaryen_bin} {seed} > o 2> e
-#else
+else
   # run the command normally
   ./scripts/fuzz_opt.py {auto_init} --binaryen-bin {binaryen_bin} {seed} {temp_wasm} > o 2> e
 fi

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -2931,7 +2931,7 @@ elif [ -n "$BINARYEN_PIEJS_WASM" ]; then
   # BINARYEN_PIEJS_WASM was provided, so we want to give that fuzzer the actual
   # file we are reducing. All other fuzzers should *not* be given this file, as
   # it may not even be valid for them (that fuzzer uses special js/wasm
-  # combinations. We therefore provide the temp wasm file to BINARYEN_PIEJS_WASM
+  # combinations). We therefore provide the temp wasm file to BINARYEN_PIEJS_WASM
   # and *not* as a Python argument after the seed.
   BINARYEN_PIEJS_WASM={temp_wasm} ./scripts/fuzz_opt.py {auto_init} --binaryen-bin {binaryen_bin} {seed} > o 2> e
 else

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -2122,6 +2122,7 @@ class PreserveImportsExportsJS(TestCaseHandler):
                 # file, so this is the first time we hit an error. Save the
                 # pre wasm file, the one we began with, as `before_wasm`, so
                 # that the reducer will make us proceed exactly from there.
+                print(f'copying {self.pre_wasm} to original for reduction: {before_wasm}')
                 shutil.copyfile(self.pre_wasm, before_wasm)
             raise e
 


### PR DESCRIPTION
This fuzzer generates its own files, so reducing it needs some hacks,
unfortunately. Another option might be to separate this fuzzer out
entirely to its own file, or to at least not run multiple fuzzers on the
same testcase (see below), but I'm not sure those are better options.

When the main fuzzer runs multiple internal testcase handlers on a
single wasm file, we must make sure while reducing that only
PreserveImportsExportsJS receives its wasm. That wasm only works
with its JS, so other fuzzers will fail on it. To do so, use an env var
`BINARYEN_PIEJS_WASM` which tells the fuzzer we are reducing
in such a situation. The fuzzer reduction script then passes in the
reduced file that way, rather than the usual way, so other fuzzers
do not notice it.

Also rename `orig.wasm` to `initial.wasm` as this was confusing
given that reduction always starts from `original.wasm`.