### PR TITLE
Skip d8 lit tests on windows

### DIFF
--- a/test/lit/d8/fuzz_shell.wast
+++ b/test/lit/d8/fuzz_shell.wast
@@ -1,5 +1,9 @@
 ;; Test running a wasm file in fuzz_shell.js.
 
+;; This fails on windows-ARM on CI for unclear reasons. v8 is somehow not
+;; properly installed.
+;; REQUIRES: linux
+
 (module
   (func $test (export "test") (result i32)
     (i32.const 42)

--- a/test/lit/d8/fuzz_shell_exceptions.wast
+++ b/test/lit/d8/fuzz_shell_exceptions.wast
@@ -1,5 +1,9 @@
 ;; Test throwing from JS by calling the throw import.
 
+;; This fails on windows-ARM on CI for unclear reasons. v8 is somehow not
+;; properly installed.
+;; REQUIRES: linux
+
 (module
   (import "fuzzing-support" "throw" (func $throw (param i32)))
 

--- a/test/lit/d8/fuzz_shell_jspi.wast
+++ b/test/lit/d8/fuzz_shell_jspi.wast
@@ -1,3 +1,7 @@
+;; This fails on windows-ARM on CI for unclear reasons. v8 is somehow not
+;; properly installed.
+;; REQUIRES: linux
+
 (module
   (import "fuzzing-support" "log-i32" (func $log (param i32)))
 

--- a/test/lit/d8/fuzz_shell_sleep.wast
+++ b/test/lit/d8/fuzz_shell_sleep.wast
@@ -1,3 +1,7 @@
+;; This fails on windows-ARM on CI for unclear reasons. v8 is somehow not
+;; properly installed.
+;; REQUIRES: linux
+
 (module
   (import "fuzzing-support" "sleep" (func $sleep (param i32 i32) (result i32)))
 


### PR DESCRIPTION
It is not clear why v8 is not installed on CI specifically on windows-arm,
but apparently it isn't. As this just affects 4 tests, skip them on windows.

Example error:

https://github.com/WebAssembly/binaryen/actions/runs/26543251282/job/78189409612

```
Failed Tests (4):
  Binaryen lit tests :: d8/fuzz_shell.wast
  Binaryen lit tests :: d8/fuzz_shell_exceptions.wast
  Binaryen lit tests :: d8/fuzz_shell_jspi.wast
  Binaryen lit tests :: d8/fuzz_shell_sleep.wast

```
