### PR TITLE
Fix i64x2 shift on big-endian

### DIFF
--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -1483,8 +1483,8 @@ Literal Literal::shl(const Literal& other) const {
       return Literal(uint32_t(i32)
                      << Bits::getEffectiveShifts(other.i32, Type::i32));
     case Type::i64:
-      return Literal(uint64_t(i64)
-                     << Bits::getEffectiveShifts(other.i64, Type::i64));
+      return Literal(uint64_t(i64) << Bits::getEffectiveShifts(
+                       other.getInteger(), Type::i64));
     default:
       WASM_UNREACHABLE("unexpected type");
   }
@@ -1495,7 +1495,8 @@ Literal Literal::shrS(const Literal& other) const {
     case Type::i32:
       return Literal(i32 >> Bits::getEffectiveShifts(other.i32, Type::i32));
     case Type::i64:
-      return Literal(i64 >> Bits::getEffectiveShifts(other.i64, Type::i64));
+      return Literal(i64 >>
+                     Bits::getEffectiveShifts(other.getInteger(), Type::i64));
     default:
       WASM_UNREACHABLE("unexpected type");
   }
@@ -1508,7 +1509,7 @@ Literal Literal::shrU(const Literal& other) const {
                      Bits::getEffectiveShifts(other.i32, Type::i32));
     case Type::i64:
       return Literal(uint64_t(i64) >>
-                     Bits::getEffectiveShifts(other.i64, Type::i64));
+                     Bits::getEffectiveShifts(other.getInteger(), Type::i64));
     default:
       WASM_UNREACHABLE("unexpected type");
   }


### PR DESCRIPTION
Since the i64x2.sh* functions use i32 as shift argument the access to `other.i64` may not use the correct union member. On big-endian systems this causes tests in `test/spec/testsuite/simd_bit_shift.wast` and a few other places to fail.

Ref https://github.com/WebAssembly/binaryen/issues/2983