### PR TITLE
[NFC] Remove quit() from fuzz_shell.js

### DIFF
--- a/scripts/auto_update_tests.py
+++ b/scripts/auto_update_tests.py
@@ -57,7 +57,7 @@ def update_example_tests():
             subprocess.check_call(cmd)
             print('run...', output_file)
             proc = subprocess.run([output_file], capture_output=True)
-            assert proc.returncode == 0, [proc.returncode, proc.stderror, proc.stdout]
+            assert proc.returncode == 0, [proc.returncode, proc.stderr, proc.stdout]
             actual = proc.stdout
             with open(expected, 'wb') as o:
                 o.write(actual)

--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -520,8 +520,7 @@ function build(binary, isSecond) {
   try {
     instance = new WebAssembly.Instance(module, imports);
   } catch (e) {
-    console.log('exception thrown: failed to instantiate module: ' + e);
-    quit();
+    throw new Error('exception thrown: failed to instantiate module: ' + e);
   }
 
   // Do not add the second instance's exports to the list, as that would be


### PR DESCRIPTION
This was called in an error condition. `quit` does not exist in most JS
shells, so this just throws. Fix it to throw a nicer error.

Also fix another error in an error path in python - there is no
`proc.stderror`, it is `stderr`.