### PR TITLE
Fix binary writing for test_emit_all_features

### DIFF
--- a/test/unit/test_features.py
+++ b/test/unit/test_features.py
@@ -422,14 +422,15 @@ class TargetFeaturesSectionTest(utils.BinaryenTestCase):
                             opts=['-mvp', '--detect-features', '--enable-simd'])
 
     def test_emit_all_features(self):
+        temp_path = os.path.join(shared.options.out_dir, 'test_emit_all_features.wasm')
         p = shared.run_process(shared.WASM_OPT +
-                               ['--emit-target-features', '-all', '-o', '-'],
+                               ['--emit-target-features', '-all', '-o', temp_path],
                                input="(module)", check=False,
                                capture_output=True, decode_output=False)
         self.assertEqual(p.returncode, 0)
         p2 = shared.run_process(shared.WASM_OPT +
-                                ['--print-features', '-o', os.devnull],
-                                input=p.stdout, check=False,
+                                ['--print-features', '-o', os.devnull, temp_path],
+                                check=False,
                                 capture_output=True)
         self.assertEqual(p2.returncode, 0)
         self.assertEqual([


### PR DESCRIPTION
In #8639, the CI failed on Windows 11 because the total number of features became 26 (0x1A), which is the EOF byte in Windows. Write to a temp file to ensure that the file is read as binary. Resolves the CI in the next PR.

Part of #8544.