### PR TITLE
[wasm-split] Scan trapping globals' initailizer

### DIFF
--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -762,27 +762,6 @@ ModuleSplitter::PrimarySecondaryUsedNames ModuleSplitter::computeUsedNames() {
         }
       }
     }
-
-    // Compute the transitive closure of globals referenced in other globals'
-    // initializers. Since globals can reference other globals, we must ensure
-    // that if a global is used in a module, all its dependencies are also
-    // marked as used.
-    UniqueNonrepeatingDeferredQueue<Name> worklist;
-    for (auto global : used.globals) {
-      worklist.push(global);
-    }
-    while (!worklist.empty()) {
-      Name name = worklist.pop();
-      // At this point all globals are still in the primary module, so this
-      // exists
-      auto* global = primary.getGlobal(name);
-      if (!global->imported() && global->init) {
-        for (auto* get : FindAll<GlobalGet>(global->init).list) {
-          worklist.push(get->name);
-          used.globals.insert(get->name);
-        }
-      }
-    }
     return used;
   };
 
@@ -840,6 +819,34 @@ ModuleSplitter::PrimarySecondaryUsedNames ModuleSplitter::computeUsedNames() {
         primaryUsed.tables.insert(table->name);
       }
     }
+  }
+
+  // Compute the transitive closure of globals referenced in other globals'
+  // initializers. Since globals can reference other globals, we must ensure
+  // that if a global is used in a module, all its dependencies are also marked
+  // as used.
+  auto computeTransitiveGlobals = [&](UsedNames& used) {
+    UniqueNonrepeatingDeferredQueue<Name> worklist;
+    for (auto global : used.globals) {
+      worklist.push(global);
+    }
+    while (!worklist.empty()) {
+      Name name = worklist.pop();
+      // At this point all globals are still in the primary module, so this
+      // exists
+      auto* global = primary.getGlobal(name);
+      if (!global->imported() && global->init) {
+        for (auto* get : FindAll<GlobalGet>(global->init).list) {
+          worklist.push(get->name);
+          used.globals.insert(get->name);
+        }
+      }
+    }
+  };
+
+  computeTransitiveGlobals(primaryUsed);
+  for (auto& used : secondaryUsed) {
+    computeTransitiveGlobals(used);
   }
 
   return std::make_pair(primaryUsed, secondaryUsed);

--- a/test/lit/wasm-split/trapping-module-items.wast
+++ b/test/lit/wasm-split/trapping-module-items.wast
@@ -20,6 +20,20 @@
   )
  )
 
+ ;; PRIMARY:         (global $null-desc nullref
+ ;; PRIMARY-TNH-NOT: (global $null-desc nullref
+ (global $null-desc (ref null none)
+  (ref.null none)
+ )
+
+ ;; PRIMARY:         (global $trapping-global-init-global-get (ref $struct)
+ ;; PRIMARY-TNH-NOT: (global $trapping-global-init-global-get (ref $struct)
+ (global $trapping-global-init-global-get (ref $struct)
+  (struct.new_desc $struct
+   (global.get $null-desc)
+  )
+ )
+
  ;; PRIMARY:         (table $trapping-table 1 1 (ref $struct)
  ;; PRIMARY-TNH-NOT: (table $trapping-table 1 1 (ref $struct)
  (table $trapping-table 1 1 (ref $struct)


### PR DESCRIPTION
This basically reverts #8790, which had unforseen consequences. We didn't scan trapping globals' initializer because computing transitive globals happened before adding those trapping globals to the primary module.