### PR TITLE
Use cmake standard `BUILD_SHARED_LIBS` setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
       # size for pthreads is tiny,
       # https://github.com/WebAssembly/binaryen/issues/8594
       run: |
-        ./alpine.sh cmake . -G Ninja -DCMAKE_CXX_FLAGS="-static" -DCMAKE_C_FLAGS="-static" -DCMAKE_EXE_LINKER_FLAGS="-Wl,-z,stack-size=8388608" -DCMAKE_BUILD_TYPE=Release -DBUILD_STATIC_LIB=ON -DBUILD_MIMALLOC=ON -DCMAKE_INSTALL_PREFIX=install
+        ./alpine.sh cmake . -G Ninja -DCMAKE_CXX_FLAGS="-static" -DCMAKE_C_FLAGS="-static" -DCMAKE_EXE_LINKER_FLAGS="-Wl,-z,stack-size=8388608" -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DBUILD_MIMALLOC=ON -DCMAKE_INSTALL_PREFIX=install
 
     - name: build
       run: |

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -150,7 +150,7 @@ jobs:
       # size for pthreads is tiny,
       # https://github.com/WebAssembly/binaryen/issues/8594
       run: |
-        ./alpine.sh cmake . -G Ninja -DCMAKE_CXX_FLAGS="-static" -DCMAKE_C_FLAGS="-static" -DCMAKE_EXE_LINKER_FLAGS="-Wl,-z,stack-size=8388608" -DCMAKE_BUILD_TYPE=Release -DBUILD_STATIC_LIB=ON -DBUILD_MIMALLOC=ON -DCMAKE_INSTALL_PREFIX=install
+        ./alpine.sh cmake . -G Ninja -DCMAKE_CXX_FLAGS="-static" -DCMAKE_C_FLAGS="-static" -DCMAKE_EXE_LINKER_FLAGS="-Wl,-z,stack-size=8388608" -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DBUILD_MIMALLOC=ON -DCMAKE_INSTALL_PREFIX=install
 
     - name: build
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,11 +52,11 @@ if(EMSCRIPTEN)
   set(BUILD_LLVM_DWARF OFF)
 endif()
 
-option(BUILD_STATIC_LIB "Build as a static library" OFF)
+option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 if(MSVC OR EMSCRIPTEN)
   # We don't have dllexport declarations set up for Windows yet.
   # With emscripten we require a static library to create binaryen_js correctly.
-  set(BUILD_STATIC_LIB ON)
+  set(BUILD_SHARED_LIBS OFF)
 endif()
 
 # Advised to turn on when statically linking against musl libc (e.g., in the
@@ -451,18 +451,18 @@ else() # MSVC
 endif()
 
 # Declare libbinaryen
+# This will be either be STATIC or SHARED depending on BUILD_SHARED_LIBS
+add_library(binaryen)
 
-if(BUILD_STATIC_LIB)
-  message(STATUS "Building libbinaryen as statically linked library.")
-  add_library(binaryen STATIC)
-  add_definitions(-DBUILD_STATIC_LIBRARY)
-else()
+if(BUILD_SHARED_LIBS)
+  add_definitions(-DBUILD_SHARED_LIBS)
   message(STATUS "Building libbinaryen as shared library.")
-  add_library(binaryen SHARED)
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     # Disable interposition and resolve Binaryen symbols locally.
     add_link_flag("-Bsymbolic")
   endif()
+else()
+  message(STATUS "Building libbinaryen as statically linked library.")
 endif()
 target_link_libraries(binaryen PUBLIC Threads::Threads)
 binaryen_setup_rpath(binaryen)
@@ -475,13 +475,13 @@ if(BUILD_MIMALLOC)
     message(FATAL_ERROR "Linking mimalloc is only supported on Linux.")
   endif()
   message(STATUS "Building with mimalloc allocator.")
-  if(BUILD_STATIC_LIB)
+  if(BUILD_SHARED_LIBS)
+    target_link_options(mimalloc PRIVATE "-Wl,--as-needed")
+    target_link_libraries(binaryen PRIVATE mimalloc)
+  else()
     target_link_libraries(binaryen PRIVATE "-Wl,--push-state,--as-needed")
     target_link_libraries(binaryen PRIVATE mimalloc-static)
     target_link_libraries(binaryen PRIVATE "-Wl,--pop-state")
-  else()
-    target_link_options(mimalloc PRIVATE "-Wl,--as-needed")
-    target_link_libraries(binaryen PRIVATE mimalloc)
   endif()
 endif()
 
@@ -518,7 +518,7 @@ set(binaryen_SOURCES
 )
 target_sources(binaryen PRIVATE ${binaryen_SOURCES})
 
-if(INSTALL_LIBS OR NOT BUILD_STATIC_LIB)
+if(INSTALL_LIBS OR BUILD_SHARED_LIBS)
   install(TARGETS binaryen
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -58,7 +58,9 @@
 #if defined(__EMSCRIPTEN__)
 #include <emscripten.h>
 #define BINARYEN_API EMSCRIPTEN_KEEPALIVE
-#elif defined(_MSC_VER) && !defined(BUILD_STATIC_LIBRARY)
+#elif defined(_MSC_VER) && defined(BUILD_SHARED_LIBS)
+// TODO: This is not yet used since we disabled BUILD_SHARED_LIBS under
+// _MSC_VER in CMakeLists.txt
 #define BINARYEN_API __declspec(dllexport)
 #else
 #define BINARYEN_API

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -18,9 +18,9 @@ endif()
 
 if(BUILD_MIMALLOC)
   # Match static/dynamic linking between libbinaryen and mimalloc
-  set(MI_BUILD_STATIC ${BUILD_STATIC_LIB})
-  if (BUILD_STATIC_LIB)
-    set(MI_BUILD_SHARED OFF)
+  set(MI_BUILD_SHARED ${BUILD_SHARED_LIBS})
+  if (BUILD_SHARED_LIBS)
+    set(MI_BUILD_STATIC OFF)
   endif()
   set(MI_BUILD_OBJECT OFF)
   set(MI_BUILD_TESTS OFF)
@@ -35,11 +35,11 @@ if(BUILD_MIMALLOC)
   # Do not show debug and warning messages of the allocator by default.
   # (They can still be enabled via MIMALLOC_VERBOSE=1 wasm-opt ...)
   add_compile_definitions(MI_DEBUG=0)
-  
-  if(BUILD_STATIC_LIB)
+
+  if(BUILD_SHARED_LIBS)
+    add_subdirectory(mimalloc)
+  else()
     # No need to install libmimalloc.a when it's linked statically into the tools.
     add_subdirectory(mimalloc EXCLUDE_FROM_ALL)
-  else()
-    add_subdirectory(mimalloc)
   endif()
 endif()


### PR DESCRIPTION
See https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html

I'm not sure why we made up our own setting here rather than using the standard one.