### PR TITLE
[legalize-js-interface] Don't delete exports

### DIFF
--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -161,9 +161,6 @@ struct LegalizeJSInterface : public Pass {
         module->removeFunction(pair.first);
       }
     }
-
-    module->removeExport(GET_TEMP_RET_EXPORT);
-    module->removeExport(SET_TEMP_RET_EXPORT);
   }
 
 private:


### PR DESCRIPTION
Instead we can just rely on emscripten's metadce to remove these like all other unused exports.

See https://github.com/emscripten-core/emscripten/pull/26793

Also, note that we did not have any tests for this removal anyway.