### PR TITLE
Fuzzer: Do not return 0 from upTo when input is finished

### DIFF
--- a/src/tools/fuzzing/random.cpp
+++ b/src/tools/fuzzing/random.cpp
@@ -66,9 +66,6 @@ float Random::getFloat() { return Literal(get32()).reinterpretf32(); }
 double Random::getDouble() { return Literal(get64()).reinterpretf64(); }
 
 uint32_t Random::upTo(uint32_t x) {
-  if (finished()) {
-    return 0;
-  }
   if (x == 0) {
     return 0;
   }

--- a/test/passes/fuzz_metrics_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_noprint.bin.txt
@@ -9,27 +9,27 @@ total
  [table-data]   : 23      
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 9732    
+ [total]        : 9511    
  [vars]         : 165     
- Binary         : 710     
- Block          : 1566    
- Break          : 305     
- Call           : 257     
+ Binary         : 701     
+ Block          : 1509    
+ Break          : 303     
+ Call           : 255     
  CallIndirect   : 109     
- Const          : 1657    
- Drop           : 148     
- GlobalGet      : 787     
- GlobalSet      : 552     
- If             : 510     
- Load           : 177     
+ Const          : 1586    
+ Drop           : 99      
+ GlobalGet      : 784     
+ GlobalSet      : 550     
+ If             : 507     
+ Load           : 174     
  LocalGet       : 802     
- LocalSet       : 593     
- Loop           : 217     
- Nop            : 128     
+ LocalSet       : 585     
+ Loop           : 216     
+ Nop            : 127     
  RefFunc        : 23      
- Return         : 95      
+ Return         : 93      
  Select         : 88      
- Store          : 71      
+ Store          : 70      
  Switch         : 4       
- Unary          : 660     
- Unreachable    : 273     
+ Unary          : 654     
+ Unreachable    : 272     

--- a/test/passes/fuzz_metrics_passes_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_passes_noprint.bin.txt
@@ -9,27 +9,27 @@ total
  [table-data]   : 28      
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 8649    
+ [total]        : 9880    
  [vars]         : 253     
- Binary         : 597     
- Block          : 1475    
- Break          : 252     
- Call           : 323     
- CallIndirect   : 46      
- Const          : 1348    
- Drop           : 91      
- GlobalGet      : 732     
- GlobalSet      : 543     
- If             : 491     
- Load           : 135     
- LocalGet       : 683     
- LocalSet       : 507     
- Loop           : 182     
- Nop            : 131     
+ Binary         : 685     
+ Block          : 1660    
+ Break          : 304     
+ Call           : 343     
+ CallIndirect   : 57      
+ Const          : 1537    
+ Drop           : 102     
+ GlobalGet      : 812     
+ GlobalSet      : 601     
+ If             : 560     
+ Load           : 159     
+ LocalGet       : 820     
+ LocalSet       : 611     
+ Loop           : 210     
+ Nop            : 151     
  RefFunc        : 28      
- Return         : 78      
- Select         : 84      
- Store          : 43      
+ Return         : 84      
+ Select         : 95      
+ Store          : 56      
  Switch         : 2       
- Unary          : 607     
- Unreachable    : 271     
+ Unary          : 704     
+ Unreachable    : 299     

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,6 +1,6 @@
 Metrics
 total
- [exports]      : 14      
+ [exports]      : 13      
  [funcs]        : 18      
  [globals]      : 2       
  [imports]      : 13      
@@ -9,8 +9,8 @@ total
  [table-data]   : 3       
  [tables]       : 2       
  [tags]         : 2       
- [total]        : 527     
- [vars]         : 50      
+ [total]        : 525     
+ [vars]         : 51      
  ArrayNewFixed  : 2       
  AtomicFence    : 1       
  Binary         : 27      
@@ -18,12 +18,12 @@ total
  Break          : 9       
  Call           : 17      
  CallRef        : 1       
- Const          : 103     
+ Const          : 101     
  Drop           : 8       
  GlobalGet      : 48      
  GlobalSet      : 44      
  If             : 29      
- LocalGet       : 14      
+ LocalGet       : 15      
  LocalSet       : 10      
  Loop           : 4       
  MemoryInit     : 1       
@@ -45,6 +45,6 @@ total
  TableSet       : 1       
  TryTable       : 2       
  TupleExtract   : 1       
- TupleMake      : 4       
+ TupleMake      : 3       
  Unary          : 29      
  Unreachable    : 23      


### PR DESCRIPTION
This was added to simplify our output when the random data is small - it
makes us pick simpler options, which helps a little there - but the downsides
are large, so revert this part.

Specifically, we consume all the random input to generate functions. We
then do a small amount of random usage at the end, things like export
mutation. To handle that, we keep returning random values even after
the random input is consumed (using some xor-ing to try to keep things
random). But if we just return 0 at that point, we are missing out on a lot of
variety.

This was added in #7832. All the rest of that PR makes sense - we can
check for the end of the random data and do simpler things - but we
should not do the simplest possible thing in the generic `upTo` method
which would simplify everything, even things we don't want to.