### PR TITLE
Improve indirect call effects in GlobalEffects

### DIFF
--- a/src/passes/GlobalEffects.cpp
+++ b/src/passes/GlobalEffects.cpp
@@ -52,9 +52,9 @@ struct FuncInfo {
  Only funcs that are 'addressed' may be the target of an indirect call. A
  function is addressed if:
  - It appears in a ref.func expression
- - It appears in an `elem declare` statement (note that we already ignore `elem`
+ - It appears in an `elem` segment (note that we already ignore `elem declare`
    statements in our IR, but we check separately for funcs that appear in
- `ref.func`).
+   `ref.func`).
  - It's exported, because it may flow back to us as a reference.
  - It's imported, which implies it is `elem declare`d.
 

--- a/src/passes/GlobalEffects.cpp
+++ b/src/passes/GlobalEffects.cpp
@@ -48,26 +48,33 @@ struct FuncInfo {
   std::unordered_set<HeapType> indirectCalledTypes;
 };
 
+/*
+ Only funcs that are 'addressed' may be the target of an indirect call. A
+ function is addressed if:
+ - It appears in a ref.func expression
+ - It appears in an `elem declare` statement (note that we already ignore `elem`
+   statements in our IR, but we check separately for funcs that appear in
+ `ref.func`).
+ - It's exported, because it may flow back to us as a reference.
+ - It's imported, which implies it is `elem declare`d.
+
+ If a function doesn't meet any of these criteria, it can't be the target of
+ an indirect call and we don't need to include its effects in indirect calls.
+*/
 std::unordered_set<Function*> getAddressedFuncs(Module& module) {
-  struct AddressedFuncsWalker
-    : PostWalker<AddressedFuncsWalker,
-                 UnifiedExpressionVisitor<AddressedFuncsWalker>> {
-    const Module& module;
+  struct AddressedFuncsWalker : PostWalker<AddressedFuncsWalker> {
     std::unordered_set<Function*>& addressedFuncs;
 
-    AddressedFuncsWalker(const Module& module,
-                         std::unordered_set<Function*>& addressedFuncs)
-      : module(module), addressedFuncs(addressedFuncs) {}
+    AddressedFuncsWalker(std::unordered_set<Function*>& addressedFuncs)
+      : addressedFuncs(addressedFuncs) {}
 
-    void visitExpression(Expression* curr) {
-      if (auto* refFunc = curr->dynCast<RefFunc>()) {
-        addressedFuncs.insert(module.getFunction(refFunc->func));
-      }
+    void visitRefFunc(RefFunc* refFunc) {
+      addressedFuncs.insert(getModule()->getFunction(refFunc->func));
     }
   };
 
   std::unordered_set<Function*> addressedFuncs;
-  AddressedFuncsWalker walker(module, addressedFuncs);
+  AddressedFuncsWalker walker(addressedFuncs);
   walker.walkModule(&module);
 
   ModuleUtils::iterImportedFunctions(
@@ -80,9 +87,6 @@ std::unordered_set<Function*> getAddressedFuncs(Module& module) {
       continue;
     }
 
-    // TODO: internal or external? I think internal
-    // This might be why we failed to lookup the function earlier
-    // Maybe we can use Function* after all
     addressedFuncs.insert(module.getFunction(*export_->getInternalName()));
   }
 
@@ -96,7 +100,6 @@ std::unordered_set<Function*> getAddressedFuncs(Module& module) {
 
 std::map<Function*, FuncInfo> analyzeFuncs(Module& module,
                                            const PassOptions& passOptions) {
-  std::unordered_set<Name> addressedFuncs;
   ModuleUtils::ParallelFunctionAnalysis<FuncInfo> analysis(
     module, [&](Function* func, FuncInfo& funcInfo) {
       if (func->imported()) {
@@ -127,14 +130,10 @@ std::map<Function*, FuncInfo> analyzeFuncs(Module& module,
           const PassOptions& options;
           FuncInfo& funcInfo;
 
-          std::unordered_set<Name>& addressedFuncs;
-
           CallScanner(Module& wasm,
                       const PassOptions& options,
-                      FuncInfo& funcInfo,
-                      std::unordered_set<Name>& addressedFuncs)
-            : wasm(wasm), options(options), funcInfo(funcInfo),
-              addressedFuncs(addressedFuncs) {}
+                      FuncInfo& funcInfo)
+            : wasm(wasm), options(options), funcInfo(funcInfo) {}
 
           void visitExpression(Expression* curr) {
             ShallowEffectAnalyzer effects(options, wasm, curr);
@@ -167,7 +166,7 @@ std::map<Function*, FuncInfo> analyzeFuncs(Module& module,
             }
           }
         };
-        CallScanner scanner(module, passOptions, funcInfo, addressedFuncs);
+        CallScanner scanner(module, passOptions, funcInfo);
         scanner.walkFunction(func);
       }
     });
@@ -199,7 +198,7 @@ using CallGraph =
 
 CallGraph buildCallGraph(const Module& module,
                          const std::map<Function*, FuncInfo>& funcInfos,
-                         const std::unordered_set<Function*> addressedFuncs,
+                         const std::unordered_set<Function*>& addressedFuncs,
                          bool closedWorld) {
   CallGraph callGraph;
   if (!closedWorld) {
@@ -398,7 +397,8 @@ void copyEffectsToFunctions(const std::map<Function*, FuncInfo>& funcInfos) {
 
 struct GenerateGlobalEffects : public Pass {
   void run(Module* module) override {
-    auto funcInfos = analyzeFuncs(*module, getPassOptions());
+    std::map<Function*, FuncInfo> funcInfos =
+      analyzeFuncs(*module, getPassOptions());
 
     auto addressedFuncs = getAddressedFuncs(*module);
 

--- a/src/passes/GlobalEffects.cpp
+++ b/src/passes/GlobalEffects.cpp
@@ -22,6 +22,7 @@
 #include <ranges>
 
 #include "ir/effects.h"
+#include "ir/element-utils.h"
 #include "ir/module-utils.h"
 #include "pass.h"
 #include "support/graph_traversal.h"
@@ -47,8 +48,55 @@ struct FuncInfo {
   std::unordered_set<HeapType> indirectCalledTypes;
 };
 
+std::unordered_set<Function*> getAddressedFuncs(Module& module) {
+  struct AddressedFuncsWalker
+    : PostWalker<AddressedFuncsWalker,
+                 UnifiedExpressionVisitor<AddressedFuncsWalker>> {
+    const Module& module;
+    std::unordered_set<Function*>& addressedFuncs;
+
+    AddressedFuncsWalker(const Module& module,
+                         std::unordered_set<Function*>& addressedFuncs)
+      : module(module), addressedFuncs(addressedFuncs) {}
+
+    void visitExpression(Expression* curr) {
+      if (auto* refFunc = curr->dynCast<RefFunc>()) {
+        addressedFuncs.insert(module.getFunction(refFunc->func));
+      }
+    }
+  };
+
+  std::unordered_set<Function*> addressedFuncs;
+  AddressedFuncsWalker walker(module, addressedFuncs);
+  walker.walkModule(&module);
+
+  ModuleUtils::iterImportedFunctions(
+    module, [&addressedFuncs, &module](Function* import) {
+      addressedFuncs.insert(module.getFunction(import->name));
+    });
+
+  for (const auto& export_ : module.exports) {
+    if (export_->kind != ExternalKind::Function) {
+      continue;
+    }
+
+    // TODO: internal or external? I think internal
+    // This might be why we failed to lookup the function earlier
+    // Maybe we can use Function* after all
+    addressedFuncs.insert(module.getFunction(*export_->getInternalName()));
+  }
+
+  ElementUtils::iterAllElementFunctionNames(
+    &module, [&addressedFuncs, &module](Name func) {
+      addressedFuncs.insert(module.getFunction(func));
+    });
+
+  return addressedFuncs;
+}
+
 std::map<Function*, FuncInfo> analyzeFuncs(Module& module,
                                            const PassOptions& passOptions) {
+  std::unordered_set<Name> addressedFuncs;
   ModuleUtils::ParallelFunctionAnalysis<FuncInfo> analysis(
     module, [&](Function* func, FuncInfo& funcInfo) {
       if (func->imported()) {
@@ -79,10 +127,14 @@ std::map<Function*, FuncInfo> analyzeFuncs(Module& module,
           const PassOptions& options;
           FuncInfo& funcInfo;
 
+          std::unordered_set<Name>& addressedFuncs;
+
           CallScanner(Module& wasm,
                       const PassOptions& options,
-                      FuncInfo& funcInfo)
-            : wasm(wasm), options(options), funcInfo(funcInfo) {}
+                      FuncInfo& funcInfo,
+                      std::unordered_set<Name>& addressedFuncs)
+            : wasm(wasm), options(options), funcInfo(funcInfo),
+              addressedFuncs(addressedFuncs) {}
 
           void visitExpression(Expression* curr) {
             ShallowEffectAnalyzer effects(options, wasm, curr);
@@ -115,7 +167,7 @@ std::map<Function*, FuncInfo> analyzeFuncs(Module& module,
             }
           }
         };
-        CallScanner scanner(module, passOptions, funcInfo);
+        CallScanner scanner(module, passOptions, funcInfo, addressedFuncs);
         scanner.walkFunction(func);
       }
     });
@@ -147,6 +199,7 @@ using CallGraph =
 
 CallGraph buildCallGraph(const Module& module,
                          const std::map<Function*, FuncInfo>& funcInfos,
+                         const std::unordered_set<Function*> addressedFuncs,
                          bool closedWorld) {
   CallGraph callGraph;
   if (!closedWorld) {
@@ -182,7 +235,9 @@ CallGraph buildCallGraph(const Module& module,
     }
 
     // Type -> Function
-    callGraph[caller->type.getHeapType()].insert(caller);
+    if (addressedFuncs.contains(caller)) {
+      callGraph[caller->type.getHeapType()].insert(caller);
+    }
   }
 
   // Type -> Type
@@ -343,11 +398,12 @@ void copyEffectsToFunctions(const std::map<Function*, FuncInfo>& funcInfos) {
 
 struct GenerateGlobalEffects : public Pass {
   void run(Module* module) override {
-    std::map<Function*, FuncInfo> funcInfos =
-      analyzeFuncs(*module, getPassOptions());
+    auto funcInfos = analyzeFuncs(*module, getPassOptions());
 
-    auto callGraph =
-      buildCallGraph(*module, funcInfos, getPassOptions().closedWorld);
+    auto addressedFuncs = getAddressedFuncs(*module);
+
+    auto callGraph = buildCallGraph(
+      *module, funcInfos, addressedFuncs, getPassOptions().closedWorld);
 
     propagateEffects(*module, getPassOptions(), funcInfos, callGraph);
 

--- a/test/lit/passes/global-effects-closed-world.wast
+++ b/test/lit/passes/global-effects-closed-world.wast
@@ -348,15 +348,12 @@
   )
 
   ;; CHECK:      (func $f (type $1) (param $ref (ref $only-has-effects-in-not-addressable-function))
-  ;; CHECK-NEXT:  (call $calls-type-with-effects-but-not-addressable
-  ;; CHECK-NEXT:   (local.get $ref)
-  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT: )
   (func $f (param $ref (ref $only-has-effects-in-not-addressable-function))
     ;; The type $has-effects-but-not-exported doesn't have an address because
     ;; it's not exported and it's never the target of a ref.func.
-    ;; We should be able to determine that $ref can only point to $nop.
-    ;; TODO: Only aggregate effects from functions that are addressed.
+    ;; So the call_ref has no potential targets and thus no effects.
     (call $calls-type-with-effects-but-not-addressable (local.get $ref))
   )
 )


### PR DESCRIPTION
Part of #8615. We currently union the effects of all functions of a given type when computing the effects for indirect calls. Make this more precise by excluding effects of functions that never have their address taken.