### PR TITLE
[wasm-split] Move shareImportableItems (NFC)

### DIFF
--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -558,310 +558,6 @@ static void walkSegments(Walker& walker, Module* module) {
   }
 }
 
-void ModuleSplitter::indirectReferencesToSecondaryFunctions() {
-  // Turn references to secondary functions into references to thunks that
-  // perform a direct call to the original referent. The direct calls in the
-  // thunks will be handled like all other cross-module calls later, in
-  // |indirectCallsToSecondaryFunctions|.
-  struct Gatherer : public PostWalker<Gatherer> {
-    ModuleSplitter& parent;
-
-    Gatherer(ModuleSplitter& parent) : parent(parent) {}
-
-    // Collect RefFuncs in a map from the function name to all RefFuncs that
-    // refer to it. We only collect this for secondary funcs.
-    InsertOrderedMap<Name, std::vector<RefFunc*>> map;
-
-    void visitRefFunc(RefFunc* curr) {
-      Module* currModule = getModule();
-      // Add ref.func to the map when
-      // 1. ref.func's target func is in one of the secondary modules and
-      // 2. the current module is a different module (either the primary module
-      //    or a different secondary module)
-      if (parent.allSecondaryFuncs.contains(curr->func) &&
-          (currModule == &parent.primary ||
-           parent.secondaries.at(parent.funcToSecondaryIndex.at(curr->func))
-               .get() != currModule)) {
-        map[curr->func].push_back(curr);
-      }
-    }
-  } gatherer(*this);
-  // We shouldn't use collector.walkModuleCode here, because we don't want to
-  // walk global initializers. At this point, all globals are still in the
-  // primary module, so if we walk global initializers here, it will create
-  // unnecessary trampolines.
-  //
-  // For example, we have (global $a funcref (ref.func $foo)), and $foo was
-  // split into a secondary module. Because $a is at this point still in the
-  // primary module, $foo will be considered to exist in a different module, so
-  // this will create a trampoline for $foo. But it is possible that later we
-  // find out $a is exclusively used by that secondary module and move $a there.
-  // In that case, $a can just reference $foo locally, but if we scan global
-  // initializers here, we would have created an unnecessary trampoline for
-  // $foo.
-  walkSegments(gatherer, &primary);
-  for (auto& curr : primary.functions) {
-    if (!curr->imported()) {
-      gatherer.walkFunction(curr.get());
-    }
-  }
-  for (auto& secondaryPtr : secondaries) {
-    gatherer.walkModule(secondaryPtr.get());
-  }
-
-  // Ignore references to secondary functions that occur in the active segment
-  // that will contain the imported placeholders. Indirect calls to table slots
-  // initialized by that segment will already go to the right place once the
-  // secondary module has been loaded and the table has been patched.
-  std::unordered_set<RefFunc*> ignore;
-  if (tableManager.activeSegment) {
-    for (auto* expr : tableManager.activeSegment->data) {
-      if (auto* ref = expr->dynCast<RefFunc>()) {
-        ignore.insert(ref);
-      }
-    }
-  }
-
-  // Fix up what we found: Generate trampolines as described earlier, and apply
-  // them.
-  Builder builder(primary);
-  // Generate the new trampoline function and add it to the module.
-  for (auto& [name, refFuncs] : gatherer.map) {
-    // Find the relevant (non-ignored) RefFuncs. If there are none, we can skip
-    // creating a thunk entirely.
-    std::vector<RefFunc*> relevantRefFuncs;
-    for (auto* refFunc : refFuncs) {
-      assert(refFunc->func == name);
-      if (!ignore.contains(refFunc)) {
-        relevantRefFuncs.push_back(refFunc);
-      }
-    }
-    if (relevantRefFuncs.empty()) {
-      continue;
-    }
-
-    Name trampoline = getTrampoline(name);
-    // Update RefFuncs to refer to it.
-    for (auto* refFunc : relevantRefFuncs) {
-      refFunc->func = trampoline;
-    }
-  }
-}
-
-void ModuleSplitter::indirectCallsToSecondaryFunctions() {
-  // Update direct calls of secondary functions to be indirect calls of their
-  // corresponding table indices instead.
-  struct CallIndirector : public PostWalker<CallIndirector> {
-    ModuleSplitter& parent;
-    CallIndirector(ModuleSplitter& parent) : parent(parent) {}
-    void visitCall(Call* curr) {
-      // Return if the call's target is not in one of the secondary module.
-      if (!parent.allSecondaryFuncs.contains(curr->target)) {
-        return;
-      }
-      // Return if the current module is the same module as the call's target,
-      // because we don't need a call_indirect within the same module.
-      Module* currModule = getModule();
-      if (currModule != &parent.primary &&
-          parent.secondaries.at(parent.funcToSecondaryIndex.at(curr->target))
-              .get() == currModule) {
-        return;
-      }
-
-      Builder builder(*getModule());
-      Index secIndex = parent.funcToSecondaryIndex.at(curr->target);
-      auto* func = parent.secondaries.at(secIndex)->getFunction(curr->target);
-      auto tableSlot =
-        parent.tableManager.getSlot(curr->target, func->type.getHeapType());
-
-      replaceCurrent(
-        builder.makeCallIndirect(tableSlot.tableName,
-                                 tableSlot.makeExpr(parent.primary),
-                                 curr->operands,
-                                 func->type.getHeapType(),
-                                 curr->isReturn));
-    }
-  };
-  CallIndirector callIndirector(*this);
-  callIndirector.walkModule(&primary);
-  for (auto& secondaryPtr : secondaries) {
-    callIndirector.walkModule(secondaryPtr.get());
-  }
-}
-
-void ModuleSplitter::exportImportCalledPrimaryFunctions() {
-  // Find primary functions called/referred to from the secondary modules.
-  using CalledPrimaryToModules = std::map<Name, std::set<Module*>>;
-  for (auto& secondaryPtr : secondaries) {
-    Module* secondary = secondaryPtr.get();
-    ModuleUtils::ParallelFunctionAnalysis<CalledPrimaryToModules> callCollector(
-      *secondary,
-      [&](Function* func, CalledPrimaryToModules& calledPrimaryToModules) {
-        struct CallCollector : PostWalker<CallCollector> {
-          const std::unordered_set<Name>& primaryFuncs;
-          CalledPrimaryToModules& calledPrimaryToModules;
-          CallCollector(const std::unordered_set<Name>& primaryFuncs,
-                        CalledPrimaryToModules& calledPrimaryToModules)
-            : primaryFuncs(primaryFuncs),
-              calledPrimaryToModules(calledPrimaryToModules) {}
-          void visitCall(Call* curr) {
-            if (primaryFuncs.contains(curr->target)) {
-              calledPrimaryToModules[curr->target].insert(getModule());
-            }
-          }
-          void visitRefFunc(RefFunc* curr) {
-            if (primaryFuncs.contains(curr->func)) {
-              calledPrimaryToModules[curr->func].insert(getModule());
-            }
-          }
-        };
-        CallCollector(primaryFuncs, calledPrimaryToModules)
-          .walkFunctionInModule(func, secondary);
-      });
-
-    CalledPrimaryToModules calledPrimaryToModules;
-    for (auto& [_, map] : callCollector.map) {
-      calledPrimaryToModules.merge(map);
-    }
-
-    // Ensure each called primary function is exported and imported
-    for (auto& [func, modules] : calledPrimaryToModules) {
-      exportImportFunction(func, modules);
-    }
-  }
-}
-
-void ModuleSplitter::setupTablePatching() {
-  if (!tableManager.activeTable) {
-    return;
-  }
-
-  std::map<Module*, std::map<Index, Function*>> moduleToReplacedElems;
-  // Replace table references to secondary functions with an imported
-  // placeholder that encodes the table index in its name:
-  // `importNamespace`.`index`.
-  forEachElement(
-    primary, [&](Name table, Name, Index index, Expression*& elem) {
-      auto* ref = elem->dynCast<RefFunc>();
-      if (!ref) {
-        return;
-      }
-      if (!allSecondaryFuncs.contains(ref->func)) {
-        return;
-      }
-      assert(table == tableManager.activeTable->name);
-
-      placeholderMap[table][index] = ref->func;
-      Index secondaryIndex = funcToSecondaryIndex.at(ref->func);
-      Module& secondary = *secondaries.at(secondaryIndex);
-      Name secondaryName = config.secondaryNames.at(secondaryIndex);
-      auto* secondaryFunc = secondary.getFunction(ref->func);
-      moduleToReplacedElems[&secondary][index] = secondaryFunc;
-      if (!config.usePlaceholders) {
-        // TODO: This can create active element segments with lots of nulls. We
-        // should optimize them like we do data segments with zeros.
-        elem = Builder(primary).makeRefNull(HeapType::nofunc);
-        return;
-      }
-      auto placeholder = std::make_unique<Function>();
-      placeholder->module = config.placeholderNamespacePrefix.toString() + "." +
-                            secondaryName.toString();
-      placeholder->base = std::to_string(index);
-      placeholder->name = Names::getValidFunctionName(
-        primary, std::string("placeholder_") + placeholder->base.toString());
-      placeholder->hasExplicitName = true;
-      placeholder->type = secondaryFunc->type.with(Inexact);
-      elem = Builder(primary).makeRefFunc(placeholder->name, placeholder->type);
-      primary.addFunction(std::move(placeholder));
-    });
-
-  if (moduleToReplacedElems.size() == 0) {
-    // No placeholders to patch out of the table
-    return;
-  }
-
-  for (auto& [secondaryPtr, replacedElems] : moduleToReplacedElems) {
-    Module& secondary = *secondaryPtr;
-    auto secondaryTable =
-      ModuleUtils::copyTable(tableManager.activeTable, secondary);
-
-    if (tableManager.activeBase.global.size()) {
-      assert(tableManager.activeTableSegments.size() == 1 &&
-             "Unexpected number of segments with non-const base");
-      assert(secondary.tables.size() == 1 && secondary.elementSegments.empty());
-      // Since addition is not currently allowed in initializer expressions, we
-      // need to start the new secondary segment where the primary segment
-      // starts. The secondary segment will contain the same primary functions
-      // as the primary module except in positions where it needs to overwrite a
-      // placeholder function. All primary functions in the table therefore need
-      // to be imported into the second module. TODO: use better strategies
-      // here, such as using ref.func in the start function or standardizing
-      // addition in initializer expressions.
-      ElementSegment* primarySeg = tableManager.activeTableSegments.front();
-      std::vector<Expression*> secondaryElems;
-      secondaryElems.reserve(primarySeg->data.size());
-
-      // Copy functions from the primary segment to the secondary segment,
-      // replacing placeholders and creating new exports and imports as
-      // necessary.
-      auto replacement = replacedElems.begin();
-      for (Index i = 0;
-           i < primarySeg->data.size() && replacement != replacedElems.end();
-           ++i) {
-        if (replacement->first == i) {
-          // primarySeg->data[i] is a placeholder, so use the secondary
-          // function.
-          auto* func = replacement->second;
-          auto* ref = Builder(secondary).makeRefFunc(func->name, func->type);
-          secondaryElems.push_back(ref);
-          ++replacement;
-        } else if (auto* get = primarySeg->data[i]->dynCast<RefFunc>()) {
-          exportImportFunction(get->func, {&secondary});
-          auto* copied =
-            ExpressionManipulator::copy(primarySeg->data[i], secondary);
-          secondaryElems.push_back(copied);
-        }
-      }
-
-      auto offset = ExpressionManipulator::copy(primarySeg->offset, secondary);
-      auto secondarySeg = std::make_unique<ElementSegment>(
-        secondaryTable->name, offset, secondaryTable->type, secondaryElems);
-      secondarySeg->setName(primarySeg->name, primarySeg->hasExplicitName);
-      secondary.addElementSegment(std::move(secondarySeg));
-      return;
-    }
-
-    // Create active table segments in the secondary module to patch in the
-    // original functions when it is instantiated.
-    Index currBase = replacedElems.begin()->first;
-    std::vector<Expression*> currData;
-    auto finishSegment = [&]() {
-      auto* offset = Builder(secondary).makeConst(
-        Literal::makeFromInt32(currBase, secondaryTable->addressType));
-      auto secondarySeg = std::make_unique<ElementSegment>(
-        secondaryTable->name, offset, secondaryTable->type, currData);
-      Name name = Names::getValidElementSegmentName(
-        secondary, Name::fromInt(secondary.elementSegments.size()));
-      secondarySeg->setName(name, false);
-      secondary.addElementSegment(std::move(secondarySeg));
-    };
-    for (auto curr = replacedElems.begin(); curr != replacedElems.end();
-         ++curr) {
-      if (curr->first != currBase + currData.size()) {
-        finishSegment();
-        currBase = curr->first;
-        currData.clear();
-      }
-      auto* func = curr->second;
-      currData.push_back(
-        Builder(secondary).makeRefFunc(func->name, func->type));
-    }
-    if (currData.size()) {
-      finishSegment();
-    }
-  }
-}
-
 void ModuleSplitter::shareImportableItems() {
   // Map internal names to (one of) their corresponding export names. Don't
   // consider functions because they have already been imported and exported as
@@ -1219,6 +915,310 @@ void ModuleSplitter::shareImportableItems() {
   }
   for (auto& name : tagsToRemove) {
     primary.removeTag(name);
+  }
+}
+
+void ModuleSplitter::indirectReferencesToSecondaryFunctions() {
+  // Turn references to secondary functions into references to thunks that
+  // perform a direct call to the original referent. The direct calls in the
+  // thunks will be handled like all other cross-module calls later, in
+  // |indirectCallsToSecondaryFunctions|.
+  struct Gatherer : public PostWalker<Gatherer> {
+    ModuleSplitter& parent;
+
+    Gatherer(ModuleSplitter& parent) : parent(parent) {}
+
+    // Collect RefFuncs in a map from the function name to all RefFuncs that
+    // refer to it. We only collect this for secondary funcs.
+    InsertOrderedMap<Name, std::vector<RefFunc*>> map;
+
+    void visitRefFunc(RefFunc* curr) {
+      Module* currModule = getModule();
+      // Add ref.func to the map when
+      // 1. ref.func's target func is in one of the secondary modules and
+      // 2. the current module is a different module (either the primary module
+      //    or a different secondary module)
+      if (parent.allSecondaryFuncs.contains(curr->func) &&
+          (currModule == &parent.primary ||
+           parent.secondaries.at(parent.funcToSecondaryIndex.at(curr->func))
+               .get() != currModule)) {
+        map[curr->func].push_back(curr);
+      }
+    }
+  } gatherer(*this);
+  // We shouldn't use collector.walkModuleCode here, because we don't want to
+  // walk global initializers. At this point, all globals are still in the
+  // primary module, so if we walk global initializers here, it will create
+  // unnecessary trampolines.
+  //
+  // For example, we have (global $a funcref (ref.func $foo)), and $foo was
+  // split into a secondary module. Because $a is at this point still in the
+  // primary module, $foo will be considered to exist in a different module, so
+  // this will create a trampoline for $foo. But it is possible that later we
+  // find out $a is exclusively used by that secondary module and move $a there.
+  // In that case, $a can just reference $foo locally, but if we scan global
+  // initializers here, we would have created an unnecessary trampoline for
+  // $foo.
+  walkSegments(gatherer, &primary);
+  for (auto& curr : primary.functions) {
+    if (!curr->imported()) {
+      gatherer.walkFunction(curr.get());
+    }
+  }
+  for (auto& secondaryPtr : secondaries) {
+    gatherer.walkModule(secondaryPtr.get());
+  }
+
+  // Ignore references to secondary functions that occur in the active segment
+  // that will contain the imported placeholders. Indirect calls to table slots
+  // initialized by that segment will already go to the right place once the
+  // secondary module has been loaded and the table has been patched.
+  std::unordered_set<RefFunc*> ignore;
+  if (tableManager.activeSegment) {
+    for (auto* expr : tableManager.activeSegment->data) {
+      if (auto* ref = expr->dynCast<RefFunc>()) {
+        ignore.insert(ref);
+      }
+    }
+  }
+
+  // Fix up what we found: Generate trampolines as described earlier, and apply
+  // them.
+  Builder builder(primary);
+  // Generate the new trampoline function and add it to the module.
+  for (auto& [name, refFuncs] : gatherer.map) {
+    // Find the relevant (non-ignored) RefFuncs. If there are none, we can skip
+    // creating a thunk entirely.
+    std::vector<RefFunc*> relevantRefFuncs;
+    for (auto* refFunc : refFuncs) {
+      assert(refFunc->func == name);
+      if (!ignore.contains(refFunc)) {
+        relevantRefFuncs.push_back(refFunc);
+      }
+    }
+    if (relevantRefFuncs.empty()) {
+      continue;
+    }
+
+    Name trampoline = getTrampoline(name);
+    // Update RefFuncs to refer to it.
+    for (auto* refFunc : relevantRefFuncs) {
+      refFunc->func = trampoline;
+    }
+  }
+}
+
+void ModuleSplitter::indirectCallsToSecondaryFunctions() {
+  // Update direct calls of secondary functions to be indirect calls of their
+  // corresponding table indices instead.
+  struct CallIndirector : public PostWalker<CallIndirector> {
+    ModuleSplitter& parent;
+    CallIndirector(ModuleSplitter& parent) : parent(parent) {}
+    void visitCall(Call* curr) {
+      // Return if the call's target is not in one of the secondary module.
+      if (!parent.allSecondaryFuncs.contains(curr->target)) {
+        return;
+      }
+      // Return if the current module is the same module as the call's target,
+      // because we don't need a call_indirect within the same module.
+      Module* currModule = getModule();
+      if (currModule != &parent.primary &&
+          parent.secondaries.at(parent.funcToSecondaryIndex.at(curr->target))
+              .get() == currModule) {
+        return;
+      }
+
+      Builder builder(*getModule());
+      Index secIndex = parent.funcToSecondaryIndex.at(curr->target);
+      auto* func = parent.secondaries.at(secIndex)->getFunction(curr->target);
+      auto tableSlot =
+        parent.tableManager.getSlot(curr->target, func->type.getHeapType());
+
+      replaceCurrent(
+        builder.makeCallIndirect(tableSlot.tableName,
+                                 tableSlot.makeExpr(parent.primary),
+                                 curr->operands,
+                                 func->type.getHeapType(),
+                                 curr->isReturn));
+    }
+  };
+  CallIndirector callIndirector(*this);
+  callIndirector.walkModule(&primary);
+  for (auto& secondaryPtr : secondaries) {
+    callIndirector.walkModule(secondaryPtr.get());
+  }
+}
+
+void ModuleSplitter::exportImportCalledPrimaryFunctions() {
+  // Find primary functions called/referred to from the secondary modules.
+  using CalledPrimaryToModules = std::map<Name, std::set<Module*>>;
+  for (auto& secondaryPtr : secondaries) {
+    Module* secondary = secondaryPtr.get();
+    ModuleUtils::ParallelFunctionAnalysis<CalledPrimaryToModules> callCollector(
+      *secondary,
+      [&](Function* func, CalledPrimaryToModules& calledPrimaryToModules) {
+        struct CallCollector : PostWalker<CallCollector> {
+          const std::unordered_set<Name>& primaryFuncs;
+          CalledPrimaryToModules& calledPrimaryToModules;
+          CallCollector(const std::unordered_set<Name>& primaryFuncs,
+                        CalledPrimaryToModules& calledPrimaryToModules)
+            : primaryFuncs(primaryFuncs),
+              calledPrimaryToModules(calledPrimaryToModules) {}
+          void visitCall(Call* curr) {
+            if (primaryFuncs.contains(curr->target)) {
+              calledPrimaryToModules[curr->target].insert(getModule());
+            }
+          }
+          void visitRefFunc(RefFunc* curr) {
+            if (primaryFuncs.contains(curr->func)) {
+              calledPrimaryToModules[curr->func].insert(getModule());
+            }
+          }
+        };
+        CallCollector(primaryFuncs, calledPrimaryToModules)
+          .walkFunctionInModule(func, secondary);
+      });
+
+    CalledPrimaryToModules calledPrimaryToModules;
+    for (auto& [_, map] : callCollector.map) {
+      calledPrimaryToModules.merge(map);
+    }
+
+    // Ensure each called primary function is exported and imported
+    for (auto& [func, modules] : calledPrimaryToModules) {
+      exportImportFunction(func, modules);
+    }
+  }
+}
+
+void ModuleSplitter::setupTablePatching() {
+  if (!tableManager.activeTable) {
+    return;
+  }
+
+  std::map<Module*, std::map<Index, Function*>> moduleToReplacedElems;
+  // Replace table references to secondary functions with an imported
+  // placeholder that encodes the table index in its name:
+  // `importNamespace`.`index`.
+  forEachElement(
+    primary, [&](Name table, Name, Index index, Expression*& elem) {
+      auto* ref = elem->dynCast<RefFunc>();
+      if (!ref) {
+        return;
+      }
+      if (!allSecondaryFuncs.contains(ref->func)) {
+        return;
+      }
+      assert(table == tableManager.activeTable->name);
+
+      placeholderMap[table][index] = ref->func;
+      Index secondaryIndex = funcToSecondaryIndex.at(ref->func);
+      Module& secondary = *secondaries.at(secondaryIndex);
+      Name secondaryName = config.secondaryNames.at(secondaryIndex);
+      auto* secondaryFunc = secondary.getFunction(ref->func);
+      moduleToReplacedElems[&secondary][index] = secondaryFunc;
+      if (!config.usePlaceholders) {
+        // TODO: This can create active element segments with lots of nulls. We
+        // should optimize them like we do data segments with zeros.
+        elem = Builder(primary).makeRefNull(HeapType::nofunc);
+        return;
+      }
+      auto placeholder = std::make_unique<Function>();
+      placeholder->module = config.placeholderNamespacePrefix.toString() + "." +
+                            secondaryName.toString();
+      placeholder->base = std::to_string(index);
+      placeholder->name = Names::getValidFunctionName(
+        primary, std::string("placeholder_") + placeholder->base.toString());
+      placeholder->hasExplicitName = true;
+      placeholder->type = secondaryFunc->type.with(Inexact);
+      elem = Builder(primary).makeRefFunc(placeholder->name, placeholder->type);
+      primary.addFunction(std::move(placeholder));
+    });
+
+  if (moduleToReplacedElems.size() == 0) {
+    // No placeholders to patch out of the table
+    return;
+  }
+
+  for (auto& [secondaryPtr, replacedElems] : moduleToReplacedElems) {
+    Module& secondary = *secondaryPtr;
+    auto secondaryTable =
+      ModuleUtils::copyTable(tableManager.activeTable, secondary);
+
+    if (tableManager.activeBase.global.size()) {
+      assert(tableManager.activeTableSegments.size() == 1 &&
+             "Unexpected number of segments with non-const base");
+      assert(secondary.tables.size() == 1 && secondary.elementSegments.empty());
+      // Since addition is not currently allowed in initializer expressions, we
+      // need to start the new secondary segment where the primary segment
+      // starts. The secondary segment will contain the same primary functions
+      // as the primary module except in positions where it needs to overwrite a
+      // placeholder function. All primary functions in the table therefore need
+      // to be imported into the second module. TODO: use better strategies
+      // here, such as using ref.func in the start function or standardizing
+      // addition in initializer expressions.
+      ElementSegment* primarySeg = tableManager.activeTableSegments.front();
+      std::vector<Expression*> secondaryElems;
+      secondaryElems.reserve(primarySeg->data.size());
+
+      // Copy functions from the primary segment to the secondary segment,
+      // replacing placeholders and creating new exports and imports as
+      // necessary.
+      auto replacement = replacedElems.begin();
+      for (Index i = 0;
+           i < primarySeg->data.size() && replacement != replacedElems.end();
+           ++i) {
+        if (replacement->first == i) {
+          // primarySeg->data[i] is a placeholder, so use the secondary
+          // function.
+          auto* func = replacement->second;
+          auto* ref = Builder(secondary).makeRefFunc(func->name, func->type);
+          secondaryElems.push_back(ref);
+          ++replacement;
+        } else if (auto* get = primarySeg->data[i]->dynCast<RefFunc>()) {
+          exportImportFunction(get->func, {&secondary});
+          auto* copied =
+            ExpressionManipulator::copy(primarySeg->data[i], secondary);
+          secondaryElems.push_back(copied);
+        }
+      }
+
+      auto offset = ExpressionManipulator::copy(primarySeg->offset, secondary);
+      auto secondarySeg = std::make_unique<ElementSegment>(
+        secondaryTable->name, offset, secondaryTable->type, secondaryElems);
+      secondarySeg->setName(primarySeg->name, primarySeg->hasExplicitName);
+      secondary.addElementSegment(std::move(secondarySeg));
+      return;
+    }
+
+    // Create active table segments in the secondary module to patch in the
+    // original functions when it is instantiated.
+    Index currBase = replacedElems.begin()->first;
+    std::vector<Expression*> currData;
+    auto finishSegment = [&]() {
+      auto* offset = Builder(secondary).makeConst(
+        Literal::makeFromInt32(currBase, secondaryTable->addressType));
+      auto secondarySeg = std::make_unique<ElementSegment>(
+        secondaryTable->name, offset, secondaryTable->type, currData);
+      Name name = Names::getValidElementSegmentName(
+        secondary, Name::fromInt(secondary.elementSegments.size()));
+      secondarySeg->setName(name, false);
+      secondary.addElementSegment(std::move(secondarySeg));
+    };
+    for (auto curr = replacedElems.begin(); curr != replacedElems.end();
+         ++curr) {
+      if (curr->first != currBase + currData.size()) {
+        finishSegment();
+        currBase = curr->first;
+        currData.clear();
+      }
+      auto* func = curr->second;
+      currData.push_back(
+        Builder(secondary).makeRefFunc(func->name, func->type));
+    }
+    if (currData.size()) {
+      finishSegment();
+    }
   }
 }
 


### PR DESCRIPTION
This just moves the function up in the file. A follow-up PR will change the order of functions and run it before
`indirectReferencesToSecondaryFunctions`, so I'd like to match the order of the functions in the file to match that order, but if I move the function in that PR, it is hard to see what changes in the function.