### PR TITLE
Add std::inplace_vector polyfill from c++26 [NFC]

### DIFF
--- a/src/passes/ConstantFieldPropagation.cpp
+++ b/src/passes/ConstantFieldPropagation.cpp
@@ -60,7 +60,6 @@
 #include "ir/utils.h"
 #include "pass.h"
 #include "support/hash.h"
-#include "support/inplace_vector.h"
 #include "support/small_vector.h"
 #include "support/unique_deferring_queue.h"
 #include "wasm-builder.h"
@@ -312,7 +311,9 @@ struct FunctionOptimizer : public WalkerPass<PostWalker<FunctionOptimizer>> {
     //  values = [ { 42, [A, B] }, { 1337, [C] } ];
     struct Value {
       PossibleConstantValues constant;
-      inplace_vector<HeapType, 2> types;
+      // Use a SmallVector as we'll only have 2 Values, and so the stack usage
+      // here is fixed.
+      SmallVector<HeapType, 10> types;
 
       // Whether this slot is used. If so, |constant| has a value, and |types|
       // is not empty.

--- a/src/passes/ConstantFieldPropagation.cpp
+++ b/src/passes/ConstantFieldPropagation.cpp
@@ -312,7 +312,7 @@ struct FunctionOptimizer : public WalkerPass<PostWalker<FunctionOptimizer>> {
     //  values = [ { 42, [A, B] }, { 1337, [C] } ];
     struct Value {
       PossibleConstantValues constant;
-      std::inplace_vector<HeapType, 2> types;
+      inplace_vector<HeapType, 2> types;
 
       // Whether this slot is used. If so, |constant| has a value, and |types|
       // is not empty.

--- a/src/passes/ConstantFieldPropagation.cpp
+++ b/src/passes/ConstantFieldPropagation.cpp
@@ -60,6 +60,7 @@
 #include "ir/utils.h"
 #include "pass.h"
 #include "support/hash.h"
+#include "support/inplace_vector.h"
 #include "support/small_vector.h"
 #include "support/unique_deferring_queue.h"
 #include "wasm-builder.h"
@@ -311,9 +312,7 @@ struct FunctionOptimizer : public WalkerPass<PostWalker<FunctionOptimizer>> {
     //  values = [ { 42, [A, B] }, { 1337, [C] } ];
     struct Value {
       PossibleConstantValues constant;
-      // Use a SmallVector as we'll only have 2 Values, and so the stack usage
-      // here is fixed.
-      SmallVector<HeapType, 10> types;
+      std::inplace_vector<HeapType, 2> types;
 
       // Whether this slot is used. If so, |constant| has a value, and |types|
       // is not empty.

--- a/src/support/inplace_vector.h
+++ b/src/support/inplace_vector.h
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2026 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// A vector of elements with a maximum size, storing them all in-place. This is
+// similar to C++26's inplace_vector, and is basically a small_vector, except
+// there is never any dynamic storage.
+//
+
+#ifndef wasm_support_inplace_vector_h
+#define wasm_support_inplace_vector_h
+
+#include <array>
+#include <cassert>
+#include <vector>
+
+#include "support/parent_index_iterator.h"
+
+namespace std {
+
+template<typename T, size_t N> class inplace_vector {
+  // fixed-space storage
+  size_t usedFixed = 0;
+  std::array<T, N> fixed{};
+
+public:
+  using value_type = T;
+
+  inplace_vector() {}
+  inplace_vector(const inplace_vector<T, N>& other)
+    : usedFixed(other.usedFixed), fixed(other.fixed) {}
+  inplace_vector(inplace_vector<T, N>&& other)
+    : usedFixed(other.usedFixed), fixed(std::move(other.fixed)) {}
+  inplace_vector(std::initializer_list<T> init) {
+    for (T item : init) {
+      push_back(item);
+    }
+  }
+  inplace_vector(size_t initialSize) { resize(initialSize); }
+
+  inplace_vector<T, N>& operator=(const inplace_vector<T, N>& other) {
+    usedFixed = other.usedFixed;
+    fixed = other.fixed;
+    return *this;
+  }
+
+  inplace_vector<T, N>& operator=(inplace_vector<T, N>&& other) {
+    usedFixed = other.usedFixed;
+    fixed = std::move(other.fixed);
+    return *this;
+  }
+
+  T& operator[](size_t i) { return fixed[i]; }
+
+  const T& operator[](size_t i) const {
+    return const_cast<inplace_vector<T, N>&>(*this)[i];
+  }
+
+  void push_back(const T& x) {
+    assert(usedFixed < N);
+    fixed[usedFixed++] = x;
+  }
+
+  template<typename... ArgTypes> void emplace_back(ArgTypes&&... Args) {
+    assert(usedFixed < N);
+    new (&fixed[usedFixed++]) T(std::forward<ArgTypes>(Args)...);
+  }
+
+  void pop_back() {
+    assert(usedFixed > 0);
+    usedFixed--;
+  }
+
+  T& back() {
+    assert(usedFixed > 0);
+    return fixed[usedFixed - 1];
+  }
+
+  const T& back() const {
+    assert(usedFixed > 0);
+    return fixed[usedFixed - 1];
+  }
+
+  size_t size() const { return usedFixed; }
+
+  bool empty() const { return size() == 0; }
+
+  void clear() { usedFixed = 0; }
+
+  void resize(size_t newSize) {
+    assert(newSize <= N);
+    usedFixed = newSize;
+  }
+
+  size_t capacity() const { return N; }
+
+  bool operator==(const inplace_vector<T, N>& other) const {
+    if (usedFixed != other.usedFixed) {
+      return false;
+    }
+    for (size_t i = 0; i < usedFixed; i++) {
+      if (fixed[i] != other.fixed[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool operator!=(const inplace_vector<T, N>& other) const {
+    return !(*this == other);
+  }
+
+  // iteration
+
+  struct Iterator : wasm::ParentIndexIterator<inplace_vector<T, N>*, Iterator> {
+    using value_type = T;
+    using pointer = T*;
+    using reference = T&;
+
+    Iterator(inplace_vector<T, N>* parent, size_t index)
+      : wasm::ParentIndexIterator<inplace_vector<T, N>*, Iterator>{parent,
+                                                                   index} {}
+    Iterator(const Iterator& other) = default;
+
+    T& operator*() { return (*this->parent)[this->index]; }
+  };
+
+  struct ConstIterator
+    : wasm::ParentIndexIterator<const inplace_vector<T, N>*, ConstIterator> {
+    using value_type = const T;
+    using pointer = const T*;
+    using reference = const T&;
+
+    ConstIterator(const inplace_vector<T, N>* parent, size_t index)
+      : wasm::ParentIndexIterator<const inplace_vector<T, N>*, ConstIterator>{
+          parent, index} {}
+    ConstIterator(const ConstIterator& other) = default;
+
+    const T& operator*() const { return (*this->parent)[this->index]; }
+  };
+
+  Iterator begin() { return Iterator(this, 0); }
+  Iterator end() { return Iterator(this, size()); }
+  ConstIterator begin() const { return ConstIterator(this, 0); }
+  ConstIterator end() const { return ConstIterator(this, size()); }
+
+  void erase(Iterator a, Iterator b) {
+    // Atm we only support erasing at the end, which is very efficient.
+    assert(b == end());
+    resize(a.index);
+  }
+};
+
+// A inplace_vector for which some values may be read before they are written,
+// and in that case they have the value zero.
+template<typename T, size_t N>
+struct ZeroInitinplace_vector : public inplace_vector<T, N> {
+  T& operator[](size_t i) {
+    if (i >= this->size()) {
+      resize(i + 1);
+    }
+    return inplace_vector<T, N>::operator[](i);
+  }
+
+  const T& operator[](size_t i) const {
+    return const_cast<ZeroInitinplace_vector<T, N>&>(*this)[i];
+  }
+
+  void resize(size_t newSize) {
+    auto oldSize = this->size();
+    inplace_vector<T, N>::resize(newSize);
+    for (size_t i = oldSize; i < this->size(); i++) {
+      (*this)[i] = 0;
+    }
+  }
+};
+
+} // namespace std
+
+#endif // wasm_support_inplace_vector_h

--- a/src/support/inplace_vector.h
+++ b/src/support/inplace_vector.h
@@ -30,7 +30,7 @@
 
 #include "support/parent_index_iterator.h"
 
-namespace std {
+namespace wasm {
 
 template<typename T, size_t N> class inplace_vector {
   // fixed-space storage
@@ -165,6 +165,6 @@ public:
   }
 };
 
-} // namespace std
+} // namespace wasm
 
 #endif // wasm_support_inplace_vector_h

--- a/src/support/inplace_vector.h
+++ b/src/support/inplace_vector.h
@@ -46,7 +46,7 @@ public:
   inplace_vector(inplace_vector<T, N>&& other)
     : usedFixed(other.usedFixed), fixed(std::move(other.fixed)) {}
   inplace_vector(std::initializer_list<T> init) {
-    for (T item : init) {
+    for (const T& item : init) {
       push_back(item);
     }
   }

--- a/src/support/inplace_vector.h
+++ b/src/support/inplace_vector.h
@@ -16,8 +16,9 @@
 
 //
 // A vector of elements with a maximum size, storing them all in-place. This is
-// similar to C++26's inplace_vector, and is basically a small_vector, except
+// similar to c++26's inplace_vector, and is basically a small_vector, except
 // there is never any dynamic storage.
+// TODO: remove when we have c++26
 //
 
 #ifndef wasm_support_inplace_vector_h

--- a/src/support/inplace_vector.h
+++ b/src/support/inplace_vector.h
@@ -164,30 +164,6 @@ public:
   }
 };
 
-// A inplace_vector for which some values may be read before they are written,
-// and in that case they have the value zero.
-template<typename T, size_t N>
-struct ZeroInitinplace_vector : public inplace_vector<T, N> {
-  T& operator[](size_t i) {
-    if (i >= this->size()) {
-      resize(i + 1);
-    }
-    return inplace_vector<T, N>::operator[](i);
-  }
-
-  const T& operator[](size_t i) const {
-    return const_cast<ZeroInitinplace_vector<T, N>&>(*this)[i];
-  }
-
-  void resize(size_t newSize) {
-    auto oldSize = this->size();
-    inplace_vector<T, N>::resize(newSize);
-    for (size_t i = oldSize; i < this->size(); i++) {
-      (*this)[i] = 0;
-    }
-  }
-};
-
 } // namespace std
 
 #endif // wasm_support_inplace_vector_h

--- a/src/support/small_vector.h
+++ b/src/support/small_vector.h
@@ -49,7 +49,7 @@ public:
     : usedFixed(other.usedFixed), fixed(std::move(other.fixed)),
       flexible(std::move(other.flexible)) {}
   SmallVector(std::initializer_list<T> init) {
-    for (T item : init) {
+    for (const T& item : init) {
       push_back(item);
     }
   }

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -17,6 +17,7 @@ set(unittest_SOURCES
   int128.cpp
   leaves.cpp
   glbs.cpp
+  inplace_vector.cpp
   interpreter.cpp
   intervals.cpp
   istring.cpp

--- a/test/gtest/inplace_vector.cpp
+++ b/test/gtest/inplace_vector.cpp
@@ -5,6 +5,7 @@ using InplaceVectorTest = ::testing::Test;
 
 TEST_F(InplaceVectorTest, Size) {
   std::inplace_vector<int64_t, 10> vec;
+  // An inplace_vector is just a size plus the in-place storage.
   EXPECT_EQ(sizeof(vec), sizeof(size_t) + 10 * sizeof(int64_t));
 }
 

--- a/test/gtest/inplace_vector.cpp
+++ b/test/gtest/inplace_vector.cpp
@@ -3,17 +3,22 @@
 
 using InplaceVectorTest = ::testing::Test;
 
+using namespace wasm;
+
 TEST_F(InplaceVectorTest, Size) {
-  std::inplace_vector<int64_t, 10> vec;
+  inplace_vector<int64_t, 10> vec;
   // An inplace_vector is just a size plus the in-place storage.
   EXPECT_EQ(sizeof(vec), sizeof(size_t) + 10 * sizeof(int64_t));
 }
 
 TEST_F(InplaceVectorTest, Basics) {
-  std::inplace_vector<int, 3> vec;
+  inplace_vector<int, 3> vec;
 
+  EXPECT_EQ(vec.size(), 0);
+  EXPECT_TRUE(vec.empty());
   vec.push_back(10);
   EXPECT_EQ(vec[0], 10);
+  EXPECT_EQ(vec.size(), 1);
 
   vec.resize(3);
   EXPECT_EQ(vec.size(), 3);
@@ -28,7 +33,7 @@ TEST_F(InplaceVectorTest, Basics) {
 }
 
 TEST_F(InplaceVectorTest, I) {
-  std::inplace_vector<int, 3> vec{10, 20, 30};
+  inplace_vector<int, 3> vec{10, 20, 30};
   std::vector<int> normal;
 
   for (auto x : vec) {

--- a/test/gtest/inplace_vector.cpp
+++ b/test/gtest/inplace_vector.cpp
@@ -1,0 +1,9 @@
+#include "support/inplace_vector.h"
+#include "gtest/gtest.h"
+
+using InplaceVectorTest = ::testing::Test;
+
+TEST_F(InplaceVectorTest, Basics) {
+  std::inplace_vector<int64_t, 10> vec;
+  EXPECT_EQ(sizeof(vec), sizeof(size_t) + 10 * sizeof(int64_t));
+}

--- a/test/gtest/inplace_vector.cpp
+++ b/test/gtest/inplace_vector.cpp
@@ -3,7 +3,36 @@
 
 using InplaceVectorTest = ::testing::Test;
 
-TEST_F(InplaceVectorTest, Basics) {
+TEST_F(InplaceVectorTest, Size) {
   std::inplace_vector<int64_t, 10> vec;
   EXPECT_EQ(sizeof(vec), sizeof(size_t) + 10 * sizeof(int64_t));
+}
+
+TEST_F(InplaceVectorTest, Basics) {
+  std::inplace_vector<int, 3> vec;
+
+  vec.push_back(10);
+  EXPECT_EQ(vec[0], 10);
+
+  vec.resize(3);
+  EXPECT_EQ(vec.size(), 3);
+
+  vec[1] = 20;
+  vec[2] = 30;  
+  EXPECT_EQ(vec[1], 20);
+  EXPECT_EQ(vec[2], 30);
+
+  vec.pop_back();
+  EXPECT_EQ(vec.size(), 2);
+}
+
+TEST_F(InplaceVectorTest, I) {
+  std::inplace_vector<int, 3> vec{10, 20, 30};
+  std::vector<int> normal;
+
+  for (auto x : vec) {
+    normal.push_back(x);
+  }
+
+  EXPECT_EQ(normal, std::vector<int>({10, 20, 30}));
 }

--- a/test/gtest/inplace_vector.cpp
+++ b/test/gtest/inplace_vector.cpp
@@ -18,7 +18,7 @@ TEST_F(InplaceVectorTest, Basics) {
   EXPECT_EQ(vec.size(), 3);
 
   vec[1] = 20;
-  vec[2] = 30;  
+  vec[2] = 30;
   EXPECT_EQ(vec[1], 20);
   EXPECT_EQ(vec[2], 30);
 


### PR DESCRIPTION
Header is basically our SmallVector, modified to remove the dynamic
allocation.

This is already useful in one place, and will help more with a future PR.