### PR TITLE
Support fuzzing more Relaxed SIMD instructions

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -4790,6 +4790,14 @@ Expression* TranslateToFuzzReader::makeBinary(Type type) {
 
                                       // SIMD Swizzle
                                       SwizzleVecI8x16)
+                                 .add(FeatureSet::RelaxedSIMD,
+                                      RelaxedSwizzleVecI8x16,
+                                      RelaxedMinVecF32x4,
+                                      RelaxedMaxVecF32x4,
+                                      RelaxedMinVecF64x2,
+                                      RelaxedMaxVecF64x2,
+                                      RelaxedQ15MulrSVecI16x8,
+                                      RelaxedDotI8x16I7x16SToVecI16x8)
                                  .add(FeatureSet::FP16,
                                       EqVecF16x8,
                                       EqVecF16x8,
@@ -5113,13 +5121,18 @@ Expression* TranslateToFuzzReader::makeSIMDShuffle() {
 }
 
 Expression* TranslateToFuzzReader::makeSIMDTernary() {
-  // TODO: Enable qfma/qfms once it is implemented in V8 and the interpreter
-  // SIMDTernaryOp op = pick(Bitselect,
-  //                         QFMAF32x4,
-  //                         QFMSF32x4,
-  //                         QFMAF64x2,
-  //                         QFMSF64x2);
-  SIMDTernaryOp op = Bitselect;
+  SIMDTernaryOp op = pick(FeatureOptions<SIMDTernaryOp>()
+                            .add(FeatureSet::SIMD, Bitselect)
+                            .add(FeatureSet::RelaxedSIMD,
+                                 RelaxedMaddVecF32x4,
+                                 RelaxedNmaddVecF32x4,
+                                 RelaxedMaddVecF64x2,
+                                 RelaxedNmaddVecF64x2,
+                                 RelaxedLaneselectI8x16,
+                                 RelaxedLaneselectI16x8,
+                                 RelaxedLaneselectI32x4,
+                                 RelaxedLaneselectI64x2,
+                                 RelaxedDotI8x16I7x16AddSToVecI32x4));
   Expression* a = make(Type::v128);
   Expression* b = make(Type::v128);
   Expression* c = make(Type::v128);


### PR DESCRIPTION
Extend the binary and ternary WebAssembly fuzzer generators to cover more Relaxed SIMD.