### PR TITLE
[NFC] revert msvc exclusion in wasm-type-printing

### DIFF
--- a/src/wasm-type-printing.h
+++ b/src/wasm-type-printing.h
@@ -49,6 +49,7 @@ template<typename Subclass> struct TypeNameGeneratorBase {
 private:
   constexpr void assertValidUsage() {
     // TODO: Convert to C++20 requires check
+    // The check need MSVC 18.6.0+, otherwise it will cause compiler crash.
 #if (!defined(__GNUC__) || __GNUC__ >= 14)
     // Check that the subclass provides `getNames` with the correct type.
     using Self = TypeNameGeneratorBase<Subclass>;

--- a/src/wasm-type-printing.h
+++ b/src/wasm-type-printing.h
@@ -48,9 +48,8 @@ template<typename Subclass> struct TypeNameGeneratorBase {
 
 private:
   constexpr void assertValidUsage() {
-    // This check current causes a crash on MSVC
     // TODO: Convert to C++20 requires check
-#if !defined(_MSC_VER) && (!defined(__GNUC__) || __GNUC__ >= 14)
+#if (!defined(__GNUC__) || __GNUC__ >= 14)
     // Check that the subclass provides `getNames` with the correct type.
     using Self = TypeNameGeneratorBase<Subclass>;
     static_assert(


### PR DESCRIPTION
The compiler crash bug has been fixed in visual studio 2026
https://developercommunity.visualstudio.com/t/msvc-error-C1001:-Internal-compiler-erro/10992638?scope=follow