### PR TITLE
[NFC] Using orderedBefore in skipNonNullCast

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1581,7 +1581,7 @@ struct OptimizeInstructions
             // trap we want to move. (We use a shallow effect analyzer since we
             // will only move the ref.as_non_null itself.)
             ShallowEffectAnalyzer movingEffects(options, *getModule(), input);
-            if (crossedEffects.invalidates(movingEffects)) {
+            if (movingEffects.orderedBefore(crossedEffects)) {
               return;
             }
 

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2574,7 +2574,7 @@ struct OptimizeInstructions
         auto& options = getPassRunner()->options;
         EffectAnalyzer descEffects(options, *getModule(), curr->desc);
         ShallowEffectAnalyzer movingEffects(options, *getModule(), curr->ref);
-        if (descEffects.invalidates(movingEffects)) {
+        if (movingEffects.orderedBefore(descEffects)) {
           return;
         }
       }


### PR DESCRIPTION
When OptimizeInstructions skips explicit `ref.as_non_null` instructions because they are flowing into a parent expression that will already do a null check, it has to check that moving the trap effect past any subsequent children of the parent is allowed. Update the code to use `orderedBefore` instead of `invalidates`. Also make this change in another place that removes a `ref.as_non_null` in the same way.

This is not a functional change because traps are ordered symmetrically with other effects; a trap can be moved forward past another effect iff it can be moved backward past that other effect. The code therefore has the same behavior whether it uses `orderedBefore`, `orderedAfter`, or `invalidates` here. `orderedBefore` makes the most sense given then context, though.
