### PR TITLE
Fix implicitly-deleted default constructor error on older Xcode versions

### DIFF
--- a/src/support/istring.h
+++ b/src/support/istring.h
@@ -69,7 +69,13 @@ public:
 
   std::string_view view() const { return str.view(); }
 
-  IString() = default;
+  // Use an explicit constructor instead of `= default` because some older
+  // compilers (e.g. Apple Clang in older Xcode versions) delete the default
+  // constructor if there is a const member without an in-class initializer,
+  // even if that member's type has a default constructor.
+  // FIXME: Use `= default` once we bump the min clang/Xcode version that
+  // we support.
+  IString() : str({nullptr}) {}
 
   IString(View v) : str(v) {}
 


### PR DESCRIPTION
Older versions of Clang (particularly those shipped with older Xcode versions) are more strict about the initialization of const members. According to the C++ standard, if a class has a const member that is not initialized at the point of declaration and lacks a user-provided default constructor that initializes it, the default constructor is implicitly deleted.

While newer versions of Clang and other compilers may allow this if the member has a trivial default constructor (like our View struct, which has an inline initializer for its only member), older versions of Apple Clang have been known to reject this, leading to build failures when inheriting from IString (e.g., in the Name class).

This change provides an explicit default constructor for IString that initializes the 'str' member, ensuring compatibility across a wider range of compiler versions.