### PR TITLE
Avoid assertion in BrOn parsing

### DIFF
--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -2093,6 +2093,15 @@ Result<> IRBuilder::makeBrOn(Index label,
   }
   CHECK_ERR(visitBrOn(&curr));
 
+  // Validate things that would cause errors later.
+  if (curr.ref->type != Type::unreachable && !curr.ref->type.isRef()) {
+    return Err{"br_on* ref must be a ref"};
+  }
+  if (curr.desc && curr.desc->type != Type::unreachable &&
+      !curr.desc->type.isRef()) {
+    return Err{"br_on_cast_desc* must be a ref"};
+  }
+
   // Validate type immediates before we forget them.
   switch (op) {
     case BrOnNull:


### PR DESCRIPTION
The ref and the desc are used as references in `finalize()`, and we assert
there if they are e.g. `i32`.

Fixes #8633