### PR TITLE
Canonicalize NaNs when casting between float and double

### DIFF
--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -864,7 +864,7 @@ Literal Literal::extendToUI64() const {
 
 Literal Literal::extendToF64() const {
   assert(type == Type::f32);
-  return Literal(double(getf32()));
+  return standardizeNaN(Literal(static_cast<double>(getf32())));
 }
 
 Literal Literal::extendS8() const {
@@ -1164,7 +1164,7 @@ Literal Literal::sqrt() const {
 Literal Literal::demote() const {
   auto f64 = getf64();
   if (std::isnan(f64)) {
-    return Literal(float(f64));
+    return standardizeNaN(Literal(static_cast<float>(f64)));
   }
   if (std::isinf(f64)) {
     return Literal(float(f64));
@@ -2786,7 +2786,8 @@ template<LaneOrder Side> Literal extendF32(const Literal& vec) {
   LaneArray<2> result;
   for (size_t i = 0; i < 2; ++i) {
     size_t idx = (Side == LaneOrder::Low) ? i : i + 2;
-    result[i] = Literal((double)lanes[idx].getf32());
+    result[i] = Literal::standardizeNaN(
+      Literal(static_cast<double>(lanes[idx].getf32())));
   }
   return Literal(result);
 }


### PR DESCRIPTION
Fixes #8626. Also part of #8261.

The bug is due to the fact that C++ doesn't guarantee a bitwise representation for NaNs that are casted from double -> float or vice versa. From https://en.cppreference.com/cpp/language/implicit_conversion:

> Floating-point promotion
A [prvalue](https://en.cppreference.com/cpp/language/value_category#prvalue) of type float can be converted to a prvalue of type double. The value does not change.

In the case of NaNs, the value (NaN) is preserved regardless of the particular NaN that is picked, so we have no guarantee of the bitwise representation. And for double -> float:

> If the conversion is listed under floating-point promotions, it is a promotion and not a conversion.
> * If the source value can be represented exactly in the destination type, it does not change.
> * If the source value is between two representable values of the destination type, the result is one of those two values (it is implementation-defined which one, although if IEEE arithmetic is supported, rounding defaults [to nearest](https://en.cppreference.com/cpp/numeric/fenv/FE_round)).
> * Otherwise, the behavior is undefined.

I assume NaN conversions again fall under case 1 meaning that the "value" (NaN) is preserved but not the bitwise representation.

Canonicalize NaNs after promotion or demotion to ensure that the quiet bit remains set.