### PR TITLE
[CI] Build on macos-14 rather than macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,10 @@ jobs:
     strategy:
       matrix:
         # Test on the oldest support Ubuntu version in addition to `latest`.
-        os: [ubuntu-22.04, ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
+        # Build using the oldest support macOS version.  For emsdk this is
+        # currently macos-13, but unfortunately that doesn't exist in github
+        # actions so we settle for macos-14.
+        os: [ubuntu-22.04, ubuntu-latest, macos-14, windows-latest, windows-11-arm]
     steps:
     - uses: actions/setup-python@v5
       with:
@@ -74,7 +77,7 @@ jobs:
 
     - name: install ninja (macos)
       run: brew install ninja
-      if: matrix.os == 'macos-latest'
+      if: startsWith(matrix.os, 'macos')
 
     - name: install ninja (win)
       run: choco install ninja
@@ -94,7 +97,7 @@ jobs:
 
     - name: cmake (macos)
       run: cmake -S . -B out -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=out/install '-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64'
-      if: matrix.os == 'macos-latest'
+      if: startsWith(matrix.os, 'macos')
 
     - name: cmake (win)
       # -G "Visual Studio 15 2017"

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, windows-11-arm]
+        os: [macos-14, windows-latest, windows-11-arm]
     defaults:
       run:
         shell: bash
@@ -27,7 +27,7 @@ jobs:
 
     - name: install ninja (macos)
       run: brew install ninja
-      if: matrix.os == 'macos-latest'
+      if: startsWith(matrix.os, 'macos')
 
     - name: install ninja (win)
       run: choco install ninja
@@ -40,7 +40,7 @@ jobs:
       run: |
         cmake -S . -B out -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=out/install -DCMAKE_OSX_ARCHITECTURES=x86_64
         cmake -S . -B out-arm64 -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=out-arm64/install -DCMAKE_OSX_ARCHITECTURES=arm64
-      if: matrix.os == 'macos-latest'
+      if: startsWith(matrix.os, 'macos')
 
     - name: cmake (win)
       # -G "Visual Studio 15 2017"
@@ -57,7 +57,7 @@ jobs:
 
     - name: build-arm64
       run: cmake --build out-arm64 -v --config Release --target install
-      if: matrix.os == 'macos-latest'
+      if: startsWith(matrix.os, 'macos')
 
     - name: strip
       run: find out*/install/ -type f -perm -u=x -exec strip -x {} +
@@ -83,7 +83,7 @@ jobs:
     - name: archive-arm64
       id: archive-arm64
       run: |
-        OSNAME=$(echo ${{ matrix.os }} | sed 's/-latest//' | sed 's/-11-arm//')
+        OSNAME=$(echo ${{ matrix.os }} | sed 's/-11-arm//' | sed 's/-14//')
         VERSION=$GITHUB_REF_NAME
         PKGNAME="binaryen-$VERSION-arm64-$OSNAME"
         TARBALL=$PKGNAME.tar.gz
@@ -95,7 +95,7 @@ jobs:
         cmake -E sha256sum $TARBALL > $SHASUM
         echo "TARBALL=$TARBALL" >> $GITHUB_OUTPUT
         echo "SHASUM=$SHASUM" >> $GITHUB_OUTPUT
-      if: ${{ matrix.os == 'macos-latest' || matrix.os == 'windows-11-arm' }} 
+      if: ${{ matrix.os == 'macos-14' || matrix.os == 'windows-11-arm' }}
 
     - name: upload tarball
       uses: softprops/action-gh-release@v1


### PR DESCRIPTION
In emsdk we actually build on macos-13, but sadly there is not macos-13 available in github actions.

In doing this I'm trying to get binaryen CI to reproduce the current issue we are seeing in emsdk CI:
```
In file included from /Users/distiller/project/binaryen/main/src/ir/import-names.h:23:
/Users/distiller/project/binaryen/main/src/support/name.h:35:12: error: call to implicitly-deleted default constructor of 'wasm::IString'
  Name() : IString() {}
           ^
/Users/distiller/project/binaryen/main/src/support/istring.h:72:3: note: explicitly defaulted function was implicitly deleted here
  IString() = default;
  ^
/Users/distiller/project/binaryen/main/src/support/istring.h:68:14: note: default constructor of 'IString' is implicitly deleted because field 'str' of const-qualified type 'const wasm::IString::View' would not be initialized
  const View str;
             ^
```

Split out from #8719 