### PR TITLE
Fix clang 13 build

### DIFF
--- a/src/analysis/lattice.h
+++ b/src/analysis/lattice.h
@@ -17,9 +17,9 @@
 #ifndef wasm_analysis_lattice_h
 #define wasm_analysis_lattice_h
 
-#if __cplusplus >= 202002L
+#if __has_include(<concepts>)
 #include <concepts>
-#endif // __cplusplus >= 202002L
+#endif
 
 namespace wasm::analysis {
 

--- a/src/analysis/lattice.h
+++ b/src/analysis/lattice.h
@@ -37,7 +37,7 @@ inline LatticeComparison reverseComparison(LatticeComparison comparison) {
   }
 }
 
-#if __cplusplus >= 202002L
+#if defined(__cpp_lib_concepts)
 
 template<typename L>
 concept Lattice = requires(const L& lattice,
@@ -78,12 +78,12 @@ concept FullLattice =
     { lattice.meet(elem, constElem) } noexcept -> std::same_as<bool>;
   };
 
-#else // __cplusplus >= 202002L
+#else // defined(__cpp_lib_concepts)
 
 #define Lattice typename
 #define FullLattice typename
 
-#endif // __cplusplus >= 202002L
+#endif // defined(__cpp_lib_concepts)
 
 } // namespace wasm::analysis
 

--- a/src/analysis/lattices/abstraction.h
+++ b/src/analysis/lattices/abstraction.h
@@ -22,7 +22,7 @@
 #include "../lattice.h"
 #include "support/utilities.h"
 
-#if __cplusplus >= 202002L
+#if defined(__cpp_lib_concepts)
 #include "analysis/lattices/bool.h"
 #endif
 
@@ -218,7 +218,7 @@ private:
   }
 };
 
-#if __cplusplus >= 202002L
+#if defined(__cpp_lib_concepts)
 static_assert(Lattice<Abstraction<Bool, Bool, Bool>>);
 #endif
 

--- a/src/analysis/lattices/array.h
+++ b/src/analysis/lattices/array.h
@@ -54,7 +54,7 @@ public:
   }
 
   Element getTop() const noexcept
-#if __cplusplus >= 202002L
+#if defined(__cpp_lib_concepts)
     requires FullLattice<L>
 #endif
   {
@@ -101,7 +101,7 @@ public:
 
   // Pairwise meet on the elements.
   bool meet(Element& meetee, const Element& meeter) const noexcept
-#if __cplusplus >= 202002L
+#if defined(__cpp_lib_concepts)
     requires FullLattice<L>
 #endif
   {
@@ -113,7 +113,7 @@ public:
   }
 };
 
-#if __cplusplus >= 202002L
+#if defined(__cpp_lib_concepts)
 static_assert(FullLattice<Array<Bool, 1>>);
 static_assert(Lattice<Array<Flat<bool>, 1>>);
 #endif

--- a/src/analysis/lattices/bool.h
+++ b/src/analysis/lattices/bool.h
@@ -75,9 +75,9 @@ struct Bool {
   }
 };
 
-#if __cplusplus >= 202002L
+#if defined(__cpp_lib_concepts)
 static_assert(Lattice<Bool>);
-#endif // __cplusplus >= 202002L
+#endif // defined(__cpp_lib_concepts)
 
 } // namespace wasm::analysis
 

--- a/src/analysis/lattices/conetype.h
+++ b/src/analysis/lattices/conetype.h
@@ -174,7 +174,7 @@ private:
   }
 };
 
-#if __cplusplus >= 202002L
+#if defined(__cpp_lib_concepts)
 static_assert(Lattice<ConeType>);
 static_assert(FullLattice<ConeType>);
 #endif

--- a/src/analysis/lattices/flat.h
+++ b/src/analysis/lattices/flat.h
@@ -30,7 +30,7 @@
 
 namespace wasm::analysis {
 
-#if __cplusplus >= 202002L
+#if defined(__cpp_lib_concepts)
 
 template<typename T>
 concept Flattenable = std::copyable<T> && std::equality_comparable<T>;
@@ -118,7 +118,7 @@ public:
   }
 };
 
-#if __cplusplus >= 202002L
+#if defined(__cpp_lib_concepts)
 static_assert(Lattice<Flat<int>>);
 #endif
 

--- a/src/analysis/lattices/flat.h
+++ b/src/analysis/lattices/flat.h
@@ -21,7 +21,7 @@
 #include <type_traits>
 #include <variant>
 
-#if __cplusplus >= 202002L
+#if __has_include(<concepts>)
 #include <concepts>
 #endif
 

--- a/src/analysis/lattices/int.h
+++ b/src/analysis/lattices/int.h
@@ -26,7 +26,7 @@ namespace wasm::analysis {
 
 // The lattice of integers of the given type `T`, ordered by <. The min integer
 // is the bottom element and the max integer is the top element.
-#if __cplusplus >= 202002L
+#if defined(__cpp_lib_concepts)
 template<std::integral T>
 #else
 template<typename T>
@@ -59,12 +59,12 @@ using UInt32 = Integer<uint32_t>;
 using Int64 = Integer<int64_t>;
 using UInt64 = Integer<uint64_t>;
 
-#if __cplusplus >= 202002L
+#if defined(__cpp_lib_concepts)
 static_assert(FullLattice<Int32>);
 static_assert(FullLattice<Int64>);
 static_assert(FullLattice<UInt32>);
 static_assert(FullLattice<UInt64>);
-#endif // __cplusplus >= 202002L
+#endif // defined(__cpp_lib_concepts)
 
 } // namespace wasm::analysis
 

--- a/src/analysis/lattices/inverted.h
+++ b/src/analysis/lattices/inverted.h
@@ -52,7 +52,7 @@ template<FullLattice L> struct Inverted {
 // Deduction guide.
 template<typename L> Inverted(L&&) -> Inverted<L>;
 
-#if __cplusplus >= 202002L
+#if defined(__cpp_lib_concepts)
 static_assert(Lattice<Inverted<Bool>>);
 #endif
 

--- a/src/analysis/lattices/lift.h
+++ b/src/analysis/lattices/lift.h
@@ -77,7 +77,7 @@ template<Lattice L> struct Lift {
 // Deduction guide.
 template<typename L> Lift(L&&) -> Lift<L>;
 
-#if __cplusplus >= 202002L
+#if defined(__cpp_lib_concepts)
 static_assert(Lattice<Lift<Bool>>);
 #endif
 

--- a/src/analysis/lattices/shared.h
+++ b/src/analysis/lattices/shared.h
@@ -121,9 +121,9 @@ template<Lattice L> struct SharedPath {
 // Deduction guide.
 template<typename L> SharedPath(L&&) -> SharedPath<L>;
 
-#if __cplusplus >= 202002L
+#if defined(__cpp_lib_concepts)
 static_assert(Lattice<SharedPath<Bool>>);
-#endif // __cplusplus >= 202002L
+#endif // defined(__cpp_lib_concepts)
 
 } // namespace wasm::analysis
 

--- a/src/analysis/lattices/stack.h
+++ b/src/analysis/lattices/stack.h
@@ -185,7 +185,7 @@ template<Lattice L> struct Stack {
 // Deduction guide.
 template<typename L> Stack(L&&) -> Stack<L>;
 
-#if __cplusplus >= 202002L
+#if defined(__cpp_lib_concepts)
 static_assert(Lattice<Stack<Bool>>);
 #endif
 

--- a/src/analysis/lattices/tuple.h
+++ b/src/analysis/lattices/tuple.h
@@ -137,7 +137,7 @@ public:
   }
 };
 
-#if __cplusplus >= 202002L
+#if defined(__cpp_lib_concepts)
 static_assert(FullLattice<Tuple<>>);
 static_assert(FullLattice<Tuple<Bool>>);
 #endif

--- a/src/analysis/lattices/valtype.h
+++ b/src/analysis/lattices/valtype.h
@@ -73,7 +73,7 @@ struct ValType {
   }
 };
 
-#if __cplusplus >= 202002L
+#if defined(__cpp_lib_concepts)
 static_assert(FullLattice<ValType>);
 #endif
 

--- a/src/analysis/lattices/vector.h
+++ b/src/analysis/lattices/vector.h
@@ -154,7 +154,7 @@ private:
 // Deduction guide.
 template<typename L> Vector(L&&, size_t) -> Vector<L>;
 
-#if __cplusplus >= 202002L
+#if defined(__cpp_lib_concepts)
 static_assert(FullLattice<Vector<Bool>>);
 static_assert(Lattice<Vector<Flat<bool>>>);
 #endif

--- a/src/analysis/transfer-function.h
+++ b/src/analysis/transfer-function.h
@@ -19,7 +19,9 @@
 
 #if __cplusplus >= 202002L
 #include <concepts>
+#if __has_include(<ranges>)
 #include <ranges>
+#endif
 #endif
 
 #if defined(__cpp_lib_concepts) && defined(__cpp_lib_ranges)

--- a/src/analysis/transfer-function.h
+++ b/src/analysis/transfer-function.h
@@ -17,11 +17,11 @@
 #ifndef wasm_analysis_transfer_function_h
 #define wasm_analysis_transfer_function_h
 
-#if __cplusplus >= 202002L
+#if __has_include(<concepts>)
 #include <concepts>
+#endif
 #if __has_include(<ranges>)
 #include <ranges>
-#endif
 #endif
 
 #if defined(__cpp_lib_concepts) && defined(__cpp_lib_ranges)

--- a/src/analysis/transfer-function.h
+++ b/src/analysis/transfer-function.h
@@ -18,10 +18,13 @@
 #define wasm_analysis_transfer_function_h
 
 #if __cplusplus >= 202002L
-
 #include <concepts>
-#include <iterator>
 #include <ranges>
+#endif
+
+#if defined(__cpp_lib_concepts) && defined(__cpp_lib_ranges)
+
+#include <iterator>
 
 #include "cfg.h"
 #include "lattice.h"
@@ -47,10 +50,10 @@ concept TransferFunctionImpl = requires(
 
 } // namespace wasm::analysis
 
-#else // __cplusplus >= 202002L
+#else // defined(__cpp_lib_concepts) && defined(__cpp_lib_ranges)
 
 #define TransferFunction typename
 
-#endif // __cplusplus >= 202002L
+#endif // defined(__cpp_lib_concepts) && defined(__cpp_lib_ranges)
 
 #endif // wasm_analysis_transfer_function_h

--- a/src/support/graph_traversal.h
+++ b/src/support/graph_traversal.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if __cplusplus >= 202002L
+#if __has_include(<concepts>)
 #include <concepts>
 #endif
 #include <functional>

--- a/src/support/graph_traversal.h
+++ b/src/support/graph_traversal.h
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+#if __cplusplus >= 202002L
 #include <concepts>
+#endif
 #include <functional>
 #include <iterator>
 #include <unordered_set>
@@ -32,8 +34,12 @@ namespace wasm {
 // successors([](const T&) { }, t); }
 template<typename T, typename SuccessorFunction> class Graph {
 public:
+#if defined(__cpp_lib_concepts)
   template<std::input_iterator It, std::sentinel_for<It> Sen>
     requires std::convertible_to<std::iter_reference_t<It>, T>
+#else
+  template<typename It, typename Sen>
+#endif
   Graph(It rootsBegin, Sen rootsEnd, SuccessorFunction successors)
     : roots(rootsBegin, rootsEnd), successors(std::move(successors)) {}
 
@@ -66,10 +72,17 @@ private:
   SuccessorFunction successors;
 };
 
+#if defined(__cpp_lib_concepts)
 template<std::input_iterator It,
          std::sentinel_for<It> Sen,
          typename SuccessorFunction>
 Graph(It, Sen, SuccessorFunction)
   -> Graph<std::iter_value_t<It>, std::decay_t<SuccessorFunction>>;
+#else
+template<typename It, typename Sen, typename SuccessorFunction>
+Graph(It, Sen, SuccessorFunction)
+  -> Graph<typename std::iterator_traits<It>::value_type,
+           std::decay_t<SuccessorFunction>>;
+#endif
 
 } // namespace wasm

--- a/src/support/graph_traversal.h
+++ b/src/support/graph_traversal.h
@@ -41,7 +41,8 @@ public:
   template<typename It, typename Sen>
 #endif
   Graph(It rootsBegin, Sen rootsEnd, SuccessorFunction successors)
-    : roots(rootsBegin, rootsEnd), successors(std::move(successors)) {}
+    : roots(rootsBegin, rootsEnd), successors(std::move(successors)) {
+  }
 
   // Traverse the graph depth-first, calling `successors` exactly once for each
   // node (unless the node appears multiple times in `roots`). Return the set of

--- a/src/tools/wasm-fuzz-lattices.cpp
+++ b/src/tools/wasm-fuzz-lattices.cpp
@@ -148,7 +148,7 @@ struct RandomLattice {
   bool join(Element& a, const Element& b) const noexcept;
 };
 
-#if __cplusplus >= 202002L
+#if defined(__cpp_lib_concepts)
 static_assert(FullLattice<RandomFullLattice>);
 static_assert(Lattice<RandomLattice>);
 #endif


### PR DESCRIPTION
Clang-13 advertises C++20 support with `__cplusplus >= 202002L`, but it does not have all the features of C++20.

So instead use the C++20 individual feature testing macros to check for the various features: https://en.cppreference.com/cpp/feature_test

which Clang-13 accurately reports.

Authored on top of PR https://github.com/WebAssembly/binaryen/pull/8668, will rebase before landing, if/when https://github.com/WebAssembly/binaryen/pull/8668 is approved.