### PR TITLE
Testing: Add verbose logging feature, and stop excessive spec logging

### DIFF
--- a/check.py
+++ b/check.py
@@ -189,7 +189,7 @@ def run_opt_test(wast, stdout=None):
     support.run_command(cmd, stdout=stdout)
 
 
-def check_expected(actual, expected, stdout=None):
+def check_expected(actual, expected):
     if expected and os.path.exists(expected):
         expected = open(expected).read()
         shared.verbose_log('       (using expected output)')
@@ -254,7 +254,7 @@ def run_one_spec_test(wast: Path, stdout=None):
             support.write_wast(split_name, module)
             run_opt_test(split_name, stdout=stdout)    # also that our optimizer doesn't break on it
 
-            result_wast_file = shared.binary_format_check(split_name, verify_final_result=False, base_name=base_name, stdout=stdout)
+            result_wast_file = shared.binary_format_check(split_name, verify_final_result=False, base_name=base_name)
             with open(result_wast_file) as f:
                 result_wast = f.read()
                 # add the asserts, and verify that the test still passes

--- a/check.py
+++ b/check.py
@@ -192,7 +192,7 @@ def run_opt_test(wast, stdout=None):
 def check_expected(actual, expected, stdout=None):
     if expected and os.path.exists(expected):
         expected = open(expected).read()
-        shared.verbose_log('       (using expected output)', file=stdout)
+        shared.verbose_log('       (using expected output)')
         actual = actual.strip()
         expected = expected.strip()
         if actual != expected:
@@ -229,7 +229,7 @@ def run_one_spec_test(wast: Path, stdout=None):
         actual = run_spec_test(str(wast), stdout=stdout)
     except Exception as e:
         if ('wasm-validator error' in str(e) or 'error: ' in str(e)) and '.fail.' in test_name:
-            shared.verbose_log('<< test failed as expected >>', file=stdout)
+            shared.verbose_log('<< test failed as expected >>')
             return  # don't try all the binary format stuff TODO
         else:
             shared.fail_with_error(str(e))
@@ -249,7 +249,7 @@ def run_one_spec_test(wast: Path, stdout=None):
             if not module:
                 # Skip any initial assertions that don't have a module
                 continue
-            shared.verbose_log(f'        testing split module {i}', file=stdout)
+            shared.verbose_log(f'        testing split module {i}')
             split_name = base_name + f'_split{i}.wast'
             support.write_wast(split_name, module)
             run_opt_test(split_name, stdout=stdout)    # also that our optimizer doesn't break on it

--- a/check.py
+++ b/check.py
@@ -191,7 +191,7 @@ def run_opt_test(wast, stdout=None):
 def check_expected(actual, expected, stdout=None):
     if expected and os.path.exists(expected):
         expected = open(expected).read()
-        print('       (using expected output)', file=stdout)
+        shared.verbose_log('       (using expected output)', file=stdout)
         actual = actual.strip()
         expected = expected.strip()
         if actual != expected:
@@ -228,7 +228,7 @@ def run_one_spec_test(wast: Path, stdout=None):
         actual = run_spec_test(str(wast), stdout=stdout)
     except Exception as e:
         if ('wasm-validator error' in str(e) or 'error: ' in str(e)) and '.fail.' in test_name:
-            print('<< test failed as expected >>', file=stdout)
+            shared.verbose_log('<< test failed as expected >>', file=stdout)
             return  # don't try all the binary format stuff TODO
         else:
             shared.fail_with_error(str(e))
@@ -248,7 +248,7 @@ def run_one_spec_test(wast: Path, stdout=None):
             if not module:
                 # Skip any initial assertions that don't have a module
                 continue
-            print(f'        testing split module {i}', file=stdout)
+            shared.verbose_log(f'        testing split module {i}', file=stdout)
             split_name = base_name + f'_split{i}.wast'
             support.write_wast(split_name, module)
             run_opt_test(split_name, stdout=stdout)    # also that our optimizer doesn't break on it

--- a/check.py
+++ b/check.py
@@ -235,7 +235,7 @@ def run_one_spec_test(wast: Path, stdout=None):
             shared.fail_with_error(str(e))
             raise
 
-    check_expected(actual, expected)
+    check_expected(actual, expected, stdout=stdout)
 
     if not is_splittable(wast):
         return
@@ -262,7 +262,7 @@ def run_one_spec_test(wast: Path, stdout=None):
 
     # compare all the outputs to the expected output
     actual = run_spec_test(transformed_path, stdout=stdout)
-    check_expected(actual, os.path.join(shared.get_test_dir('spec'), 'expected-output', test_name + '.log'))
+    check_expected(actual, os.path.join(shared.get_test_dir('spec'), 'expected-output', test_name + '.log'), stdout=stdout)
 
 
 def run_spec_test_with_wrapped_stdout(wast: Path):

--- a/check.py
+++ b/check.py
@@ -189,7 +189,7 @@ def run_opt_test(wast, stdout=None):
     support.run_command(cmd, stdout=stdout)
 
 
-def check_expected(actual, expected):
+def check_expected(actual, expected, stdout=None):
     if expected and os.path.exists(expected):
         expected = open(expected).read()
         shared.verbose_log('       (using expected output)')
@@ -254,7 +254,7 @@ def run_one_spec_test(wast: Path, stdout=None):
             support.write_wast(split_name, module)
             run_opt_test(split_name, stdout=stdout)    # also that our optimizer doesn't break on it
 
-            result_wast_file = shared.binary_format_check(split_name, verify_final_result=False, base_name=base_name)
+            result_wast_file = shared.binary_format_check(split_name, verify_final_result=False, base_name=base_name, stdout=stdout)
             with open(result_wast_file) as f:
                 result_wast = f.read()
                 # add the asserts, and verify that the test still passes

--- a/check.py
+++ b/check.py
@@ -235,7 +235,7 @@ def run_one_spec_test(wast: Path, stdout=None):
             shared.fail_with_error(str(e))
             raise
 
-    check_expected(actual, expected, stdout=stdout)
+    check_expected(actual, expected)
 
     if not is_splittable(wast):
         return
@@ -262,7 +262,7 @@ def run_one_spec_test(wast: Path, stdout=None):
 
     # compare all the outputs to the expected output
     actual = run_spec_test(transformed_path, stdout=stdout)
-    check_expected(actual, os.path.join(shared.get_test_dir('spec'), 'expected-output', test_name + '.log'), stdout=stdout)
+    check_expected(actual, os.path.join(shared.get_test_dir('spec'), 'expected-output', test_name + '.log'))
 
 
 def run_spec_test_with_wrapped_stdout(wast: Path):

--- a/check.py
+++ b/check.py
@@ -192,7 +192,7 @@ def run_opt_test(wast, stdout=None):
 def check_expected(actual, expected, stdout=None):
     if expected and os.path.exists(expected):
         expected = open(expected).read()
-        shared.verbose_log('       (using expected output)')
+        shared.verbose_log('       (using expected output)', file=stdout)
         actual = actual.strip()
         expected = expected.strip()
         if actual != expected:
@@ -229,7 +229,7 @@ def run_one_spec_test(wast: Path, stdout=None):
         actual = run_spec_test(str(wast), stdout=stdout)
     except Exception as e:
         if ('wasm-validator error' in str(e) or 'error: ' in str(e)) and '.fail.' in test_name:
-            shared.verbose_log('<< test failed as expected >>')
+            shared.verbose_log('<< test failed as expected >>', file=stdout)
             return  # don't try all the binary format stuff TODO
         else:
             shared.fail_with_error(str(e))
@@ -249,7 +249,7 @@ def run_one_spec_test(wast: Path, stdout=None):
             if not module:
                 # Skip any initial assertions that don't have a module
                 continue
-            shared.verbose_log(f'        testing split module {i}')
+            shared.verbose_log(f'        testing split module {i}', file=stdout)
             split_name = base_name + f'_split{i}.wast'
             support.write_wast(split_name, module)
             run_opt_test(split_name, stdout=stdout)    # also that our optimizer doesn't break on it

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -480,16 +480,16 @@ def binary_format_check(wast, verify_final_result=True, base_name=None, stdout=N
     as_file = f"{base_name}-a.wasm" if base_name is not None else "a.wasm"
     disassembled_file = f"{base_name}-ab.wast" if base_name is not None else "ab.wast"
 
-    verbose_log('         (binary format check)', file=stdout)
+    verbose_log('         (binary format check)')
     cmd = WASM_AS + [wast, '-o', as_file, '-all', '-g']
-    verbose_log('            ', ' '.join(cmd), file=stdout)
+    verbose_log('            ', ' '.join(cmd))
     if os.path.exists(as_file):
         os.unlink(as_file)
     subprocess.check_call(cmd, stdout=subprocess.PIPE)
     assert os.path.exists(as_file)
 
     cmd = WASM_DIS + [as_file, '-o', disassembled_file, '-all']
-    verbose_log('            ', ' '.join(cmd), file=stdout)
+    verbose_log('            ', ' '.join(cmd))
     if os.path.exists(disassembled_file):
         os.unlink(disassembled_file)
     subprocess.check_call(cmd, stdout=subprocess.PIPE)
@@ -497,7 +497,7 @@ def binary_format_check(wast, verify_final_result=True, base_name=None, stdout=N
 
     # make sure it is a valid wast
     cmd = WASM_OPT + [disassembled_file, '-all', '-q']
-    verbose_log('            ', ' '.join(cmd), file=stdout)
+    verbose_log('            ', ' '.join(cmd))
     subprocess.check_call(cmd, stdout=subprocess.PIPE)
 
     if verify_final_result:

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -97,6 +97,9 @@ def parse_args(args):
         action='store_false', default=True,
         help='Disables the automatic selection of important initial contents '
              'in fuzzer.')
+    parser.add_argument(
+        '--verbose', action='store_true', default=False,
+        help='Enables verbose logging.')
 
     return parser.parse_args(args)
 
@@ -112,6 +115,11 @@ warnings = []
 def warn(text):
     warnings.append(text)
     print('warning:', text, file=sys.stderr)
+
+
+def verbose_log(*args, **kwargs):
+    if options.verbose:
+        print(*args, **kwargs)
 
 
 # setup
@@ -468,16 +476,16 @@ def binary_format_check(wast, verify_final_result=True, base_name=None, stdout=N
     as_file = f"{base_name}-a.wasm" if base_name is not None else "a.wasm"
     disassembled_file = f"{base_name}-ab.wast" if base_name is not None else "ab.wast"
 
-    print('         (binary format check)', file=stdout)
+    verbose_log('         (binary format check)', file=stdout)
     cmd = WASM_AS + [wast, '-o', as_file, '-all', '-g']
-    print('            ', ' '.join(cmd), file=stdout)
+    verbose_log('            ', ' '.join(cmd), file=stdout)
     if os.path.exists(as_file):
         os.unlink(as_file)
     subprocess.check_call(cmd, stdout=subprocess.PIPE)
     assert os.path.exists(as_file)
 
     cmd = WASM_DIS + [as_file, '-o', disassembled_file, '-all']
-    print('            ', ' '.join(cmd), file=stdout)
+    verbose_log('            ', ' '.join(cmd), file=stdout)
     if os.path.exists(disassembled_file):
         os.unlink(disassembled_file)
     subprocess.check_call(cmd, stdout=subprocess.PIPE)
@@ -485,7 +493,7 @@ def binary_format_check(wast, verify_final_result=True, base_name=None, stdout=N
 
     # make sure it is a valid wast
     cmd = WASM_OPT + [disassembled_file, '-all', '-q']
-    print('            ', ' '.join(cmd), file=stdout)
+    verbose_log('            ', ' '.join(cmd), file=stdout)
     subprocess.check_call(cmd, stdout=subprocess.PIPE)
 
     if verify_final_result:

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -120,6 +120,7 @@ def warn(text):
 def print_heading(msg):
     print(f'[ {msg} ]')
 
+
 def verbose_log(*args, **kwargs):
     if options.verbose:
         print(*args, **kwargs)

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -474,7 +474,7 @@ options.spec_tests = [t for t in options.spec_tests if _can_run_spec_test(t)]
 # check utilities
 
 
-def binary_format_check(wast, verify_final_result=True, base_name=None, stdout=None):
+def binary_format_check(wast, verify_final_result=True, base_name=None):
     # checks we can convert the wast to binary and back
 
     as_file = f"{base_name}-a.wasm" if base_name is not None else "a.wasm"

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -474,7 +474,7 @@ options.spec_tests = [t for t in options.spec_tests if _can_run_spec_test(t)]
 # check utilities
 
 
-def binary_format_check(wast, verify_final_result=True, base_name=None):
+def binary_format_check(wast, verify_final_result=True, base_name=None, stdout=None):
     # checks we can convert the wast to binary and back
 
     as_file = f"{base_name}-a.wasm" if base_name is not None else "a.wasm"

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -480,16 +480,16 @@ def binary_format_check(wast, verify_final_result=True, base_name=None, stdout=N
     as_file = f"{base_name}-a.wasm" if base_name is not None else "a.wasm"
     disassembled_file = f"{base_name}-ab.wast" if base_name is not None else "ab.wast"
 
-    verbose_log('         (binary format check)')
+    verbose_log('         (binary format check)', file=stdout)
     cmd = WASM_AS + [wast, '-o', as_file, '-all', '-g']
-    verbose_log('            ', ' '.join(cmd))
+    verbose_log('            ', ' '.join(cmd), file=stdout)
     if os.path.exists(as_file):
         os.unlink(as_file)
     subprocess.check_call(cmd, stdout=subprocess.PIPE)
     assert os.path.exists(as_file)
 
     cmd = WASM_DIS + [as_file, '-o', disassembled_file, '-all']
-    verbose_log('            ', ' '.join(cmd))
+    verbose_log('            ', ' '.join(cmd), file=stdout)
     if os.path.exists(disassembled_file):
         os.unlink(disassembled_file)
     subprocess.check_call(cmd, stdout=subprocess.PIPE)
@@ -497,7 +497,7 @@ def binary_format_check(wast, verify_final_result=True, base_name=None, stdout=N
 
     # make sure it is a valid wast
     cmd = WASM_OPT + [disassembled_file, '-all', '-q']
-    verbose_log('            ', ' '.join(cmd))
+    verbose_log('            ', ' '.join(cmd), file=stdout)
     subprocess.check_call(cmd, stdout=subprocess.PIPE)
 
     if verify_final_result:

--- a/scripts/test/support.py
+++ b/scripts/test/support.py
@@ -16,6 +16,8 @@ import io
 import re
 import subprocess
 
+from . import shared
+
 QUOTED = re.compile(r'\(module\s*(\$\S*)?\s+(quote|binary)')
 
 MODULE_DEFINITION_OR_INSTANCE = re.compile(r'(?m)\(module\s+(instance|definition)')
@@ -147,7 +149,7 @@ def run_command(cmd, expected_status=0, stdout=None, stderr=None,
         assert stderr == subprocess.PIPE or stderr is None, \
             "Can't redirect stderr if using expected_err"
         stderr = subprocess.PIPE
-    print('executing: ', ' '.join(cmd), file=stdout)
+    shared.verbose_log('executing: ', ' '.join(cmd), file=stdout)
 
     out, err, code = _subprocess_run(cmd, stdout=subprocess.PIPE, stderr=stderr, encoding='UTF-8')
 

--- a/scripts/test/support.py
+++ b/scripts/test/support.py
@@ -16,8 +16,6 @@ import io
 import re
 import subprocess
 
-from . import shared
-
 QUOTED = re.compile(r'\(module\s*(\$\S*)?\s+(quote|binary)')
 
 MODULE_DEFINITION_OR_INSTANCE = re.compile(r'(?m)\(module\s+(instance|definition)')
@@ -149,7 +147,7 @@ def run_command(cmd, expected_status=0, stdout=None, stderr=None,
         assert stderr == subprocess.PIPE or stderr is None, \
             "Can't redirect stderr if using expected_err"
         stderr = subprocess.PIPE
-    shared.verbose_log('executing: ', ' '.join(cmd), file=stdout)
+    print('executing: ', ' '.join(cmd), file=stdout)
 
     out, err, code = _subprocess_run(cmd, stdout=subprocess.PIPE, stderr=stderr, encoding='UTF-8')
 


### PR DESCRIPTION
New logging:

```
$ ./check.py spec
[ checking wasm-shell spec testcases... ]
Running with 14 workers
.. address-offset-range.fail.wast
.. binary.wast
.. break-drop.wast
.. atomics.wast
```

Old logging, available with `--verbose`:

```
$ ./check.py spec --verbose
[ checking wasm-shell spec testcases... ]
Running with 14 workers
.. address-offset-range.fail.wast
executing:  /home/azakai/Dev/2-binaryen/bin/wasm-shell /home/azakai/Dev/2-binaryen/test/spec/address-offset-range.fail.wast
<< test failed as expected >>
.. binary.wast
executing:  /home/azakai/Dev/2-binaryen/bin/wasm-shell /home/azakai/Dev/2-binaryen/test/spec/binary.wast
executing:  /home/azakai/Dev/2-binaryen/bin/wasm-shell test-spec-binary.transformed
.. break-drop.wast
executing:  /home/azakai/Dev/2-binaryen/bin/wasm-shell /home/azakai/Dev/2-binaryen/test/spec/break-drop.wast
        testing split module 0
executing:  /home/azakai/Dev/2-binaryen/bin/wasm-opt test-spec-break-drop_split0.wast -O -all -q
         (binary format check)
             /home/azakai/Dev/2-binaryen/bin/wasm-as test-spec-break-drop_split0.wast -o test-spec-break-drop-a.wasm -all -g
             /home/azakai/Dev/2-binaryen/bin/wasm-dis test-spec-break-drop-a.wasm -o test-spec-break-drop-ab.wast -all
             /home/azakai/Dev/2-binaryen/bin/wasm-opt test-spec-break-drop-ab.wast -all -q
executing:  /home/azakai/Dev/2-binaryen/bin/wasm-shell test-spec-break-drop.transformed
.. bulk-array.wast
executing:  /home/azakai/Dev/2-binaryen/bin/wasm-shell /home/azakai/Dev/2-binaryen/test/spec/bulk-array.wast
        testing split module 0
executing:  /home/azakai/Dev/2-binaryen/bin/wasm-opt test-spec-bulk-array_split0.wast -O -all -q
         (binary format check)
             /home/azakai/Dev/2-binaryen/bin/wasm-as test-spec-bulk-array_split0.wast -o test-spec-bulk-array-a.wasm -all -g
             /home/azakai/Dev/2-binaryen/bin/wasm-dis test-spec-bulk-array-a.wasm -o test-spec-bulk-array-ab.wast -all
             /home/azakai/Dev/2-binaryen/bin/wasm-opt test-spec-bulk-array-ab.wast -all -q
executing:  /home/azakai/Dev/2-binaryen/bin/wasm-shell test-spec-bulk-array.transformed
```