### PR TITLE
[wasm-split] Sync secondary tables' initial/max

### DIFF
--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -1107,7 +1107,11 @@ void ModuleSplitter::setupTablePatching() {
     // so we should export and import the active table here.
     auto secondaryTable =
       secondary.getTableOrNull(tableManager.activeTable->name);
-    if (!secondaryTable) {
+    if (secondaryTable) {
+      // In case it's already in the secondary module, sync the initial/max
+      secondaryTable->initial = tableManager.activeTable->initial;
+      secondaryTable->max = tableManager.activeTable->max;
+    } else {
       secondaryTable =
         ModuleUtils::copyTable(tableManager.activeTable, secondary);
       makeImportExport(*tableManager.activeTable,

--- a/test/lit/wasm-split/active-table-base-global-used-elsewhere.wast
+++ b/test/lit/wasm-split/active-table-base-global-used-elsewhere.wast
@@ -18,8 +18,8 @@
 
  ;; PRIMARY:      (import "placeholder.deferred" "1" (func $placeholder_1))
 
- ;; PRIMARY:      (table $table 2 funcref)
- (table $table 1 funcref)
+ ;; PRIMARY:      (table $table 2 2 funcref)
+ (table $table 1 1 funcref)
  (elem (global.get $base) $keep)
  ;; PRIMARY:      (elem $0 (global.get $base) $keep $placeholder_1)
 
@@ -40,7 +40,7 @@
  (func $keep
   (call $split)
  )
- ;; SECONDARY:      (import "primary" "table" (table $table 1 funcref))
+ ;; SECONDARY:      (import "primary" "table" (table $table 2 2 funcref))
 
  ;; SECONDARY:      (import "primary" "global" (global $base i32))
 


### PR DESCRIPTION
When an existing table is used as the active table, after we increate the size of the table by placing placeholders, we should sync it to the secondary modules' imports of the table.

Fixes https://github.com/emscripten-core/emscripten/issues/26959.