### PR TITLE
Fix test_cluster_fuzz.py V8 flags mismatch

### DIFF
--- a/test/unit/test_cluster_fuzz.py
+++ b/test/unit/test_cluster_fuzz.py
@@ -435,11 +435,14 @@ class ClusterFuzz(utils.BinaryenTestCase):
             valid_executions = 0
             for i in range(1, N + 1):
                 fuzz_file = os.path.join(temp_dir.name, f'fuzz-binaryen-{i}.js')
+                flags_file = os.path.join(temp_dir.name, f'flags-binaryen-{i}.js')
 
+                # Read flags from flags file to faithfully simulate how
+                # ClusterFuzz runs V8.
+                with open(flags_file) as f:
+                    flags = f.read().strip().split()
                 # Add --fuzzing to allow legacy and standard EH to coexist
-                cmd = [shared.V8,
-                       '--wasm-staging',
-                       '--experimental-wasm-custom-descriptors',
+                cmd = [shared.V8] + flags + [
                        '--fuzzing',
                        fuzz_file]
                 # Capture stderr even though we will not read it. It may


### PR DESCRIPTION
When running test_cluster_fuzz.py, it was launching V8 with a hardcoded list
of flags, instead of reading the flags from the generated flags file.
This caused V8 to fail compilation of test cases that included relaxed atomics
(which are generated by default now since relaxed atomics fuzzing was enabled),
because V8 requires --experimental-wasm-acquire-release flag for them, and this
flag was not in the hardcoded list.

This CL fixes this by reading the flags from the generated flags file to
faithfully simulate how ClusterFuzz runs V8.
