### PR TITLE
Supply fuzz imports to second modules as well

### DIFF
--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -470,7 +470,10 @@ struct ExecutionResults {
         secondInterface = std::make_unique<LoggingExternalInterface>(
           loggings, *second, linkedInstances);
         secondInstance = std::make_shared<ModuleRunner>(
-          *second, secondInterface.get(), linkedInstances);
+          *second,
+          secondInterface.get(),
+          linkedInstances,
+          std::make_shared<FuzzerImportResolver>(linkedInstances));
         instantiate(*secondInstance, *secondInterface);
       }
 

--- a/test/lit/exec/fuzz-exec-second-import.wast
+++ b/test/lit/exec/fuzz-exec-second-import.wast
@@ -1,0 +1,16 @@
+;; RUN: wasm-opt %s -all --fuzz-exec-before --fuzz-exec-second=%s.second -q -o /dev/null 2>&1 | filecheck %s
+
+;; Check that imported externref globals work in second modules as well.
+
+(module
+  (import "__fuzz_import" "extern$" (global $gimport$0 externref))
+
+  (func (export "check") (result i32)
+    (ref.is_null (global.get $gimport$0))
+  )
+)
+
+;; CHECK:      [fuzz-exec] export check
+;; CHECK-NEXT: [fuzz-exec] note result: check => 0
+;; CHECK:      [fuzz-exec] export check_second
+;; CHECK-NEXT: [fuzz-exec] note result: check_second => 0

--- a/test/lit/exec/fuzz-exec-second-import.wast.second
+++ b/test/lit/exec/fuzz-exec-second-import.wast.second
@@ -1,0 +1,7 @@
+(module
+  (import "__fuzz_import" "extern$" (global $gimport$0 externref))
+
+  (func (export "check_second") (result i32)
+    (ref.is_null (global.get $gimport$0))
+  )
+)


### PR DESCRIPTION
Update execution-results.h to supply standard fuzzing imports, including imported externref globals materialized on demand, to second modules. This matches the behavior of fuzz_shell.js, which already makes these imports available to both modules.
