### PR TITLE
j2cl-merge-itables: Fatal abort if optimizable types are public

### DIFF
--- a/src/passes/J2CLItableMerging.cpp
+++ b/src/passes/J2CLItableMerging.cpp
@@ -106,7 +106,8 @@ struct J2CLItableMerging : public Pass {
         return it != typeNameInfo.fieldNames.end() && it->second.equals(name);
       };
 
-    auto publicTypes = ModuleUtils::getPublicHeapTypes(wasm, getPassOptions().worldMode);
+    auto publicTypes =
+      ModuleUtils::getPublicHeapTypes(wasm, getPassOptions().worldMode);
     std::unordered_set<HeapType> publicTypesSet(publicTypes.begin(),
                                                 publicTypes.end());
 
@@ -148,10 +149,11 @@ struct J2CLItableMerging : public Pass {
       }
 
       if (publicTypesSet.contains(heapType) ||
-          publicTypesSet.contains(vtabletype) || 
+          publicTypesSet.contains(vtabletype) ||
           publicTypesSet.contains(itabletype)) {
         Fatal() << "Cannot merge itables because the J2CL type "
-                << ModuleHeapType(wasm, heapType) << " or its dispatch tables are public";
+                << ModuleHeapType(wasm, heapType)
+                << " or its dispatch tables are public";
       }
 
       auto structItableSize = itabletype.getStruct().fields.size();

--- a/src/passes/J2CLItableMerging.cpp
+++ b/src/passes/J2CLItableMerging.cpp
@@ -30,6 +30,7 @@
 #include <string_view>
 #include <unordered_map>
 
+#include "ir/module-utils.h"
 #include "ir/type-updating.h"
 #include "pass.h"
 #include "support/utilities.h"
@@ -105,6 +106,10 @@ struct J2CLItableMerging : public Pass {
         return it != typeNameInfo.fieldNames.end() && it->second.equals(name);
       };
 
+    auto publicTypes = ModuleUtils::getPublicHeapTypes(wasm, getPassOptions().worldMode);
+    std::unordered_set<HeapType> publicTypesSet(publicTypes.begin(),
+                                                publicTypes.end());
+
     // 1. Collect all structs that correspond that a Java type.
     for (auto [heapType, typeNameInfo] : wasm.typeNames) {
       if (!heapType.isStruct()) {
@@ -140,6 +145,13 @@ struct J2CLItableMerging : public Pass {
 
         vtabletype = type.fields[0].type.getHeapType();
         itabletype = type.fields[1].type.getHeapType();
+      }
+
+      if (publicTypesSet.contains(heapType) ||
+          publicTypesSet.contains(vtabletype) || 
+          publicTypesSet.contains(itabletype)) {
+        Fatal() << "Cannot merge itables because the J2CL type "
+                << ModuleHeapType(wasm, heapType) << " or its dispatch tables are public";
       }
 
       auto structItableSize = itabletype.getStruct().fields.size();

--- a/test/lit/passes/j2cl-merge-itables-public.wast
+++ b/test/lit/passes/j2cl-merge-itables-public.wast
@@ -1,0 +1,44 @@
+;; RUN: foreach %s %t not wasm-opt -all --closed-world --preserve-type-order --merge-j2cl-itables 2>&1 | filecheck %s
+
+;; Java class type is public
+(module
+  (rec
+    (type $Object (sub (struct
+      (field $vtable (ref $Object.vtable))
+      (field $itable (ref $Object.itable)))))
+    (type $Object.vtable (sub (struct)))
+    (type $Object.itable (struct (field (ref null struct))))
+  )
+
+  (func $f (export "f") (param $o (ref $Object)))
+)
+;; CHECK: Fatal: Cannot merge itables because the J2CL type $Object or its dispatch tables are public
+
+;; Java vtable type is public.
+;; Note that making the vtable type public also makes the described class type public.
+(module
+  (rec
+    (type $Object (sub (struct
+      (field $vtable (ref $Object.vtable))
+      (field $itable (ref $Object.itable)))))
+    (type $Object.vtable (sub (struct)))
+    (type $Object.itable (struct (field (ref null struct))))
+  )
+
+  (func $f (export "f") (param $o (ref $Object.vtable)))
+)
+;; CHECK: Fatal: Cannot merge itables because the J2CL type $Object or its dispatch tables are public
+
+;; Java itable type is public, and is defined in a separate recursion group.
+(module
+  (type $Object.itable (struct (field (ref null struct))))
+  (rec
+    (type $Object (sub (struct
+      (field $vtable (ref $Object.vtable))
+      (field $itable (ref $Object.itable)))))
+    (type $Object.vtable (sub (struct)))
+  )
+
+  (func $f (export "f") (param $o (ref $Object.itable)))
+)
+;; CHECK: Fatal: Cannot merge itables because the J2CL type $Object or its dispatch tables are public


### PR DESCRIPTION
Adds a sanity check to abort if any of the Java classes end up being public.