### PR TITLE
Skip idempotent test in fuzzing.py

### DIFF
--- a/scripts/test/fuzzing.py
+++ b/scripts/test/fuzzing.py
@@ -113,6 +113,7 @@ unfuzzable = [
     'duplicate-function-elimination_annotations.wast',
     'once-reduction_idempotent.wast',
     'local-cse_idempotent.wast',
+    'optimize-instructions-global-effects-idempotent.wast',
     # Not fully implemented.
     'waitqueue.wast',
     # TODO: fix handling of the non-utf8 names here


### PR DESCRIPTION
The fuzzer cannot preserve idempotency, so it does not support initial contents with idempotency annotations.