### PR TITLE
Run non-nullable local fixups when reducing functions

### DIFF
--- a/src/tools/wasm-reduce/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce/wasm-reduce.cpp
@@ -1089,7 +1089,6 @@ struct Reducer
       struct FunctionReplacer
         : public WalkerPass<PostWalker<FunctionReplacer>> {
         bool isFunctionParallel() override { return true; }
-        bool requiresNonNullableLocalFixups() override { return false; }
         std::unique_ptr<Pass> create() override {
           return std::make_unique<FunctionReplacer>();
         };


### PR DESCRIPTION
It's not entirely clear how FunctionReplacer was producing IR that with invalid nullable locals, but this was observed in practice in issue #8720. Fix it by running the non-nullable local fixups after the pass.

Fixes #8720.
