### PR TITLE
[wasm-merge] Preserve function names when writing a profile

### DIFF
--- a/src/tools/wasm-merge.cpp
+++ b/src/tools/wasm-merge.cpp
@@ -697,11 +697,13 @@ Input source maps can be specified by adding an -ism option right after the modu
          "",
          "Write a wasm-split manifest to the specified file. This manifest can "
          "be given to wasm-split to split the merged module along the lines of "
-         "the original modules.",
+         "the original modules. Implies --debuginfo to preserve function names "
+         "in the output module.",
          WasmMergeOption,
          Options::Arguments::One,
-         [&manifestFile](Options* o, const std::string& argument) {
+         [&](Options* o, const std::string& argument) {
            manifestFile = argument;
+           debugInfo = true;
          })
     .add("--rename-export-conflicts",
          "-rec",

--- a/test/lit/help/wasm-merge.test
+++ b/test/lit/help/wasm-merge.test
@@ -38,7 +38,8 @@
 ;; CHECK-NEXT:                                        specified file. This manifest can be
 ;; CHECK-NEXT:                                        given to wasm-split to split the merged
 ;; CHECK-NEXT:                                        module along the lines of the original
-;; CHECK-NEXT:                                        modules.
+;; CHECK-NEXT:                                        modules. Implies --debuginfo to preserve
+;; CHECK-NEXT:                                        function names in the output module.
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --rename-export-conflicts,-rec       Rename exports to avoid conflicts (rather
 ;; CHECK-NEXT:                                        than error)

--- a/test/lit/merge/manifest.wat
+++ b/test/lit/merge/manifest.wat
@@ -1,5 +1,6 @@
-;; RUN: wasm-merge %s first %s.second second %s.third third --output-manifest %t.manifest -S -o %t.wasm
+;; RUN: wasm-merge %s first %s.second second %s.third third --output-manifest %t.manifest -o %t.wasm
 ;; RUN: cat %t.manifest | filecheck %s
+;; RUN: wasm-dis %t.wasm -o - | filecheck %s --check-prefix MERGED
 
 ;; The first module is the primary module and does not appear in the manifest.
 ;; CHECK-NOT:  first
@@ -11,6 +12,30 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: third
 ;; CHECK-NEXT: qux
+
+;; The binary should contain the original function names.
+;; MERGED:      (module
+;; MERGED-NEXT:  (type $0 (func))
+;; MERGED-NEXT:  (import "env" "imported_first" (func $imported_first))
+;; MERGED-NEXT:  (import "env" "imported_second" (func $imported_second))
+;; MERGED-NEXT:  (import "env" "imported_third" (func $imported_third))
+;; MERGED-NEXT:  (export "foo" (func $foo))
+;; MERGED-NEXT:  (export "bar" (func $bar))
+;; MERGED-NEXT:  (export "baz" (func $baz))
+;; MERGED-NEXT:  (export "qux" (func $qux))
+;; MERGED-NEXT:  (func $foo
+;; MERGED-NEXT:   (call $imported_first)
+;; MERGED-NEXT:  )
+;; MERGED-NEXT:  (func $bar
+;; MERGED-NEXT:   (nop)
+;; MERGED-NEXT:  )
+;; MERGED-NEXT:  (func $baz
+;; MERGED-NEXT:   (call $imported_second)
+;; MERGED-NEXT:  )
+;; MERGED-NEXT:  (func $qux
+;; MERGED-NEXT:   (call $imported_third)
+;; MERGED-NEXT:  )
+;; MERGED-NEXT: )
 
 (module
   (import "env" "imported_first" (func $imported_first))


### PR DESCRIPTION
When wasm-merge writes a wasm-split profile, it uses names to identify functions. It is never correct to then throw those names away when writing the binary, because that would make the profile useless. To avoid this problem, have --output-manifest imply --debuginfo and preserve the function names.
