### PR TITLE
[NFC] Inline more core HeapType methods

### DIFF
--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -1115,12 +1115,19 @@ using RecGroupInfo = std::vector<HeapType>;
 
 struct HeapTypeInfo {
   using type_t = HeapType;
+  // Used in assertions to ensure that temporary types don't leak into the
+  // global store.
   bool isTemp = false;
   bool isOpen = false;
   Shareability share = Unshared;
+  // The supertype of this HeapType, if it exists.
   HeapTypeInfo* supertype = nullptr;
+  // The descriptor of this HeapType, if it exists.
   HeapTypeInfo* descriptor = nullptr;
+  // The HeapType described by this one, if it exists.
   HeapTypeInfo* described = nullptr;
+  // The recursion group of this type or null if the recursion group is trivial
+  // (i.e. contains only this type).
   RecGroupInfo* recGroup = nullptr;
   size_t recGroupIndex = 0;
   HeapTypeKind kind;

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -151,23 +151,17 @@ public:
   HeapTypeKind getKind() const;
 
   constexpr bool isBasic() const { return id <= _last_basic_type; }
-  bool isFunction() const {
-    return isMaybeShared(func) || getKind() == HeapTypeKind::Func;
-  }
-  bool isData() const {
-    auto kind = getKind();
-    return isMaybeShared(string) || kind == HeapTypeKind::Struct ||
-           kind == HeapTypeKind::Array;
-  }
-  bool isSignature() const { return getKind() == HeapTypeKind::Func; }
-  bool isContinuation() const { return getKind() == HeapTypeKind::Cont; }
-  bool isStruct() const { return getKind() == HeapTypeKind::Struct; }
-  bool isArray() const { return getKind() == HeapTypeKind::Array; }
+  bool isFunction() const;
+  bool isData() const;
+  bool isSignature() const;
+  bool isContinuation() const;
+  bool isStruct() const;
+  bool isArray() const;
   bool isExn() const { return isMaybeShared(HeapType::exn); }
   bool isString() const { return isMaybeShared(HeapType::string); }
   bool isBottom() const;
   bool isOpen() const;
-  bool isShared() const { return getShared() == Shared; }
+  bool isShared() const;
 
   Shareability getShared() const;
 
@@ -1116,6 +1110,97 @@ std::ostream& operator<<(std::ostream&, Array);
 std::ostream& operator<<(std::ostream&, const TypeBuilder::ErrorReason&);
 
 // Inline some nontrivial methods here for performance reasons.
+
+using RecGroupInfo = std::vector<HeapType>;
+
+struct HeapTypeInfo {
+  using type_t = HeapType;
+  bool isTemp = false;
+  bool isOpen = false;
+  Shareability share = Unshared;
+  HeapTypeInfo* supertype = nullptr;
+  HeapTypeInfo* descriptor = nullptr;
+  HeapTypeInfo* described = nullptr;
+  RecGroupInfo* recGroup = nullptr;
+  size_t recGroupIndex = 0;
+  HeapTypeKind kind;
+  union {
+    Signature signature;
+    Continuation continuation;
+    Struct struct_;
+    Array array;
+  };
+
+  HeapTypeInfo(Signature sig) : kind(HeapTypeKind::Func), signature(sig) {}
+  HeapTypeInfo(Continuation continuation)
+    : kind(HeapTypeKind::Cont), continuation(continuation) {}
+  HeapTypeInfo(const Struct& struct_)
+    : kind(HeapTypeKind::Struct), struct_(struct_) {}
+  HeapTypeInfo(Struct&& struct_)
+    : kind(HeapTypeKind::Struct), struct_(std::move(struct_)) {}
+  HeapTypeInfo(Array array) : kind(HeapTypeKind::Array), array(array) {}
+  ~HeapTypeInfo();
+
+  constexpr bool isSignature() const { return kind == HeapTypeKind::Func; }
+  constexpr bool isContinuation() const { return kind == HeapTypeKind::Cont; }
+  constexpr bool isStruct() const { return kind == HeapTypeKind::Struct; }
+  constexpr bool isArray() const { return kind == HeapTypeKind::Array; }
+  constexpr bool isData() const { return isStruct() || isArray(); }
+};
+
+inline HeapTypeInfo* getHeapTypeInfo(HeapType ht) {
+  assert(!ht.isBasic());
+  return (HeapTypeInfo*)ht.getID();
+}
+
+inline HeapTypeKind HeapType::getKind() const {
+  if (isBasic()) {
+    return HeapTypeKind::Basic;
+  }
+  return getHeapTypeInfo(*this)->kind;
+}
+
+inline bool HeapType::isFunction() const {
+  return isMaybeShared(func) || getKind() == HeapTypeKind::Func;
+}
+
+inline bool HeapType::isData() const {
+  auto kind = getKind();
+  return isMaybeShared(string) || kind == HeapTypeKind::Struct ||
+         kind == HeapTypeKind::Array;
+}
+
+inline bool HeapType::isSignature() const {
+  return getKind() == HeapTypeKind::Func;
+}
+
+inline bool HeapType::isContinuation() const {
+  return getKind() == HeapTypeKind::Cont;
+}
+
+inline bool HeapType::isStruct() const {
+  return getKind() == HeapTypeKind::Struct;
+}
+
+inline bool HeapType::isArray() const {
+  return getKind() == HeapTypeKind::Array;
+}
+
+inline bool HeapType::isOpen() const {
+  if (isBasic()) {
+    return false;
+  }
+  return getHeapTypeInfo(*this)->isOpen;
+}
+
+inline bool HeapType::isShared() const { return getShared() == Shared; }
+
+inline Shareability HeapType::getShared() const {
+  if (isBasic()) {
+    return (getID() & SharedMask) != 0 ? Shared : Unshared;
+  }
+  return getHeapTypeInfo(*this)->share;
+}
 
 inline bool HeapType::isBottom() const {
   if (isBasic()) {

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -38,52 +38,6 @@ namespace wasm {
 
 namespace {
 
-using RecGroupInfo = std::vector<HeapType>;
-
-struct HeapTypeInfo {
-  using type_t = HeapType;
-  // Used in assertions to ensure that temporary types don't leak into the
-  // global store.
-  bool isTemp = false;
-  bool isOpen = false;
-  Shareability share = Unshared;
-  // The supertype of this HeapType, if it exists.
-  HeapTypeInfo* supertype = nullptr;
-  // The descriptor of this HeapType, if it exists.
-  HeapTypeInfo* descriptor = nullptr;
-  // The HeapType described by this one, if it exists.
-  HeapTypeInfo* described = nullptr;
-  // The recursion group of this type or null if the recursion group is trivial
-  // (i.e. contains only this type).
-  RecGroupInfo* recGroup = nullptr;
-  size_t recGroupIndex = 0;
-  HeapTypeKind kind;
-  union {
-    Signature signature;
-    Continuation continuation;
-    Struct struct_;
-    Array array;
-  };
-
-  HeapTypeInfo(Signature sig) : kind(HeapTypeKind::Func), signature(sig) {}
-  HeapTypeInfo(Continuation continuation)
-    : kind(HeapTypeKind::Cont), continuation(continuation) {}
-  HeapTypeInfo(const Struct& struct_)
-    : kind(HeapTypeKind::Struct), struct_(struct_) {}
-  HeapTypeInfo(Struct&& struct_)
-    : kind(HeapTypeKind::Struct), struct_(std::move(struct_)) {}
-  HeapTypeInfo(Array array) : kind(HeapTypeKind::Array), array(array) {}
-  ~HeapTypeInfo();
-
-  constexpr bool isSignature() const { return kind == HeapTypeKind::Func; }
-  constexpr bool isContinuation() const { return kind == HeapTypeKind::Cont; }
-  constexpr bool isStruct() const { return kind == HeapTypeKind::Struct; }
-  constexpr bool isArray() const { return kind == HeapTypeKind::Array; }
-  constexpr bool isData() const { return isStruct() || isArray(); }
-};
-
-// Helper for finding the equirecursive least upper bound of two types.
-// Helper for printing types.
 struct TypePrinter {
   // The stream we are printing to.
   std::ostream& os;
@@ -209,11 +163,6 @@ public:
 
 namespace wasm {
 namespace {
-
-HeapTypeInfo* getHeapTypeInfo(HeapType ht) {
-  assert(!ht.isBasic());
-  return (HeapTypeInfo*)ht.getID();
-}
 
 HeapType asHeapType(std::unique_ptr<HeapTypeInfo>& info) {
   return HeapType(uintptr_t(info.get()));
@@ -879,29 +828,6 @@ HeapType::HeapType(Struct&& struct_) {
 HeapType::HeapType(Array array) {
   new (this)
     HeapType(globalRecGroupStore.insert(std::make_unique<HeapTypeInfo>(array)));
-}
-
-HeapTypeKind HeapType::getKind() const {
-  if (isBasic()) {
-    return HeapTypeKind::Basic;
-  }
-  return getHeapTypeInfo(*this)->kind;
-}
-
-bool HeapType::isOpen() const {
-  if (isBasic()) {
-    return false;
-  } else {
-    return getHeapTypeInfo(*this)->isOpen;
-  }
-}
-
-Shareability HeapType::getShared() const {
-  if (isBasic()) {
-    return (id & SharedMask) != 0 ? Shared : Unshared;
-  } else {
-    return getHeapTypeInfo(*this)->share;
-  }
 }
 
 bool HeapType::isCastable() {

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -38,6 +38,8 @@ namespace wasm {
 
 namespace {
 
+// Helper for finding the equirecursive least upper bound of two types.
+// Helper for printing types.
 struct TypePrinter {
   // The stream we are printing to.
   std::ostream& os;


### PR DESCRIPTION
This makes Unsubtyping over 2x faster on a large Dart testcase. This was the
slowest pass there by far. On `-Os` this saves 5.5% of total time.

I am not totally happy about moving this code into headers, but the benefit
is so big that I think it makes sense, unless we can think of an alternative? If
it helps, the key slowdowns this fixes are `HeapType::getShared()` took
33% of total runtime in Unsubtyping (!) and `HeapType::getKind()` took 6%.