### PR TITLE
[NFC] Remove redundant code from bad merge

### DIFF
--- a/src/ir/properties.h
+++ b/src/ir/properties.h
@@ -570,25 +570,6 @@ inline bool hasUnwritableTypeImmediate(Expression* curr) {
 
 #include "wasm-delegations-fields.def"
 
-  if (curr->type == Type::unreachable) {
-    if (curr->is<StructNew>() || curr->is<ArrayNew>() ||
-        curr->is<ArrayNewData>() || curr->is<ArrayNewElem>() ||
-        curr->is<ArrayNewFixed>() || curr->is<ContNew>() ||
-        curr->is<ContBind>()) {
-      return true;
-    }
-    if (auto* cast = curr->dynCast<RefCast>()) {
-      if (!cast->desc) {
-        return true;
-      }
-      if (!cast->desc->type.isRef()) {
-        return true;
-      }
-      if (!cast->desc->type.getHeapType().getDescribedType()) {
-        return true;
-      };
-    }
-  }
   return false;
 }
 


### PR DESCRIPTION
When #8617 landed, it introduced this code from an out-of-date version of #8616. The code had been moved in such a way that the merge kept both old and new versions instead of creating a merge conflict. Remove the outdated code.
