### PR TITLE
Fuzzer: Do not emit calls to table.get when trivialNesting is set

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -4143,8 +4143,8 @@ Expression* TranslateToFuzzReader::makeBasicRef(Type type) {
     case HeapType::func: {
       // Rarely, emit a call to imported table.get (when nullable, unshared, and
       // where we can emit a call).
-      if (type.isNullable() && share == Unshared && funcContext &&
-          tableGetImportName && !oneIn(3)) {
+      if (!trivialNesting && type.isNullable() && share == Unshared &&
+          funcContext && tableGetImportName && !oneIn(3)) {
         return makeImportTableGet();
       }
       return makeRefFuncConst(type);


### PR DESCRIPTION
`trivialNesting` means we were asked to emit something as trivial as possible.

The other option in this code, to emit a `ref.func` for the `funcref` type, is far
simpler.