### PR TITLE
PreserveImportsExportsJS fuzzer: Handle crashes and function ids

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -2219,6 +2219,10 @@ class PreserveImportsExportsJS(TestCaseHandler):
     def do_run(self, vm, js, wasm):
         out = vm.run_js(js, wasm, checked=False)
 
+        # VM crashes are actual issues we want to find.
+        if '(core dumped)' in out or 'Received signal' in out or '== C stack trace ==' in out or '== JS stack trace ==' in out:
+            raise Exception(f"VM crash:\n\n{out}")
+
         # Clean up stack traces.
         cleaned = []
         for line in out.splitlines():

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -2219,6 +2219,7 @@ class PreserveImportsExportsJS(TestCaseHandler):
     def do_run(self, vm, js, wasm):
         out = vm.run_js(js, wasm, checked=False)
 
+        # Clean up stack traces.
         cleaned = []
         for line in out.splitlines():
             if 'RuntimeError:' in line or 'TypeError:' in line:
@@ -2240,7 +2241,14 @@ class PreserveImportsExportsJS(TestCaseHandler):
                 # Ignore it, as details of traces differ based on optimizations.
                 continue
             cleaned.append(line)
-        return '\n'.join(cleaned)
+        cleaned = '\n'.join(cleaned)
+
+        # Clean up function references, which can differ after opts, things like
+        #
+        #  function 77() { [native code] }
+        #
+        cleaned = re.sub(r'function \d+\(\) ', 'function <ID>() ', cleaned)
+        return cleaned
 
     def can_run_on_wasm(self, wasm):
         return all_disallowed(DISALLOWED_FEATURES_IN_V8)


### PR DESCRIPTION
1. Report VM errors as failures (rather than see they still occur after opts).
2. Ignore function ID differences in logging.