### PR TITLE
PrintBoundary: Handle types for all externable things

### DIFF
--- a/src/passes/PrintBoundary.cpp
+++ b/src/passes/PrintBoundary.cpp
@@ -135,15 +135,16 @@ struct PrintBoundary : public Pass {
     switch (kind) {
       case ExternalKind::Function:
         return getTypes(wasm.getFunction(name)->type);
-        break;
       case ExternalKind::Table:
-        break;
+        return getTypes(wasm.getTable(name)->type);
       case ExternalKind::Memory:
-        break;
+        return getTypes(wasm.getMemory(name)->addressType);
       case ExternalKind::Global:
         return getTypes(wasm.getGlobal(name)->type);
       case ExternalKind::Tag:
-        break;
+        // Wrap it in a Type so that getTypes can handle it. That will print the
+        // params and results as we expect.
+        return getTypes(Type(wasm.getTag(name)->type, NonNullable));
       case ExternalKind::Invalid:
         WASM_UNREACHABLE("invalid ExternalKind");
     }

--- a/src/passes/PrintBoundary.cpp
+++ b/src/passes/PrintBoundary.cpp
@@ -146,9 +146,9 @@ struct PrintBoundary : public Pass {
         // params and results as we expect.
         return getTypes(Type(wasm.getTag(name)->type, NonNullable));
       case ExternalKind::Invalid:
-        WASM_UNREACHABLE("invalid ExternalKind");
+        break;
     }
-    return {};
+    WASM_UNREACHABLE("invalid ExternalKind");
   }
 
   json::Value::Ref getKindName(ExternalKind kind) {

--- a/test/lit/passes/print-boundary.wast
+++ b/test/lit/passes/print-boundary.wast
@@ -5,9 +5,21 @@
 
   (import "module2" "other" (func $bar (result i32 f32)))
 
+  (memory $mem 10 20)
+
+  (table 10 20 funcref)
+
+  (tag $e (param i32))
+
   (global $g (mut i32) (i32.const 42))
 
   (export "one" (func $one))
+
+  (export "m" (memory $mem))
+
+  (export "tab" (table 0))
+
+  (export "tag" (tag $e))
 
   (export "glob" (global $g))
 
@@ -64,9 +76,31 @@
 ;; CHECK-NEXT:    }
 ;; CHECK-NEXT:   },
 ;; CHECK-NEXT:   {
+;; CHECK-NEXT:    "name": "m",
+;; CHECK-NEXT:    "kind": "memory",
+;; CHECK-NEXT:    "type": "i32"
+;; CHECK-NEXT:   },
+;; CHECK-NEXT:   {
+;; CHECK-NEXT:    "name": "tab",
+;; CHECK-NEXT:    "kind": "table",
+;; CHECK-NEXT:    "type": "funcref"
+;; CHECK-NEXT:   },
+;; CHECK-NEXT:   {
+;; CHECK-NEXT:    "name": "tag",
+;; CHECK-NEXT:    "kind": "tag",
+;; CHECK-NEXT:    "type": {
+;; CHECK-NEXT:     "params": [
+;; CHECK-NEXT:      "i32"
+;; CHECK-NEXT:     ],
+;; CHECK-NEXT:     "results": [
+;; CHECK-NEXT:     ]
+;; CHECK-NEXT:    }
+;; CHECK-NEXT:   },
+;; CHECK-NEXT:   {
 ;; CHECK-NEXT:    "name": "glob",
 ;; CHECK-NEXT:    "kind": "global",
 ;; CHECK-NEXT:    "type": "i32"
 ;; CHECK-NEXT:   }
 ;; CHECK-NEXT:  ]
 ;; CHECK-NEXT: }
+


### PR DESCRIPTION
The old code gave memories, tables, and tags, a null Type as a placeholder.
But that actually crashes in printing. This adds a proper type for each.