### PR TITLE
Require linux on the wasm-reduce lit test

### DIFF
--- a/test/lit/wasm-reduce/reduce-validation-error.wast
+++ b/test/lit/wasm-reduce/reduce-validation-error.wast
@@ -3,7 +3,8 @@
 ;; type to be set incorrectly to nullref instead of the original type, leading
 ;; to a validation error.
 
-;; TODO: Why does this fail on CI without --force?
+;; TODO: Why does this fail on CI without --force? Why does it crash on Windows?
+;; REQUIRES: linux
 ;; RUN: wasm-reduce %s -t %t.t.wast -w %t.w.wast --force \
 ;; RUN:   --command='wasm-opt %t.t.wast -all --fuzz-exec'
 


### PR DESCRIPTION
For some reason this test is crashing on the Windows CI and possibly causing timeouts. Only run it on linux for now to avoid blocking other PRs from going in.
