### PR TITLE
Fix ContinuationStore desynchronization

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -537,7 +537,8 @@ public:
 #if WASM_INTERPRETER_DEBUG
       std::cout << indent() << "clear continuations\n";
 #endif
-      continuationStore = std::make_shared<ContinuationStore>();
+      continuationStore->continuations.clear();
+      continuationStore->resuming = false;
     }
   }
 

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -304,6 +304,13 @@ struct ContinuationStore {
 
   // Set when we are resuming execution, that is, re-winding the stack.
   bool resuming = false;
+
+  // On traps or other errors that unwind the stack, we reset the continuation
+  // store to return to a clean state ahead of further calls to exports.
+  void clear() {
+    continuations.clear();
+    resuming = false;
+  }
 };
 
 // Execute an expression
@@ -537,8 +544,7 @@ public:
 #if WASM_INTERPRETER_DEBUG
       std::cout << indent() << "clear continuations\n";
 #endif
-      continuationStore->continuations.clear();
-      continuationStore->resuming = false;
+      continuationStore->clear();
     }
   }
 

--- a/test/lit/exec/continuation-leak.wast
+++ b/test/lit/exec/continuation-leak.wast
@@ -1,0 +1,26 @@
+;; RUN: wasm-opt %s -all --fuzz-exec-before --fuzz-exec-second=%s.second -q -o /dev/null 2>&1 | filecheck %s
+
+;; Check that clearing the continuation store in linked modules clears it in-place,
+;; so that continuations leaked from the primary module do not affect the second module.
+
+(module
+  (type $func_t (func))
+  (type $cont_t (cont $func_t))
+  (tag $tag)
+  
+  (func $f_suspend
+    (suspend $tag)
+  )
+  
+  (func $test1 (export "test1")
+    (local $c (ref $cont_t))
+    (local.set $c (cont.new $cont_t (ref.func $f_suspend)))
+    (resume $cont_t (local.get $c))
+  )
+)
+
+;; CHECK:      [fuzz-exec] export test1
+;; CHECK-NEXT: [exception thrown: unhandled suspend]
+;; CHECK:      [fuzz-exec] running second module
+;; CHECK-NEXT: [fuzz-exec] export test2
+;; CHECK-NEXT: [exception thrown: unhandled suspend]

--- a/test/lit/exec/continuation-leak.wast
+++ b/test/lit/exec/continuation-leak.wast
@@ -7,11 +7,11 @@
   (type $func_t (func))
   (type $cont_t (cont $func_t))
   (tag $tag)
-  
+
   (func $f_suspend
     (suspend $tag)
   )
-  
+
   (func $test1 (export "test1")
     (local $c (ref $cont_t))
     (local.set $c (cont.new $cont_t (ref.func $f_suspend)))

--- a/test/lit/exec/continuation-leak.wast.second
+++ b/test/lit/exec/continuation-leak.wast.second
@@ -1,6 +1,6 @@
 (module
   (tag $tag)
-  
+
   (func $test2 (export "test2")
     (suspend $tag)
   )

--- a/test/lit/exec/continuation-leak.wast.second
+++ b/test/lit/exec/continuation-leak.wast.second
@@ -1,0 +1,7 @@
+(module
+  (tag $tag)
+  
+  (func $test2 (export "test2")
+    (suspend $tag)
+  )
+)


### PR DESCRIPTION
When a primary module execution traps or suspends to the host, its
continuation store is cleared. Previously, this was done by reassigning
the shared_ptr to a new ContinuationStore instance. However, secondary
(linked) modules that were instantiated prior to this still hold the
original shared_ptr to the old ContinuationStore. This led to
desynchronization, where the secondary module would run with stale
continuation state (including leaked continuations and resuming flags),
eventually causing crashes like assertion failures in visitSuspend.

This fix changes clearContinuationStore to clear the ContinuationStore
in-place (clearing the continuations vector and resetting resuming flag)
instead of reassigning the shared_ptr, ensuring all linked modules
continue to share the same cleared state.

Added a lit test to verify the fix and prevent regression.
