### PR TITLE
Remove guesswork from getStackPointerGlobal. NFC

### DIFF
--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -40,17 +40,10 @@ void addExportedFunction(Module& wasm, Function* function) {
 }
 
 Global* getStackPointerGlobal(Module& wasm) {
-  // Assumption: The stack pointer is either imported as __stack_pointer or
-  // we just assume it's the first non-imported global.
-  // TODO(sbc): Find a better way to discover the stack pointer.  Perhaps the
-  // linker could export it by name?
+  // Assumption: The stack pointer is either be an imported global called
+  // __stack_pointer or a defined global with that name.
   for (auto& g : wasm.globals) {
-    if (g->imported() && g->base == STACK_POINTER) {
-      return g.get();
-    }
-  }
-  for (auto& g : wasm.globals) {
-    if (!g->imported()) {
+    if (g->base == STACK_POINTER || g->name == STACK_POINTER) {
       return g.get();
     }
   }

--- a/test/finalize/recursive_safe_stack.wat
+++ b/test/finalize/recursive_safe_stack.wat
@@ -6,7 +6,7 @@
  (memory $0 2)
  (data (i32.const 568) "%d:%d\n\00Result: %d\n\00")
  (table $0 1 1 funcref)
- (global $global$0 (mut i32) (i32.const 66128))
+ (global $__stack_pointer (mut i32) (i32.const 66128))
  (global $global$1 i32 (i32.const 66128))
  (global $global$2 i32 (i32.const 587))
  (export "memory" (memory $0))
@@ -18,10 +18,10 @@
  )
  (func $foo (; 2 ;) (type $0) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
-  (global.set $global$0
+  (global.set $__stack_pointer
    (local.tee $2
     (i32.sub
-     (global.get $global$0)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -40,7 +40,7 @@
     (local.get $2)
    )
   )
-  (global.set $global$0
+  (global.set $__stack_pointer
    (i32.add
     (local.get $2)
     (i32.const 16)
@@ -53,10 +53,10 @@
  )
  (func $__original_main (; 3 ;) (type $2) (result i32)
   (local $0 i32)
-  (global.set $global$0
+  (global.set $__stack_pointer
    (local.tee $0
     (i32.sub
-     (global.get $global$0)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -74,7 +74,7 @@
     (local.get $0)
    )
   )
-  (global.set $global$0
+  (global.set $__stack_pointer
    (i32.add
     (local.get $0)
     (i32.const 16)

--- a/test/finalize/recursive_safe_stack.wat.out
+++ b/test/finalize/recursive_safe_stack.wat.out
@@ -6,7 +6,7 @@
  (type $4 (func (param i32 i32)))
  (import "env" "printf" (func $printf (param i32 i32) (result i32)))
  (import "env" "__handle_stack_overflow" (func $__handle_stack_overflow (param i32)))
- (global $global$0 (mut i32) (i32.const 66128))
+ (global $__stack_pointer (mut i32) (i32.const 66128))
  (global $global$1 i32 (i32.const 66128))
  (global $global$2 i32 (i32.const 587))
  (global $__stack_base (mut i32) (i32.const 0))
@@ -33,7 +33,7 @@
       (local.tee $3
        (local.tee $2
         (i32.sub
-         (global.get $global$0)
+         (global.get $__stack_pointer)
          (i32.const 16)
         )
        )
@@ -51,7 +51,7 @@
      )
     )
    )
-   (global.set $global$0
+   (global.set $__stack_pointer
     (local.get $3)
    )
   )
@@ -92,7 +92,7 @@
      )
     )
    )
-   (global.set $global$0
+   (global.set $__stack_pointer
     (local.get $4)
    )
   )
@@ -112,7 +112,7 @@
       (local.tee $1
        (local.tee $0
         (i32.sub
-         (global.get $global$0)
+         (global.get $__stack_pointer)
          (i32.const 16)
         )
        )
@@ -130,7 +130,7 @@
      )
     )
    )
-   (global.set $global$0
+   (global.set $__stack_pointer
     (local.get $1)
    )
   )
@@ -170,7 +170,7 @@
      )
     )
    )
-   (global.set $global$0
+   (global.set $__stack_pointer
     (local.get $2)
    )
   )

--- a/test/finalize/safe_stack_standalone-wasm.wat
+++ b/test/finalize/safe_stack_standalone-wasm.wat
@@ -6,7 +6,7 @@
  (memory $0 2)
  (data (i32.const 568) "%d:%d\n\00Result: %d\n\00")
  (table $0 1 1 funcref)
- (global $global$0 (mut i32) (i32.const 66128))
+ (global $__stack_pointer (mut i32) (i32.const 66128))
  (global $global$1 i32 (i32.const 66128))
  (global $global$2 i32 (i32.const 587))
  (export "memory" (memory $0))
@@ -18,10 +18,10 @@
  )
  (func $foo (; 2 ;) (type $0) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
-  (global.set $global$0
+  (global.set $__stack_pointer
    (local.tee $2
     (i32.sub
-     (global.get $global$0)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -40,7 +40,7 @@
     (local.get $2)
    )
   )
-  (global.set $global$0
+  (global.set $__stack_pointer
    (i32.add
     (local.get $2)
     (i32.const 16)
@@ -53,10 +53,10 @@
  )
  (func $__original_main (; 3 ;) (type $2) (result i32)
   (local $0 i32)
-  (global.set $global$0
+  (global.set $__stack_pointer
    (local.tee $0
     (i32.sub
-     (global.get $global$0)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -74,7 +74,7 @@
     (local.get $0)
    )
   )
-  (global.set $global$0
+  (global.set $__stack_pointer
    (i32.add
     (local.get $0)
     (i32.const 16)

--- a/test/finalize/safe_stack_standalone-wasm.wat.out
+++ b/test/finalize/safe_stack_standalone-wasm.wat.out
@@ -4,7 +4,7 @@
  (type $2 (func (result i32)))
  (type $3 (func (param i32 i32)))
  (import "env" "printf" (func $printf (param i32 i32) (result i32)))
- (global $global$0 (mut i32) (i32.const 66128))
+ (global $__stack_pointer (mut i32) (i32.const 66128))
  (global $global$1 i32 (i32.const 66128))
  (global $global$2 i32 (i32.const 587))
  (global $__stack_base (mut i32) (i32.const 0))
@@ -31,7 +31,7 @@
       (local.tee $3
        (local.tee $2
         (i32.sub
-         (global.get $global$0)
+         (global.get $__stack_pointer)
          (i32.const 16)
         )
        )
@@ -47,7 +47,7 @@
      (unreachable)
     )
    )
-   (global.set $global$0
+   (global.set $__stack_pointer
     (local.get $3)
    )
   )
@@ -86,7 +86,7 @@
      (unreachable)
     )
    )
-   (global.set $global$0
+   (global.set $__stack_pointer
     (local.get $4)
    )
   )
@@ -106,7 +106,7 @@
       (local.tee $1
        (local.tee $0
         (i32.sub
-         (global.get $global$0)
+         (global.get $__stack_pointer)
          (i32.const 16)
         )
        )
@@ -122,7 +122,7 @@
      (unreachable)
     )
    )
-   (global.set $global$0
+   (global.set $__stack_pointer
     (local.get $1)
    )
   )
@@ -160,7 +160,7 @@
      (unreachable)
     )
    )
-   (global.set $global$0
+   (global.set $__stack_pointer
     (local.get $2)
    )
   )

--- a/test/lit/passes/stack-check-memory64.wast
+++ b/test/lit/passes/stack-check-memory64.wast
@@ -9,8 +9,8 @@
 
  ;; CHECK:      (type $1 (func (param i64 i64)))
 
- ;; CHECK:      (global $sp (mut i64) (i64.const 0))
- (global $sp (mut i64) (i64.const 0))
+ ;; CHECK:      (global $__stack_pointer (mut i64) (i64.const 0))
+ (global $__stack_pointer (mut i64) (i64.const 0))
  ;; CHECK:      (global $__stack_base (mut i64) (i64.const 0))
 
  ;; CHECK:      (global $__stack_limit (mut i64) (i64.const 0))
@@ -41,15 +41,15 @@
  ;; CHECK-NEXT:     (unreachable)
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
- ;; CHECK-NEXT:   (global.set $sp
+ ;; CHECK-NEXT:   (global.set $__stack_pointer
  ;; CHECK-NEXT:    (local.get $0)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (global.get $sp)
+ ;; CHECK-NEXT:  (global.get $__stack_pointer)
  ;; CHECK-NEXT: )
  (func $use_stack (export "use_stack") (result i64)
-  (global.set $sp (i64.const 42))
-  (global.get $sp)
+  (global.set $__stack_pointer (i64.const 42))
+  (global.get $__stack_pointer)
  )
 )
 ;; CHECK:      (func $__set_stack_limits (param $0 i64) (param $1 i64)
@@ -67,8 +67,8 @@
 
  ;; CHECK:      (type $1 (func (param i64 i64)))
 
- ;; CHECK:      (global $sp (mut i64) (i64.const 0))
- (global $sp (mut i64) (i64.const 0))
+ ;; CHECK:      (global $__stack_pointer (mut i64) (i64.const 0))
+ (global $__stack_pointer (mut i64) (i64.const 0))
  ;; CHECK:      (global $__stack_base (mut i64) (i64.const 0))
  (global $__stack_base (mut i64) (i64.const 0))
  ;; CHECK:      (global $__stack_limit (mut i64) (i64.const 0))

--- a/test/passes/spill-pointers.txt
+++ b/test/passes/spill-pointers.txt
@@ -7,7 +7,7 @@
  (type $5 (func (param f64)))
  (import "env" "STACKTOP" (global $STACKTOP$asm2wasm$import i32))
  (import "env" "segfault" (func $segfault (param i32)))
- (global $stack_ptr (mut i32) (global.get $STACKTOP$asm2wasm$import))
+ (global $__stack_pointer (mut i32) (global.get $STACKTOP$asm2wasm$import))
  (memory $0 10)
  (table $0 1 1 funcref)
  (elem $0 (i32.const 0))
@@ -23,10 +23,10 @@
  (func $spill
   (local $x i32)
   (local $1 i32)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $1
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -43,7 +43,7 @@
     (local.get $x)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $1)
     (i32.const 16)
@@ -56,10 +56,10 @@
   (local $z f32)
   (local $w f64)
   (local $4 i32)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $4
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -97,7 +97,7 @@
     (local.get $w)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $4)
     (i32.const 16)
@@ -110,10 +110,10 @@
   (local $z i32)
   (local $w i32)
   (local $4 i32)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $4
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -163,7 +163,7 @@
     (local.get $w)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $4)
     (i32.const 16)
@@ -177,10 +177,10 @@
   (local $w i32)
   (local $a i32)
   (local $5 i32)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $5
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 32)
     )
    )
@@ -240,7 +240,7 @@
     (local.get $a)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $5)
     (i32.const 32)
@@ -251,10 +251,10 @@
   (local $x i32)
   (local $y i32)
   (local $2 i32)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $2
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -271,7 +271,7 @@
     (local.get $x)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $2)
     (i32.const 16)
@@ -283,10 +283,10 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $3
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -312,7 +312,7 @@
     (local.get $x)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $3)
     (i32.const 16)
@@ -325,10 +325,10 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $1
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -351,7 +351,7 @@
       (local.set $2
        (i32.const 2)
       )
-      (global.set $stack_ptr
+      (global.set $__stack_pointer
        (i32.add
         (local.get $1)
         (i32.const 16)
@@ -365,7 +365,7 @@
       (local.set $3
        (i32.const 3)
       )
-      (global.set $stack_ptr
+      (global.set $__stack_pointer
        (i32.add
         (local.get $1)
         (i32.const 16)
@@ -379,7 +379,7 @@
     (i32.const 4)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $1)
     (i32.const 16)
@@ -391,10 +391,10 @@
   (local $x i32)
   (local $1 i32)
   (local $2 i32)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $1
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -414,7 +414,7 @@
     (unreachable)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $1)
     (i32.const 16)
@@ -431,10 +431,10 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $2
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -469,7 +469,7 @@
     (local.get $x)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $2)
     (i32.const 16)
@@ -504,10 +504,10 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $1
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -526,7 +526,7 @@
     )
     (drop
      (block
-      (global.set $stack_ptr
+      (global.set $__stack_pointer
        (i32.add
         (local.get $1)
         (i32.const 16)
@@ -537,7 +537,7 @@
         (local.set $2
          (i32.const 1)
         )
-        (global.set $stack_ptr
+        (global.set $__stack_pointer
          (i32.add
           (local.get $1)
           (i32.const 16)
@@ -553,7 +553,7 @@
     (i32.const 0)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $1)
     (i32.const 16)
@@ -565,10 +565,10 @@
   (local $x i32)
   (local $2 i32)
   (local $3 f64)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $2
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -590,7 +590,7 @@
     (local.get $x)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $2)
     (i32.const 16)
@@ -603,10 +603,10 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $1
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -636,7 +636,7 @@
     (local.get $x)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $1)
     (i32.const 16)
@@ -647,10 +647,10 @@
   (local $x i32)
   (local $1 i32)
   (local $2 i32)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $1
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -672,7 +672,7 @@
     (local.get $x)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $1)
     (i32.const 16)
@@ -688,13 +688,13 @@
  (type $4 (func (param i32)))
  (type $5 (func (param f64)))
  (import "env" "segfault" (func $segfault (param i32)))
- (global $stack_ptr (mut i32) (i32.const 1716592))
+ (global $__stack_pointer (mut i32) (i32.const 1716592))
  (memory $0 10)
  (table $0 1 1 funcref)
  (elem $0 (i32.const 0))
  (export "stackSave" (func $stack_save))
  (func $stack_save (result i32)
-  (global.get $stack_ptr)
+  (global.get $__stack_pointer)
  )
  (func $nothing
  )
@@ -708,10 +708,10 @@
  (func $spill
   (local $x i32)
   (local $1 i32)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $1
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -728,7 +728,7 @@
     (local.get $x)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $1)
     (i32.const 16)
@@ -741,10 +741,10 @@
   (local $z f32)
   (local $w f64)
   (local $4 i32)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $4
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -782,7 +782,7 @@
     (local.get $w)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $4)
     (i32.const 16)
@@ -795,10 +795,10 @@
   (local $z i32)
   (local $w i32)
   (local $4 i32)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $4
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -848,7 +848,7 @@
     (local.get $w)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $4)
     (i32.const 16)
@@ -862,10 +862,10 @@
   (local $w i32)
   (local $a i32)
   (local $5 i32)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $5
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 32)
     )
    )
@@ -925,7 +925,7 @@
     (local.get $a)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $5)
     (i32.const 32)
@@ -936,10 +936,10 @@
   (local $x i32)
   (local $y i32)
   (local $2 i32)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $2
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -956,7 +956,7 @@
     (local.get $x)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $2)
     (i32.const 16)
@@ -968,10 +968,10 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $3
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -997,7 +997,7 @@
     (local.get $x)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $3)
     (i32.const 16)
@@ -1010,10 +1010,10 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $1
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -1036,7 +1036,7 @@
       (local.set $2
        (i32.const 2)
       )
-      (global.set $stack_ptr
+      (global.set $__stack_pointer
        (i32.add
         (local.get $1)
         (i32.const 16)
@@ -1050,7 +1050,7 @@
       (local.set $3
        (i32.const 3)
       )
-      (global.set $stack_ptr
+      (global.set $__stack_pointer
        (i32.add
         (local.get $1)
         (i32.const 16)
@@ -1064,7 +1064,7 @@
     (i32.const 4)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $1)
     (i32.const 16)
@@ -1076,10 +1076,10 @@
   (local $x i32)
   (local $1 i32)
   (local $2 i32)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $1
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -1099,7 +1099,7 @@
     (unreachable)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $1)
     (i32.const 16)
@@ -1116,10 +1116,10 @@
   (local $3 i32)
   (local $4 i32)
   (local $5 i32)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $2
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -1154,7 +1154,7 @@
     (local.get $x)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $2)
     (i32.const 16)
@@ -1189,10 +1189,10 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $1
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -1211,7 +1211,7 @@
     )
     (drop
      (block
-      (global.set $stack_ptr
+      (global.set $__stack_pointer
        (i32.add
         (local.get $1)
         (i32.const 16)
@@ -1222,7 +1222,7 @@
         (local.set $2
          (i32.const 1)
         )
-        (global.set $stack_ptr
+        (global.set $__stack_pointer
          (i32.add
           (local.get $1)
           (i32.const 16)
@@ -1238,7 +1238,7 @@
     (i32.const 0)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $1)
     (i32.const 16)
@@ -1250,10 +1250,10 @@
   (local $x i32)
   (local $2 i32)
   (local $3 f64)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $2
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -1275,7 +1275,7 @@
     (local.get $x)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $2)
     (i32.const 16)
@@ -1288,10 +1288,10 @@
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $1
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -1321,7 +1321,7 @@
     (local.get $x)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $1)
     (i32.const 16)
@@ -1332,10 +1332,10 @@
   (local $x i32)
   (local $1 i32)
   (local $2 i32)
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (local.tee $1
     (i32.sub
-     (global.get $stack_ptr)
+     (global.get $__stack_pointer)
      (i32.const 16)
     )
    )
@@ -1357,7 +1357,7 @@
     (local.get $x)
    )
   )
-  (global.set $stack_ptr
+  (global.set $__stack_pointer
    (i32.add
     (local.get $1)
     (i32.const 16)

--- a/test/passes/spill-pointers.wast
+++ b/test/passes/spill-pointers.wast
@@ -5,7 +5,7 @@
   (type $ii (func (param i32 i32)))
   (table 1 1 funcref)
   (elem (i32.const 0))
-  (global $stack_ptr (mut i32) (global.get $STACKTOP$asm2wasm$import))
+  (global $__stack_pointer (mut i32) (global.get $STACKTOP$asm2wasm$import))
 
   (func $nothing
   )
@@ -176,10 +176,10 @@
   (type $ii (func (param i32 i32)))
   (table 1 1 funcref)
   (elem (i32.const 0))
-  (global $stack_ptr (mut i32) (i32.const 1716592))
+  (global $__stack_pointer (mut i32) (i32.const 1716592))
   (export "stackSave" (func $stack_save))
   (func $stack_save (result i32)
-    (global.get $stack_ptr)
+    (global.get $__stack_pointer)
   )
 
   (func $nothing


### PR DESCRIPTION
We were just assuming that if no `__stack_pointer` was imported then the first global must be the `__stack_pointer`.

Instead we can just require that the global be names correctly in the name section.  This will require an emscripten-side change to ensure names are generated when running this pass.

Needed for fixing https://github.com/emscripten-core/emscripten/issues/24964.