### PR TITLE
Use C++20 string_view starts_with/ends_with methods. NFC

### DIFF
--- a/src/support/istring.h
+++ b/src/support/istring.h
@@ -113,8 +113,7 @@ public:
   bool equals(std::string_view other) const { return str.view() == other; }
 
   bool startsWith(std::string_view prefix) const {
-    // TODO: Use C++20 `starts_with`.
-    return view().substr(0, prefix.size()) == prefix;
+    return view().starts_with(prefix);
   }
   bool startsWith(IString other) const { return startsWith(other.view()); }
 
@@ -124,11 +123,7 @@ public:
   }
 
   bool endsWith(std::string_view suffix) const {
-    // TODO: Use C++20 `ends_with`.
-    if (suffix.size() > str.size()) {
-      return false;
-    }
-    return view().substr(str.size() - suffix.size()) == suffix;
+    return view().ends_with(suffix);
   }
   bool endsWith(IString other) const { return endsWith(other.view()); }
 


### PR DESCRIPTION
Also, remove the extra suffix size check from ends_with.  (I could alternatively add this to `starts_with` instead, but I assumes its not a useful optimization?).