### PR TITLE
Enable fuzzing for relaxed atomics

### DIFF
--- a/scripts/bundle_clusterfuzz.py
+++ b/scripts/bundle_clusterfuzz.py
@@ -109,7 +109,6 @@ features = [
     '--disable-fp16',
     '--disable-strings',
     '--disable-stack-switching',
-    '--disable-relaxed-atomics',
     '--disable-multibyte',
     '--disable-wide-arithmetic',
 ]

--- a/scripts/clusterfuzz/run.py
+++ b/scripts/clusterfuzz/run.py
@@ -33,7 +33,7 @@ import sys
 
 # The V8 flags we put in the "fuzzer flags" files, which tell ClusterFuzz how to
 # run V8. By default we apply all staging flags.
-FUZZER_FLAGS = '--wasm-staging --experimental-wasm-custom-descriptors --experimental-wasm-js-interop'
+FUZZER_FLAGS = '--wasm-staging --experimental-wasm-custom-descriptors --experimental-wasm-js-interop --experimental-wasm-acquire-release'
 
 # Optional V8 flags to add to FUZZER_FLAGS, some of the time.
 OPTIONAL_FUZZER_FLAGS = [
@@ -94,7 +94,6 @@ FUZZER_ARGS = [
     '--disable-fp16',
     '--disable-strings',
     '--disable-stack-switching',
-    '--disable-relaxed-atomics',
     '--disable-wide-arithmetic',
 ]
 

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -75,7 +75,6 @@ DISALLOWED_FEATURES_IN_V8 = [
     'fp16',
     'strings',
     'stack-switching',
-    'relaxed-atomics',
     'multibyte',
     'wide-arithmetic',
 ]

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -254,6 +254,7 @@ V8_OPTS = [
     '--experimental-wasm-fp16',
     '--experimental-wasm-custom-descriptors',
     '--experimental-wasm-js-interop',
+    '--experimental-wasm-acquire-release',
 ]
 
 # external tools


### PR DESCRIPTION
Part of #8165. V8 now supports relaxed atomics with the --experimental-wasm-acquire-release flag.

cc @rmahdav 