### PR TITLE
NFC: Use `const EffectAnalyzer&` in ostream operator

### DIFF
--- a/src/ir/effects.cpp
+++ b/src/ir/effects.cpp
@@ -17,9 +17,9 @@
 #include "ir/effects.h"
 #include "wasm.h"
 
-namespace std {
+namespace wasm {
 
-std::ostream& operator<<(std::ostream& o, wasm::EffectAnalyzer& effects) {
+std::ostream& operator<<(std::ostream& o, const EffectAnalyzer& effects) {
   o << "EffectAnalyzer {\n";
   if (effects.branchesOut) {
     o << "branchesOut\n";
@@ -87,10 +87,10 @@ std::ostream& operator<<(std::ostream& o, wasm::EffectAnalyzer& effects) {
   if (effects.implicitTrap) {
     o << "implicitTrap\n";
   }
-  if (effects.readOrder != wasm::MemoryOrder::Unordered) {
+  if (effects.readOrder != MemoryOrder::Unordered) {
     o << "readOrder " << effects.readOrder << "\n";
   }
-  if (effects.writeOrder != wasm::MemoryOrder::Unordered) {
+  if (effects.writeOrder != MemoryOrder::Unordered) {
     o << "writeOrder " << effects.writeOrder << "\n";
   }
   if (effects.throws_) {
@@ -160,4 +160,4 @@ std::ostream& operator<<(std::ostream& o, wasm::EffectAnalyzer& effects) {
   return o;
 }
 
-} // namespace std
+} // namespace wasm

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -1496,10 +1496,8 @@ public:
   }
 };
 
-} // namespace wasm
+std::ostream& operator<<(std::ostream& o, const EffectAnalyzer& effects);
 
-namespace std {
-std::ostream& operator<<(std::ostream& o, wasm::EffectAnalyzer& effects);
-} // namespace std
+} // namespace wasm
 
 #endif // wasm_ir_effects_h


### PR DESCRIPTION
Allows printing `const EffectAnalyzer`s.

Also move the ostream operator into the `wasm` namespace to avoid UB from extending std: https://en.cppreference.com/cpp/language/extending_std