### PR TITLE
Set branchesOut effect for call.without.effects

### DIFF
--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -726,6 +726,9 @@ private:
 
     void visitCall(Call* curr) {
       if (Intrinsics(parent.module).isCallWithoutEffects(curr)) {
+        if (curr->isReturn) {
+          parent.branchesOut = true;
+        }
         return;
       }
 

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -726,6 +726,8 @@ private:
 
     void visitCall(Call* curr) {
       if (Intrinsics(parent.module).isCallWithoutEffects(curr)) {
+        // The only effect this can have is to branch (which is an effect of the
+        // return, not the call).
         if (curr->isReturn) {
           parent.branchesOut = true;
         }

--- a/test/lit/passes/vacuum-intrinsics.wast
+++ b/test/lit/passes/vacuum-intrinsics.wast
@@ -258,4 +258,25 @@
     ;; Helper function for the above.
     (nop)
   )
+
+  ;; CHECK:      (func $const (type $1) (result i32)
+  ;; CHECK-NEXT:  (i32.const 1)
+  ;; CHECK-NEXT: )
+  (func $const (result i32)
+    (i32.const 1)
+  )
+
+  ;; CHECK:      (func $sets-branch-effect (type $1) (result i32)
+  ;; CHECK-NEXT:  (return_call $call.without.effects
+  ;; CHECK-NEXT:   (ref.func $const)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $sets-branch-effect (result i32)
+    ;; $call-without-effects still has a branch effect, even though the callee
+    ;; body is assumed to have no effects.
+    ;; Without a branch effect, we'd be free to optimize this to (unreachable).
+    ;; Also, we're free to optimize away the (unreachable).
+    (return_call $call.without.effects (ref.func $const))
+    (unreachable)
+  )
 )


### PR DESCRIPTION
Fixes #8693.