### PR TITLE
[wasm-split] Print test numbers for example tests

### DIFF
--- a/test/example/module-splitting.cpp
+++ b/test/example/module-splitting.cpp
@@ -2,8 +2,8 @@
 #include <iostream>
 
 #include "ir/module-splitting.h"
-#include "ir/stack-utils.h"
 #include "parser/wat-parser.h"
+#include "wasm-builder.h"
 #include "wasm-features.h"
 #include "wasm-validator.h"
 #include "wasm.h"
@@ -20,7 +20,9 @@ std::unique_ptr<Module> parse(char* module) {
   return wasm;
 }
 
-void do_test(const std::set<Name>& keptFuncs, std::string&& module) {
+void do_test(int testNo,
+             const std::set<Name>& keptFuncs,
+             std::string&& module) {
   WasmValidator validator;
   bool valid;
 
@@ -33,7 +35,8 @@ void do_test(const std::set<Name>& keptFuncs, std::string&& module) {
     splitFuncs.insert(func->name);
   }
 
-  std::cout << "Before:\n";
+  std::cout << "- Test " << testNo << "\n";
+  std::cout << "\nBefore:\n";
   std::cout << *primary.get();
 
   std::cout << "Keeping: ";
@@ -57,7 +60,7 @@ void do_test(const std::set<Name>& keptFuncs, std::string&& module) {
   auto results = splitFunctions(*primary, config);
   auto& secondary = *results.secondaries.begin();
 
-  std::cout << "After:\n";
+  std::cout << "\nAfter:\n";
   std::cout << *primary.get();
   std::cout << "Secondary:\n";
   std::cout << *secondary.get();
@@ -73,10 +76,10 @@ void test_minimized_exports();
 
 int main() {
   // Trivial module
-  do_test({}, "(module)");
+  do_test(0, {}, "(module)");
 
   // Global stuff
-  do_test({}, R"(
+  do_test(1, {}, R"(
     (module
      (memory $mem (export "mem") 3 42 shared)
      (table $tab (export "tab") 3 42 funcref)
@@ -85,7 +88,7 @@ int main() {
     ))");
 
   // Imported global stuff
-  do_test({}, R"(
+  do_test(2, {}, R"(
     (module
      (memory $mem (export "mem") (import "env" "mem") 3 42 shared)
      (table $tab (export "tab") (import "env" "tab") 3 42 funcref)
@@ -94,7 +97,7 @@ int main() {
     ))");
 
   // Exported global stuff
-  do_test({}, R"(
+  do_test(3, {}, R"(
     (module
      (memory $mem 3 42 shared)
      (table $tab 3 42 funcref)
@@ -107,7 +110,7 @@ int main() {
     ))");
 
   // Non-deferred function
-  do_test({"foo"}, R"(
+  do_test(4, {"foo"}, R"(
     (module
      (func $foo (param i32) (result i32)
       (local.get 0)
@@ -115,7 +118,7 @@ int main() {
     ))");
 
   // Non-deferred exported function
-  do_test({"foo"}, R"(
+  do_test(5, {"foo"}, R"(
     (module
      (export "foo" (func $foo))
      (func $foo (param i32) (result i32)
@@ -124,7 +127,7 @@ int main() {
     ))");
 
   // Non-deferred function in table
-  do_test({"foo"}, R"(
+  do_test(6, {"foo"}, R"(
     (module
      (table $table 1 funcref)
      (elem (i32.const 0) $foo)
@@ -134,7 +137,7 @@ int main() {
     ))");
 
   // Non-deferred function in table multiple times
-  do_test({"foo"}, R"(
+  do_test(7, {"foo"}, R"(
     (module
      (table $table 2 funcref)
      (elem (i32.const 0) $foo $foo)
@@ -144,7 +147,7 @@ int main() {
     ))");
 
   // Non-deferred function in table at non-const offset
-  do_test({"foo"}, R"(
+  do_test(8, {"foo"}, R"(
     (module
      (import "env" "base" (global $base i32))
      (table $table 1 funcref)
@@ -155,7 +158,7 @@ int main() {
     ))");
 
   // Non-deferred function in table at non-const offset multiple times
-  do_test({"foo"}, R"(
+  do_test(9, {"foo"}, R"(
     (module
      (import "env" "base" (global $base i32))
      (table $table 2 funcref)
@@ -166,13 +169,13 @@ int main() {
     ))");
 
   // Non-deferred imported function
-  do_test({"foo"}, R"(
+  do_test(10, {"foo"}, R"(
     (module
      (import "env" "foo" (func $foo (param i32) (result i32)))
     ))");
 
   // Non-deferred exported imported function in table at a weird offset
-  do_test({"foo"}, R"(
+  do_test(11, {"foo"}, R"(
     (module
      (import "env" "foo" (func $foo (param i32) (result i32)))
      (table $table 1000 funcref)
@@ -181,7 +184,7 @@ int main() {
     ))");
 
   // Non-deferred exported imported function in table at a non-const offset
-  do_test({"foo"}, R"(
+  do_test(12, {"foo"}, R"(
     (module
      (import "env" "base" (global $base i32))
      (import "env" "foo" (func $foo (param i32) (result i32)))
@@ -191,7 +194,7 @@ int main() {
     ))");
 
   // Deferred function
-  do_test({}, R"(
+  do_test(13, {}, R"(
     (module
      (func $foo (param i32) (result i32)
       (local.get 0)
@@ -199,7 +202,7 @@ int main() {
     ))");
 
   // Deferred exported function
-  do_test({}, R"(
+  do_test(14, {}, R"(
     (module
      (export "foo" (func $foo))
      (func $foo (param i32) (result i32)
@@ -208,7 +211,7 @@ int main() {
     ))");
 
   // Deferred function in table
-  do_test({}, R"(
+  do_test(15, {}, R"(
     (module
      (table $table 1 funcref)
      (elem (i32.const 0) $foo)
@@ -218,7 +221,7 @@ int main() {
     ))");
 
   // Deferred function in table multiple times
-  do_test({}, R"(
+  do_test(16, {}, R"(
     (module
      (table $table 2 funcref)
      (elem (i32.const 0) $foo $foo)
@@ -228,7 +231,7 @@ int main() {
     ))");
 
   // Deferred exported function in table at a weird offset
-  do_test({}, R"(
+  do_test(17, {}, R"(
     (module
      (table $table 1000 funcref)
      (elem (i32.const 42) $foo)
@@ -239,7 +242,7 @@ int main() {
     ))");
 
   // Deferred exported function in table at a non-const offset
-  do_test({}, R"(
+  do_test(18, {}, R"(
     (module
      (import "env" "base" (global $base i32))
      (table $table 1000 funcref)
@@ -251,7 +254,7 @@ int main() {
     ))");
 
   // Deferred exported function in table at a non-const offset multiple times
-  do_test({}, R"(
+  do_test(19, {}, R"(
     (module
      (import "env" "base" (global $base i32))
      (table $table 1000 funcref)
@@ -263,7 +266,7 @@ int main() {
     ))");
 
   // Deferred exported function in table at an offset from a non-const base
-  do_test({"null"}, R"(
+  do_test(20, {"null"}, R"(
     (module
      (import "env" "base" (global $base i32))
      (table $table 1000 funcref)
@@ -276,7 +279,7 @@ int main() {
     ))");
 
   // Non-deferred function calling non-deferred function
-  do_test({"foo", "bar"}, R"(
+  do_test(21, {"foo", "bar"}, R"(
     (module
      (func $foo
       (call $bar)
@@ -287,7 +290,7 @@ int main() {
     ))");
 
   // Deferred function calling non-deferred function
-  do_test({"bar"}, R"(
+  do_test(22, {"bar"}, R"(
     (module
      (func $foo
       (call $bar)
@@ -298,7 +301,7 @@ int main() {
     ))");
 
   // Non-deferred function calling deferred function
-  do_test({"foo"}, R"(
+  do_test(23, {"foo"}, R"(
     (module
      (func $foo
       (call $bar)
@@ -309,7 +312,7 @@ int main() {
     ))");
 
   // Deferred function calling deferred function
-  do_test({}, R"(
+  do_test(24, {}, R"(
     (module
      (func $foo
       (call $bar)
@@ -320,7 +323,7 @@ int main() {
     ))");
 
   // Deferred function calling non-deferred function with clashing export name
-  do_test({"foo"}, R"(
+  do_test(25, {"foo"}, R"(
     (module
      (export "%foo" (func $bar))
      (func $foo
@@ -332,7 +335,7 @@ int main() {
     ))");
 
   // Mixed table 1
-  do_test({"bar", "quux"}, R"(
+  do_test(26, {"bar", "quux"}, R"(
     (module
      (table $table 4 funcref)
      (elem (i32.const 0) $foo $bar $baz $quux)
@@ -351,7 +354,7 @@ int main() {
     ))");
 
   // Mixed table 1 with non-const offset
-  do_test({"bar", "quux"}, R"(
+  do_test(27, {"bar", "quux"}, R"(
     (module
      (import "env" "base" (global $base i32))
      (table $table 4 funcref)
@@ -371,7 +374,7 @@ int main() {
     ))");
 
   // Mixed table 2
-  do_test({"baz"}, R"(
+  do_test(28, {"baz"}, R"(
     (module
      (table $table 4 funcref)
      (elem (i32.const 0) $foo $bar $baz $quux)
@@ -390,7 +393,7 @@ int main() {
     ))");
 
   // Mixed table 2 with non-const offset
-  do_test({"baz"}, R"(
+  do_test(29, {"baz"}, R"(
     (module
      (import "env" "base" (global $base i32))
      (table $table 4 funcref)
@@ -411,7 +414,7 @@ int main() {
 
   // `foo` is exported both because it is called by `bar` and because it is in a
   // table gap
-  do_test({"foo"}, R"(
+  do_test(30, {"foo"}, R"(
     (module
      (import "env" "base" (global $base i32))
      (table $table 2 funcref)
@@ -425,7 +428,7 @@ int main() {
     ))");
 
   // Mutual recursion with table growth
-  do_test({"foo"}, R"(
+  do_test(31, {"foo"}, R"(
     (module
      (table $table 1 1 funcref)
      (elem (i32.const 0) $foo)
@@ -438,7 +441,7 @@ int main() {
     ))");
 
   // Multiple exports of a secondary function
-  do_test({}, R"(
+  do_test(32, {}, R"(
     (module
      (export "foo1" (func $foo))
      (export "foo2" (func $foo))

--- a/test/example/module-splitting.cpp
+++ b/test/example/module-splitting.cpp
@@ -39,7 +39,7 @@ void do_test(int testNo,
   std::cout << "\nBefore:\n";
   std::cout << *primary.get();
 
-  std::cout << "Keeping: ";
+  std::cout << "\nKeeping: ";
   if (keptFuncs.size()) {
     auto it = keptFuncs.begin();
     splitFuncs.erase(*it);

--- a/test/example/module-splitting.txt
+++ b/test/example/module-splitting.txt
@@ -1,7 +1,10 @@
+- Test 0
+
 Before:
 (module
 )
 Keeping: <none>
+
 After:
 (module
 )
@@ -9,6 +12,8 @@ Secondary:
 (module
 )
 
+
+- Test 1
 
 Before:
 (module
@@ -23,6 +28,7 @@ Before:
  (export "e" (tag $e))
 )
 Keeping: <none>
+
 After:
 (module
  (type $0 (func (param i32)))
@@ -39,6 +45,8 @@ Secondary:
 (module
 )
 
+
+- Test 2
 
 Before:
 (module
@@ -53,6 +61,7 @@ Before:
  (export "e" (tag $e))
 )
 Keeping: <none>
+
 After:
 (module
  (type $0 (func (param i32)))
@@ -70,6 +79,8 @@ Secondary:
 )
 
 
+- Test 3
+
 Before:
 (module
  (type $0 (func (param i32)))
@@ -83,6 +94,7 @@ Before:
  (export "e" (tag $e))
 )
 Keeping: <none>
+
 After:
 (module
  (type $0 (func (param i32)))
@@ -100,6 +112,8 @@ Secondary:
 )
 
 
+- Test 4
+
 Before:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -108,6 +122,7 @@ Before:
  )
 )
 Keeping: foo
+
 After:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -120,6 +135,8 @@ Secondary:
 )
 
 
+- Test 5
+
 Before:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -129,6 +146,7 @@ Before:
  )
 )
 Keeping: foo
+
 After:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -141,6 +159,8 @@ Secondary:
 (module
 )
 
+
+- Test 6
 
 Before:
 (module
@@ -152,6 +172,7 @@ Before:
  )
 )
 Keeping: foo
+
 After:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -166,6 +187,8 @@ Secondary:
 )
 
 
+- Test 7
+
 Before:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -176,6 +199,7 @@ Before:
  )
 )
 Keeping: foo
+
 After:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -189,6 +213,8 @@ Secondary:
 (module
 )
 
+
+- Test 8
 
 Before:
 (module
@@ -201,6 +227,7 @@ Before:
  )
 )
 Keeping: foo
+
 After:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -215,6 +242,8 @@ Secondary:
 (module
 )
 
+
+- Test 9
 
 Before:
 (module
@@ -227,6 +256,7 @@ Before:
  )
 )
 Keeping: foo
+
 After:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -242,12 +272,15 @@ Secondary:
 )
 
 
+- Test 10
+
 Before:
 (module
  (type $0 (func (param i32) (result i32)))
  (import "env" "foo" (func $foo (type $0) (param i32) (result i32)))
 )
 Keeping: foo
+
 After:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -258,6 +291,8 @@ Secondary:
 )
 
 
+- Test 11
+
 Before:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -267,6 +302,7 @@ Before:
  (export "foo" (func $foo))
 )
 Keeping: foo
+
 After:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -279,6 +315,8 @@ Secondary:
 (module
 )
 
+
+- Test 12
 
 Before:
 (module
@@ -290,6 +328,7 @@ Before:
  (export "foo" (func $foo))
 )
 Keeping: foo
+
 After:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -304,6 +343,8 @@ Secondary:
 )
 
 
+- Test 13
+
 Before:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -312,6 +353,7 @@ Before:
  )
 )
 Keeping: <none>
+
 After:
 (module
 )
@@ -324,6 +366,8 @@ Secondary:
 )
 
 
+- Test 14
+
 Before:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -333,6 +377,7 @@ Before:
  )
 )
 Keeping: <none>
+
 After:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -359,6 +404,8 @@ Secondary:
 )
 
 
+- Test 15
+
 Before:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -369,6 +416,7 @@ Before:
  )
 )
 Keeping: <none>
+
 After:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -396,6 +444,8 @@ Secondary:
 )
 
 
+- Test 16
+
 Before:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -406,6 +456,7 @@ Before:
  )
 )
 Keeping: <none>
+
 After:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -433,6 +484,8 @@ Secondary:
 )
 
 
+- Test 17
+
 Before:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -444,6 +497,7 @@ Before:
  )
 )
 Keeping: <none>
+
 After:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -472,6 +526,8 @@ Secondary:
 )
 
 
+- Test 18
+
 Before:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -484,6 +540,7 @@ Before:
  )
 )
 Keeping: <none>
+
 After:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -513,6 +570,8 @@ Secondary:
 )
 
 
+- Test 19
+
 Before:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -525,6 +584,7 @@ Before:
  )
 )
 Keeping: <none>
+
 After:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -554,6 +614,8 @@ Secondary:
 )
 
 
+- Test 20
+
 Before:
 (module
  (type $0 (func))
@@ -569,6 +631,7 @@ Before:
  )
 )
 Keeping: null
+
 After:
 (module
  (type $0 (func))
@@ -601,6 +664,8 @@ Secondary:
 )
 
 
+- Test 21
+
 Before:
 (module
  (type $0 (func))
@@ -612,6 +677,7 @@ Before:
  )
 )
 Keeping: bar, foo
+
 After:
 (module
  (type $0 (func))
@@ -627,6 +693,8 @@ Secondary:
 )
 
 
+- Test 22
+
 Before:
 (module
  (type $0 (func))
@@ -638,6 +706,7 @@ Before:
  )
 )
 Keeping: bar
+
 After:
 (module
  (type $0 (func))
@@ -656,6 +725,8 @@ Secondary:
 )
 
 
+- Test 23
+
 Before:
 (module
  (type $0 (func))
@@ -667,6 +738,7 @@ Before:
  )
 )
 Keeping: foo
+
 After:
 (module
  (type $0 (func))
@@ -691,6 +763,8 @@ Secondary:
 )
 
 
+- Test 24
+
 Before:
 (module
  (type $0 (func))
@@ -702,6 +776,7 @@ Before:
  )
 )
 Keeping: <none>
+
 After:
 (module
 )
@@ -717,6 +792,8 @@ Secondary:
 )
 
 
+- Test 25
+
 Before:
 (module
  (type $0 (func))
@@ -729,6 +806,7 @@ Before:
  )
 )
 Keeping: foo
+
 After:
 (module
  (type $0 (func))
@@ -759,6 +837,8 @@ Secondary:
 )
 
 
+- Test 26
+
 Before:
 (module
  (type $0 (func))
@@ -778,6 +858,7 @@ Before:
  )
 )
 Keeping: bar, quux
+
 After:
 (module
  (type $0 (func))
@@ -819,6 +900,8 @@ Secondary:
 )
 
 
+- Test 27
+
 Before:
 (module
  (type $0 (func))
@@ -839,6 +922,7 @@ Before:
  )
 )
 Keeping: bar, quux
+
 After:
 (module
  (type $0 (func))
@@ -881,6 +965,8 @@ Secondary:
 )
 
 
+- Test 28
+
 Before:
 (module
  (type $0 (func))
@@ -900,6 +986,7 @@ Before:
  )
 )
 Keeping: baz
+
 After:
 (module
  (type $0 (func))
@@ -947,6 +1034,8 @@ Secondary:
 )
 
 
+- Test 29
+
 Before:
 (module
  (type $0 (func))
@@ -967,6 +1056,7 @@ Before:
  )
 )
 Keeping: baz
+
 After:
 (module
  (type $0 (func))
@@ -1015,6 +1105,8 @@ Secondary:
 )
 
 
+- Test 30
+
 Before:
 (module
  (type $0 (func))
@@ -1029,6 +1121,7 @@ Before:
  )
 )
 Keeping: foo
+
 After:
 (module
  (type $0 (func))
@@ -1061,6 +1154,8 @@ Secondary:
 )
 
 
+- Test 31
+
 Before:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -1078,6 +1173,7 @@ Before:
  )
 )
 Keeping: foo
+
 After:
 (module
  (type $0 (func (param i32) (result i32)))
@@ -1109,6 +1205,8 @@ Secondary:
 )
 
 
+- Test 32
+
 Before:
 (module
  (type $0 (func))
@@ -1118,6 +1216,7 @@ Before:
  )
 )
 Keeping: <none>
+
 After:
 (module
  (type $0 (func))

--- a/test/example/module-splitting.txt
+++ b/test/example/module-splitting.txt
@@ -3,6 +3,7 @@
 Before:
 (module
 )
+
 Keeping: <none>
 
 After:
@@ -27,6 +28,7 @@ Before:
  (export "glob" (global $glob))
  (export "e" (tag $e))
 )
+
 Keeping: <none>
 
 After:
@@ -60,6 +62,7 @@ Before:
  (export "glob" (global $glob))
  (export "e" (tag $e))
 )
+
 Keeping: <none>
 
 After:
@@ -93,6 +96,7 @@ Before:
  (export "glob" (global $glob))
  (export "e" (tag $e))
 )
+
 Keeping: <none>
 
 After:
@@ -121,6 +125,7 @@ Before:
   (local.get $0)
  )
 )
+
 Keeping: foo
 
 After:
@@ -145,6 +150,7 @@ Before:
   (local.get $0)
  )
 )
+
 Keeping: foo
 
 After:
@@ -171,6 +177,7 @@ Before:
   (local.get $0)
  )
 )
+
 Keeping: foo
 
 After:
@@ -198,6 +205,7 @@ Before:
   (local.get $0)
  )
 )
+
 Keeping: foo
 
 After:
@@ -226,6 +234,7 @@ Before:
   (local.get $0)
  )
 )
+
 Keeping: foo
 
 After:
@@ -255,6 +264,7 @@ Before:
   (local.get $0)
  )
 )
+
 Keeping: foo
 
 After:
@@ -279,6 +289,7 @@ Before:
  (type $0 (func (param i32) (result i32)))
  (import "env" "foo" (func $foo (type $0) (param i32) (result i32)))
 )
+
 Keeping: foo
 
 After:
@@ -301,6 +312,7 @@ Before:
  (elem $0 (i32.const 42) $foo)
  (export "foo" (func $foo))
 )
+
 Keeping: foo
 
 After:
@@ -327,6 +339,7 @@ Before:
  (elem $0 (global.get $base) $foo)
  (export "foo" (func $foo))
 )
+
 Keeping: foo
 
 After:
@@ -352,6 +365,7 @@ Before:
   (local.get $0)
  )
 )
+
 Keeping: <none>
 
 After:
@@ -376,6 +390,7 @@ Before:
   (local.get $0)
  )
 )
+
 Keeping: <none>
 
 After:
@@ -415,6 +430,7 @@ Before:
   (local.get $0)
  )
 )
+
 Keeping: <none>
 
 After:
@@ -455,6 +471,7 @@ Before:
   (local.get $0)
  )
 )
+
 Keeping: <none>
 
 After:
@@ -496,6 +513,7 @@ Before:
   (local.get $0)
  )
 )
+
 Keeping: <none>
 
 After:
@@ -539,6 +557,7 @@ Before:
   (local.get $0)
  )
 )
+
 Keeping: <none>
 
 After:
@@ -583,6 +602,7 @@ Before:
   (local.get $0)
  )
 )
+
 Keeping: <none>
 
 After:
@@ -630,6 +650,7 @@ Before:
   (local.get $0)
  )
 )
+
 Keeping: null
 
 After:
@@ -676,6 +697,7 @@ Before:
   (nop)
  )
 )
+
 Keeping: bar, foo
 
 After:
@@ -705,6 +727,7 @@ Before:
   (nop)
  )
 )
+
 Keeping: bar
 
 After:
@@ -737,6 +760,7 @@ Before:
   (nop)
  )
 )
+
 Keeping: foo
 
 After:
@@ -775,6 +799,7 @@ Before:
   (nop)
  )
 )
+
 Keeping: <none>
 
 After:
@@ -805,6 +830,7 @@ Before:
   (call $foo)
  )
 )
+
 Keeping: foo
 
 After:
@@ -857,6 +883,7 @@ Before:
   (nop)
  )
 )
+
 Keeping: bar, quux
 
 After:
@@ -921,6 +948,7 @@ Before:
   (nop)
  )
 )
+
 Keeping: bar, quux
 
 After:
@@ -985,6 +1013,7 @@ Before:
   (nop)
  )
 )
+
 Keeping: baz
 
 After:
@@ -1055,6 +1084,7 @@ Before:
   (nop)
  )
 )
+
 Keeping: baz
 
 After:
@@ -1120,6 +1150,7 @@ Before:
   (call $foo)
  )
 )
+
 Keeping: foo
 
 After:
@@ -1172,6 +1203,7 @@ Before:
   )
  )
 )
+
 Keeping: foo
 
 After:
@@ -1215,6 +1247,7 @@ Before:
  (func $foo (type $0)
  )
 )
+
 Keeping: <none>
 
 After:


### PR DESCRIPTION
Without them it is hard to match the code with their outputs. This also inserts newlines between `Before` and `After`.