### PR TITLE
Fuzzer: Fix subtyping of bottom types when fuzzing against JS

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2473,7 +2473,9 @@ void TranslateToFuzzReader::mutateJSBoundary() {
       // interestingHeapSubTypes on the top.
       if (newHeapType.isBottom()) {
         for (auto type : interestingHeapSubTypes[newHeapType.getTop()]) {
-          options.push_back(type);
+          if (HeapType::isSubType(type, oldHeapType)) {
+            options.push_back(type);
+          }
         }
         break;
       }

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2470,12 +2470,10 @@ void TranslateToFuzzReader::mutateJSBoundary() {
       options.push_back(newHeapType);
       // We cannot look at a bottom type's supers (there can be many, and the
       // getSuperType() API doesn't return them), but can use
-      // interestingHeapSubTypes on the top.
+      // interestingHeapSubTypes: any subtype of old is valid.
       if (newHeapType.isBottom()) {
-        for (auto type : interestingHeapSubTypes[newHeapType.getTop()]) {
-          if (HeapType::isSubType(type, oldHeapType)) {
-            options.push_back(type);
-          }
+        for (auto type : interestingHeapSubTypes[oldHeapType]) {
+          options.push_back(type);
         }
         break;
       }


### PR DESCRIPTION
maybeRefine should refine between old and new, and we were missing
a check for being refined enough when traversing all subtypes of bottom.
As a result, we could un-refine, which can break if a call exists.