### PR TITLE
NFC: Simplify test with improved indirect call effects

### DIFF
--- a/test/lit/passes/global-effects-closed-world-simplify-locals.wast
+++ b/test/lit/passes/global-effects-closed-world-simplify-locals.wast
@@ -8,10 +8,10 @@
   ;; CHECK:      (type $indirect-type-super (sub (func (param i32))))
   (type $indirect-type-super (sub (func (param i32))))
 
-  ;; CHECK:      (type $1 (func (param (ref $indirect-type-super))))
-
   ;; CHECK:      (type $indirect-type-sub (sub $indirect-type-super (func (param i32))))
   (type $indirect-type-sub (sub $indirect-type-super (func (param i32))))
+
+  ;; CHECK:      (type $2 (func (param (ref $indirect-type-super))))
 
   ;; CHECK:      (global $g1 (mut i32) (i32.const 0))
   (global $g1 (mut i32) (i32.const 0))
@@ -42,18 +42,7 @@
     (global.set $g2 (local.get $i32))
   )
 
-  ;; CHECK:      (func $caller (type $1) (param $ref (ref $indirect-type-super))
-  ;; CHECK-NEXT:  (call_ref $indirect-type-super
-  ;; CHECK-NEXT:   (i32.const 1)
-  ;; CHECK-NEXT:   (local.get $ref)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT: )
-  (func $caller (param $ref (ref $indirect-type-super))
-    ;; This inherits effects from $impl1 and $impl2, so may mutate $g1 and $g2.
-    (call_ref $indirect-type-super (i32.const 1) (local.get $ref))
-  )
-
-  ;; CHECK:      (func $merges-multiple-effects (type $1) (param $ref (ref $indirect-type-super))
+  ;; CHECK:      (func $merges-multiple-effects (type $2) (param $ref (ref $indirect-type-super))
   ;; CHECK-NEXT:  (local $x i32)
   ;; CHECK-NEXT:  (local $y i32)
   ;; CHECK-NEXT:  (local $z i32)
@@ -64,7 +53,8 @@
   ;; CHECK-NEXT:   (global.get $g2)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (nop)
-  ;; CHECK-NEXT:  (call $caller
+  ;; CHECK-NEXT:  (call_ref $indirect-type-super
+  ;; CHECK-NEXT:   (i32.const 1)
   ;; CHECK-NEXT:   (local.get $ref)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -89,7 +79,7 @@
     ;; This acts as a barrier for $x and $y, but not $z because
     ;; $ref may write to $g1 (via $impl1) or $g2 (via $impl2) but not $g3.
     ;; $z is optimized out and $x and $y are left alone.
-    (call $caller (local.get $ref))
+    (call_ref $indirect-type-super (i32.const 1) (local.get $ref))
 
     (drop (local.get $x))
     (drop (local.get $y))


### PR DESCRIPTION
This was missed after #8625 and #8738. We don't need the extra indirection of a direct call in the test since we're testing effect analysis for indirect calls and call chains containing both indirect and direct calls is already tested [here](https://github.com/WebAssembly/binaryen/blob/83f68e13b2cd22e52a8e8c19b9a48cc11416c99a/test/lit/passes/global-effects-closed-world.wast#L248-L251).