### PR TITLE
Set `BUILD_STATIC_LIB` under emscripten

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,9 @@ if(EMSCRIPTEN)
 endif()
 
 option(BUILD_STATIC_LIB "Build as a static library" OFF)
-if(MSVC)
+if(MSVC OR EMSCRIPTEN)
   # We don't have dllexport declarations set up for Windows yet.
+  # With emscripten we require a static library to create binaryen_js correctly.
   set(BUILD_STATIC_LIB ON)
 endif()
 


### PR DESCRIPTION
This fixes the following warning when building with emscripten:

```
CMake Warning (dev) at CMakeLists.txt:460 (add_library):
  ADD_LIBRARY called with SHARED option but the target platform does not
  support dynamic linking.  Building a STATIC library instead.  This may lead
  to problems.
This warning is for project developers.  Use -Wno-dev to suppress it.
```