### PR TITLE
Fix typo in mark-js-called.wast

### DIFF
--- a/test/lit/passes/mark-js-called.wast
+++ b/test/lit/passes/mark-js-called.wast
@@ -3,7 +3,7 @@
 ;; RUN: foreach %s %t wasm-opt --mark-js-called -all -S -o - | filecheck %s
 
 ;; $configured will be marked as @binaryen.js.called. $already is already marked,
-;; and nothing changess. $unconfigured* are not in configureAll so they are left
+;; and nothing changes. $unconfigured* are not in configureAll so they are left
 ;; alone.
 
 (module


### PR DESCRIPTION
Found by my local spellchecking git hook when performing a merge.