### PR TITLE
Add --emit-module-names to wasm-opt

### DIFF
--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -857,7 +857,7 @@ static void dumpWasm(Name name, Module* wasm, const PassOptions& options) {
 #endif
   fullName += numstr + "-" + name.toString();
   Colors::setEnabled(false);
-  ModuleWriter writer(options);
+  ModuleWriter writer(options, false);
   writer.setDebugInfo(true);
   writer.writeBinary(*wasm, fullName + ".wasm");
 }

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -857,7 +857,7 @@ static void dumpWasm(Name name, Module* wasm, const PassOptions& options) {
 #endif
   fullName += numstr + "-" + name.toString();
   Colors::setEnabled(false);
-  ModuleWriter writer(options, false);
+  ModuleWriter writer(options);
   writer.setDebugInfo(true);
   writer.writeBinary(*wasm, fullName + ".wasm");
 }

--- a/src/tools/tool-options.h
+++ b/src/tools/tool-options.h
@@ -20,6 +20,7 @@
 #include "ir/module-utils.h"
 #include "pass.h"
 #include "support/command-line.h"
+#include "wasm-io.h"
 
 //
 // Shared options for commandline tools
@@ -259,6 +260,16 @@ struct ToolOptions : public Options {
     if (!preserveTypeOrder) {
       module.typeIndices.clear();
     }
+  }
+
+  void write(ModuleWriter& writer, Module& wasm, Output& output) const {
+    writer.setEmitModuleName(emitModuleNames);
+    writer.write(wasm, output);
+  }
+
+  void write(ModuleWriter& writer, Module& wasm, const std::string& filename) const {
+    writer.setEmitModuleName(emitModuleNames);
+    writer.write(wasm, filename);
   }
 
   virtual void addPassArg(const std::string& key, const std::string& value) {

--- a/src/tools/tool-options.h
+++ b/src/tools/tool-options.h
@@ -267,7 +267,8 @@ struct ToolOptions : public Options {
     writer.write(wasm, output);
   }
 
-  void write(ModuleWriter& writer, Module& wasm, const std::string& filename) const {
+  void
+  write(ModuleWriter& writer, Module& wasm, const std::string& filename) const {
     writer.setEmitModuleName(emitModuleNames);
     writer.write(wasm, filename);
   }

--- a/src/tools/tool-options.h
+++ b/src/tools/tool-options.h
@@ -32,6 +32,7 @@ struct ToolOptions : public Options {
 
   bool quiet = false;
   bool preserveTypeOrder = false;
+  bool emitModuleNames = false;
   IRProfile profile = IRProfile::Normal;
 
   constexpr static const char* ToolOptionsCategory = "Tool options";
@@ -69,13 +70,19 @@ struct ToolOptions : public Options {
            ToolOptionsCategory,
            Arguments::Zero,
            [this](Options*, const std::string&) { quiet = true; })
-      .add(
-        "--experimental-poppy",
-        "",
-        "Parse wast files as Poppy IR for testing purposes.",
-        ToolOptionsCategory,
-        Arguments::Zero,
-        [this](Options*, const std::string&) { profile = IRProfile::Poppy; });
+      .add("--experimental-poppy",
+           "",
+           "Parse wast files as Poppy IR for testing purposes.",
+           ToolOptionsCategory,
+           Arguments::Zero,
+           [this](Options*, const std::string&) { profile = IRProfile::Poppy; })
+      .add("--emit-module-names",
+           "",
+           "Emit module names, even if not emitting the rest of the names "
+           "section.",
+           ToolOptionsCategory,
+           Arguments::Zero,
+           [this](Options*, const std::string&) { emitModuleNames = true; });
     (*this)
       .addFeature(FeatureSet::SignExt, "sign extension operations")
       .addFeature(FeatureSet::Atomics, "atomic operations")

--- a/src/tools/wasm-as.cpp
+++ b/src/tools/wasm-as.cpp
@@ -134,7 +134,7 @@ int main(int argc, const char* argv[]) {
 
   // Ensure the destructor of ModuleWriter runs before quick_exit.
   {
-    ModuleWriter writer(options.passOptions);
+    ModuleWriter writer(options.passOptions, options.emitModuleNames);
     writer.setBinary(true);
     writer.setDebugInfo(debugInfo);
     if (sourceMapFilename.size()) {

--- a/src/tools/wasm-as.cpp
+++ b/src/tools/wasm-as.cpp
@@ -134,7 +134,7 @@ int main(int argc, const char* argv[]) {
 
   // Ensure the destructor of ModuleWriter runs before quick_exit.
   {
-    ModuleWriter writer(options.passOptions, options.emitModuleNames);
+    ModuleWriter writer(options.passOptions);
     writer.setBinary(true);
     writer.setDebugInfo(debugInfo);
     if (sourceMapFilename.size()) {
@@ -144,7 +144,7 @@ int main(int argc, const char* argv[]) {
     if (symbolMap.size() > 0) {
       writer.setSymbolMap(symbolMap);
     }
-    writer.write(wasm, options.extra["output"]);
+    options.write(writer, wasm, options.extra["output"]);
   }
 
   if (options.debug) {

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -1671,7 +1671,7 @@ int main(int argc, const char* argv[]) {
     if (options.debug) {
       std::cout << "writing..." << std::endl;
     }
-    ModuleWriter writer(options.passOptions);
+    ModuleWriter writer(options.passOptions, options.emitModuleNames);
     writer.setBinary(emitBinary);
     writer.setDebugInfo(debugInfo);
     writer.write(wasm, options.extra["output"]);

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -1671,10 +1671,10 @@ int main(int argc, const char* argv[]) {
     if (options.debug) {
       std::cout << "writing..." << std::endl;
     }
-    ModuleWriter writer(options.passOptions, options.emitModuleNames);
+    ModuleWriter writer(options.passOptions);
     writer.setBinary(emitBinary);
     writer.setDebugInfo(debugInfo);
-    writer.write(wasm, options.extra["output"]);
+    options.write(writer, wasm, options.extra["output"]);
   }
 
   flush_and_quick_exit(0);

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -279,7 +279,7 @@ int main(int argc, const char* argv[]) {
 
   if (writeOutput) {
     Output output(outfile, emitBinary ? Flags::Binary : Flags::Text);
-    ModuleWriter writer(options.passOptions, options.emitModuleNames);
+    ModuleWriter writer(options.passOptions);
     writer.setDebugInfo(debugInfo);
     // writer.setSymbolMap(symbolMap);
     writer.setBinary(emitBinary);
@@ -287,7 +287,7 @@ int main(int argc, const char* argv[]) {
       writer.setSourceMapFilename(outputSourceMapFilename);
       writer.setSourceMapUrl(outputSourceMapUrl);
     }
-    writer.write(wasm, output);
+    options.write(writer, wasm, output);
   }
 
   flush_and_quick_exit(0);

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -279,7 +279,7 @@ int main(int argc, const char* argv[]) {
 
   if (writeOutput) {
     Output output(outfile, emitBinary ? Flags::Binary : Flags::Text);
-    ModuleWriter writer(options.passOptions);
+    ModuleWriter writer(options.passOptions, options.emitModuleNames);
     writer.setDebugInfo(debugInfo);
     // writer.setSymbolMap(symbolMap);
     writer.setBinary(emitBinary);

--- a/src/tools/wasm-merge.cpp
+++ b/src/tools/wasm-merge.cpp
@@ -924,7 +924,7 @@ Input source maps can be specified by adding an -ism option right after the modu
   }
 
   if (options.extra.contains("output")) {
-    ModuleWriter writer(options.passOptions);
+    ModuleWriter writer(options.passOptions, options.emitModuleNames);
     writer.setBinary(emitBinary);
     writer.setDebugInfo(debugInfo);
     if (outputSourceMapFilename.size()) {

--- a/src/tools/wasm-merge.cpp
+++ b/src/tools/wasm-merge.cpp
@@ -924,14 +924,14 @@ Input source maps can be specified by adding an -ism option right after the modu
   }
 
   if (options.extra.contains("output")) {
-    ModuleWriter writer(options.passOptions, options.emitModuleNames);
+    ModuleWriter writer(options.passOptions);
     writer.setBinary(emitBinary);
     writer.setDebugInfo(debugInfo);
     if (outputSourceMapFilename.size()) {
       writer.setSourceMapFilename(outputSourceMapFilename);
       writer.setSourceMapUrl(outputSourceMapUrl);
     }
-    writer.write(merged, options.extra["output"]);
+    options.write(writer, merged, options.extra["output"]);
   }
 
   flush_and_quick_exit(0);

--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -659,14 +659,14 @@ int main(int argc, const char* argv[]) {
   graph.apply();
 
   if (options.extra.contains("output")) {
-    ModuleWriter writer(options.passOptions, options.emitModuleNames);
+    ModuleWriter writer(options.passOptions);
     writer.setBinary(emitBinary);
     writer.setDebugInfo(debugInfo);
     if (outputSourceMapFilename.size()) {
       writer.setSourceMapFilename(outputSourceMapFilename);
       writer.setSourceMapUrl(outputSourceMapUrl);
     }
-    writer.write(wasm, options.extra["output"]);
+    options.write(writer, wasm, options.extra["output"]);
   }
 
   // Print out everything that we found is removable, the outside might use that

--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -659,7 +659,7 @@ int main(int argc, const char* argv[]) {
   graph.apply();
 
   if (options.extra.contains("output")) {
-    ModuleWriter writer(options.passOptions);
+    ModuleWriter writer(options.passOptions, options.emitModuleNames);
     writer.setBinary(emitBinary);
     writer.setDebugInfo(debugInfo);
     if (outputSourceMapFilename.size()) {

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -95,6 +95,7 @@ int main(int argc, const char* argv[]) {
   std::string outputSourceMapFilename;
   std::string outputSourceMapUrl;
   bool emitExnref = false;
+  bool emitModuleNames = false;
 
   const std::string WasmOptOption = "wasm-opt options";
 
@@ -269,6 +270,15 @@ For more on how to optimize effectively, see
          [&outputSourceMapUrl](Options* o, const std::string& argument) {
            outputSourceMapUrl = argument;
          })
+    .add(
+      "--emit-module-names",
+      "",
+      "Emit module names, even if not emitting the rest of the names section",
+      WasmOptOption,
+      Options::Arguments::Zero,
+      [&emitModuleNames](Options*, const std::string&) {
+        emitModuleNames = true;
+      })
     .add_positional("INFILE",
                     Options::Arguments::One,
                     [](Options* o, const std::string& argument) {
@@ -407,6 +417,9 @@ For more on how to optimize effectively, see
     ModuleWriter writer(options.passOptions);
     writer.setBinary(emitBinary);
     writer.setDebugInfo(options.passOptions.debugInfo);
+    if (emitModuleNames) {
+      writer.setEmitModuleName(true);
+    }
     writer.write(wasm, options.extra["output"]);
     firstOutput = runCommand(extraFuzzCommand);
     std::cout << "[extra-fuzz-command first output:]\n" << firstOutput << '\n';
@@ -496,6 +509,9 @@ For more on how to optimize effectively, see
     ModuleWriter writer(options.passOptions);
     writer.setBinary(emitBinary);
     writer.setDebugInfo(options.passOptions.debugInfo);
+    if (emitModuleNames) {
+      writer.setEmitModuleName(true);
+    }
     if (outputSourceMapFilename.size()) {
       writer.setSourceMapFilename(outputSourceMapFilename);
       writer.setSourceMapUrl(outputSourceMapUrl);

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -405,12 +405,9 @@ For more on how to optimize effectively, see
 
   if (extraFuzzCommand.size() > 0 && options.extra.contains("output")) {
     BYN_TRACE("writing binary before opts, for extra fuzz command...\n");
-    ModuleWriter writer(options.passOptions);
+    ModuleWriter writer(options.passOptions, options.emitModuleNames);
     writer.setBinary(emitBinary);
     writer.setDebugInfo(options.passOptions.debugInfo);
-    if (options.emitModuleNames) {
-      writer.setEmitModuleName(true);
-    }
     writer.write(wasm, options.extra["output"]);
     firstOutput = runCommand(extraFuzzCommand);
     std::cout << "[extra-fuzz-command first output:]\n" << firstOutput << '\n';
@@ -497,12 +494,9 @@ For more on how to optimize effectively, see
   // Ensure the destructor of ModuleWriter runs before quick_exit.
   {
     BYN_TRACE("writing...\n");
-    ModuleWriter writer(options.passOptions);
+    ModuleWriter writer(options.passOptions, options.emitModuleNames);
     writer.setBinary(emitBinary);
     writer.setDebugInfo(options.passOptions.debugInfo);
-    if (options.emitModuleNames) {
-      writer.setEmitModuleName(true);
-    }
     if (outputSourceMapFilename.size()) {
       writer.setSourceMapFilename(outputSourceMapFilename);
       writer.setSourceMapUrl(outputSourceMapUrl);

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -269,7 +269,7 @@ For more on how to optimize effectively, see
          [&outputSourceMapUrl](Options* o, const std::string& argument) {
            outputSourceMapUrl = argument;
          })
-    
+
     .add_positional("INFILE",
                     Options::Arguments::One,
                     [](Options* o, const std::string& argument) {

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -405,10 +405,10 @@ For more on how to optimize effectively, see
 
   if (extraFuzzCommand.size() > 0 && options.extra.contains("output")) {
     BYN_TRACE("writing binary before opts, for extra fuzz command...\n");
-    ModuleWriter writer(options.passOptions, options.emitModuleNames);
+    ModuleWriter writer(options.passOptions);
     writer.setBinary(emitBinary);
     writer.setDebugInfo(options.passOptions.debugInfo);
-    writer.write(wasm, options.extra["output"]);
+    options.write(writer, wasm, options.extra["output"]);
     firstOutput = runCommand(extraFuzzCommand);
     std::cout << "[extra-fuzz-command first output:]\n" << firstOutput << '\n';
   }
@@ -494,14 +494,14 @@ For more on how to optimize effectively, see
   // Ensure the destructor of ModuleWriter runs before quick_exit.
   {
     BYN_TRACE("writing...\n");
-    ModuleWriter writer(options.passOptions, options.emitModuleNames);
+    ModuleWriter writer(options.passOptions);
     writer.setBinary(emitBinary);
     writer.setDebugInfo(options.passOptions.debugInfo);
     if (outputSourceMapFilename.size()) {
       writer.setSourceMapFilename(outputSourceMapFilename);
       writer.setSourceMapUrl(outputSourceMapUrl);
     }
-    writer.write(wasm, options.extra["output"]);
+    options.write(writer, wasm, options.extra["output"]);
   }
 
   if (extraFuzzCommand.size() > 0) {

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -95,7 +95,6 @@ int main(int argc, const char* argv[]) {
   std::string outputSourceMapFilename;
   std::string outputSourceMapUrl;
   bool emitExnref = false;
-  bool emitModuleNames = false;
 
   const std::string WasmOptOption = "wasm-opt options";
 
@@ -270,15 +269,7 @@ For more on how to optimize effectively, see
          [&outputSourceMapUrl](Options* o, const std::string& argument) {
            outputSourceMapUrl = argument;
          })
-    .add(
-      "--emit-module-names",
-      "",
-      "Emit module names, even if not emitting the rest of the names section",
-      WasmOptOption,
-      Options::Arguments::Zero,
-      [&emitModuleNames](Options*, const std::string&) {
-        emitModuleNames = true;
-      })
+    
     .add_positional("INFILE",
                     Options::Arguments::One,
                     [](Options* o, const std::string& argument) {
@@ -417,7 +408,7 @@ For more on how to optimize effectively, see
     ModuleWriter writer(options.passOptions);
     writer.setBinary(emitBinary);
     writer.setDebugInfo(options.passOptions.debugInfo);
-    if (emitModuleNames) {
+    if (options.emitModuleNames) {
       writer.setEmitModuleName(true);
     }
     writer.write(wasm, options.extra["output"]);
@@ -509,7 +500,7 @@ For more on how to optimize effectively, see
     ModuleWriter writer(options.passOptions);
     writer.setBinary(emitBinary);
     writer.setDebugInfo(options.passOptions.debugInfo);
-    if (emitModuleNames) {
+    if (options.emitModuleNames) {
       writer.setEmitModuleName(true);
     }
     if (outputSourceMapFilename.size()) {

--- a/src/tools/wasm-reduce/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce/wasm-reduce.cpp
@@ -411,7 +411,7 @@ struct Reducer
 
   bool writeAndTestReduction(ProgramResult& out) {
     // write the module out
-    ModuleWriter writer(toolOptions.passOptions);
+    ModuleWriter writer(toolOptions.passOptions, toolOptions.emitModuleNames);
     writer.setBinary(binary);
     writer.setDebugInfo(debugInfo);
     writer.write(*getModule(), test);
@@ -1488,6 +1488,9 @@ More documentation can be found at
   if (debugInfo) {
     extraFlags += " -g ";
   }
+  if (options.emitModuleNames) {
+    extraFlags += " --emit-module-names ";
+  }
 
   if (test.size() == 0) {
     Fatal() << "test file not provided\n";
@@ -1543,7 +1546,7 @@ More documentation can be found at
     if (resultOnInvalid == expected) {
       // Try it on a valid input.
       Module emptyModule;
-      ModuleWriter writer(options.passOptions);
+      ModuleWriter writer(options.passOptions, options.emitModuleNames);
       writer.setBinary(true);
       writer.write(emptyModule, test);
       ProgramResult resultOnValid(command);

--- a/src/tools/wasm-reduce/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce/wasm-reduce.cpp
@@ -411,10 +411,10 @@ struct Reducer
 
   bool writeAndTestReduction(ProgramResult& out) {
     // write the module out
-    ModuleWriter writer(toolOptions.passOptions, toolOptions.emitModuleNames);
+    ModuleWriter writer(toolOptions.passOptions);
     writer.setBinary(binary);
     writer.setDebugInfo(debugInfo);
-    writer.write(*getModule(), test);
+    toolOptions.write(writer, *getModule(), test);
     // note that it is ok for the destructively-reduced module to be bigger
     // than the previous - each destructive reduction removes logical code,
     // and so is strictly better, even if the wasm binary format happens to
@@ -1546,9 +1546,9 @@ More documentation can be found at
     if (resultOnInvalid == expected) {
       // Try it on a valid input.
       Module emptyModule;
-      ModuleWriter writer(options.passOptions, options.emitModuleNames);
+      ModuleWriter writer(options.passOptions);
       writer.setBinary(true);
-      writer.write(emptyModule, test);
+      options.write(writer, emptyModule, test);
       ProgramResult resultOnValid(command);
       if (resultOnValid == expected) {
         Fatal()

--- a/src/tools/wasm-split/split-options.cpp
+++ b/src/tools/wasm-split/split-options.cpp
@@ -312,17 +312,7 @@ WasmSplitOptions::WasmSplitOptions()
          [&](Options* o, const std::string& argument) {
            secondaryMemoryName = argument;
          })
-    .add(
-      "--emit-module-names",
-      "",
-      "Emit module names, even if not emitting the rest of the names section. "
-      "Can help differentiate the modules in stack traces. This option will be "
-      "removed once simpler ways of naming modules are widely available. See "
-      "https://bugs.chromium.org/p/v8/issues/detail?id=11808.",
-      WasmSplitOption,
-      {Mode::Split, Mode::MultiSplit, Mode::Instrument},
-      Options::Arguments::Zero,
-      [&](Options* o, const std::string& arguments) { emitModuleNames = true; })
+
     .add("--initial-table",
          "",
          "A hack to ensure the split and instrumented modules have the same "

--- a/src/tools/wasm-split/split-options.h
+++ b/src/tools/wasm-split/split-options.h
@@ -52,7 +52,6 @@ struct WasmSplitOptions : ToolOptions {
   bool placeholderMap = false;
   bool stripDebug = false;
 
-
   std::string profileFile;
   std::string profileExport = DEFAULT_PROFILE_EXPORT;
 

--- a/src/tools/wasm-split/split-options.h
+++ b/src/tools/wasm-split/split-options.h
@@ -52,8 +52,6 @@ struct WasmSplitOptions : ToolOptions {
   bool placeholderMap = false;
   bool stripDebug = false;
 
-  // TODO: Remove this. See the comment in wasm-binary.h.
-  bool emitModuleNames = false;
 
   std::string profileFile;
   std::string profileExport = DEFAULT_PROFILE_EXPORT;

--- a/src/tools/wasm-split/wasm-split.cpp
+++ b/src/tools/wasm-split/wasm-split.cpp
@@ -100,10 +100,10 @@ void writeModule(Module& wasm,
     runner.add("strip-debug");
     runner.run();
   }
-  ModuleWriter writer(options.passOptions, options.emitModuleNames);
+  ModuleWriter writer(options.passOptions);
   writer.setBinary(options.emitBinary);
   writer.setDebugInfo(options.passOptions.debugInfo && !options.stripDebug);
-  writer.write(wasm, filename);
+  options.write(writer, wasm, filename);
 }
 
 void instrumentModule(const WasmSplitOptions& options) {

--- a/src/tools/wasm-split/wasm-split.cpp
+++ b/src/tools/wasm-split/wasm-split.cpp
@@ -100,12 +100,9 @@ void writeModule(Module& wasm,
     runner.add("strip-debug");
     runner.run();
   }
-  ModuleWriter writer(options.passOptions);
+  ModuleWriter writer(options.passOptions, options.emitModuleNames);
   writer.setBinary(options.emitBinary);
   writer.setDebugInfo(options.passOptions.debugInfo && !options.stripDebug);
-  if (options.emitModuleNames) {
-    writer.setEmitModuleName(true);
-  }
   writer.write(wasm, filename);
 }
 

--- a/src/wasm-io.h
+++ b/src/wasm-io.h
@@ -99,8 +99,7 @@ class ModuleWriter : public ModuleIOBase {
 public:
   // Writing defaults to not storing the names section. Storing it is a user-
   // observable fact that must be opted into.
-  ModuleWriter(const PassOptions& options, bool emitModuleName)
-    : options(options), emitModuleName(emitModuleName) {
+  ModuleWriter(const PassOptions& options) : options(options) {
     setDebugInfo(false);
   }
 
@@ -112,6 +111,7 @@ public:
   void setSourceMapUrl(std::string sourceMapUrl_) {
     sourceMapUrl = sourceMapUrl_;
   }
+  void setEmitModuleName(bool set) { emitModuleName = set; }
 
   // write text
   void writeText(Module& wasm, Output& output);

--- a/src/wasm-io.h
+++ b/src/wasm-io.h
@@ -100,7 +100,7 @@ public:
   // Writing defaults to not storing the names section. Storing it is a user-
   // observable fact that must be opted into.
   ModuleWriter(const PassOptions& options, bool emitModuleName)
-      : options(options), emitModuleName(emitModuleName) {
+    : options(options), emitModuleName(emitModuleName) {
     setDebugInfo(false);
   }
 

--- a/src/wasm-io.h
+++ b/src/wasm-io.h
@@ -99,7 +99,8 @@ class ModuleWriter : public ModuleIOBase {
 public:
   // Writing defaults to not storing the names section. Storing it is a user-
   // observable fact that must be opted into.
-  ModuleWriter(const PassOptions& options) : options(options) {
+  ModuleWriter(const PassOptions& options, bool emitModuleName)
+      : options(options), emitModuleName(emitModuleName) {
     setDebugInfo(false);
   }
 
@@ -111,7 +112,6 @@ public:
   void setSourceMapUrl(std::string sourceMapUrl_) {
     sourceMapUrl = sourceMapUrl_;
   }
-  void setEmitModuleName(bool set) { emitModuleName = set; }
 
   // write text
   void writeText(Module& wasm, Output& output);

--- a/test/lit/emit-module-names.wast
+++ b/test/lit/emit-module-names.wast
@@ -1,0 +1,15 @@
+;; Check that --emit-module-names without -g strips function names but generates
+;; and keeps the module name.
+
+;; RUN: wasm-opt %s --emit-module-names -o %t.wasm
+;; RUN: wasm-dis %t.wasm -o - | filecheck %s
+
+;; CHECK: (module $module-name
+;; CHECK:   (func $0
+;; CHECK-NOT: $foo
+
+(module $module-name
+  (func $foo
+    (nop)
+  )
+)

--- a/test/lit/help/wasm-as.test
+++ b/test/lit/help/wasm-as.test
@@ -38,9 +38,8 @@
 ;; CHECK-NEXT:   --experimental-poppy                 Parse wast files as Poppy IR for testing
 ;; CHECK-NEXT:                                        purposes.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --emit-module-names                  Emit module names, even if not
-;; CHECK-NEXT:                                        emitting the rest of the names
-;; CHECK-NEXT:                                        section
+;; CHECK-NEXT:   --emit-module-names                  Emit module names, even if not emitting
+;; CHECK-NEXT:                                        the rest of the names section
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-sign-ext                    Enable sign extension operations
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm-as.test
+++ b/test/lit/help/wasm-as.test
@@ -38,6 +38,10 @@
 ;; CHECK-NEXT:   --experimental-poppy                 Parse wast files as Poppy IR for testing
 ;; CHECK-NEXT:                                        purposes.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --emit-module-names                  Emit module names, even if not
+;; CHECK-NEXT:                                        emitting the rest of the names
+;; CHECK-NEXT:                                        section
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-sign-ext                    Enable sign extension operations
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-sign-ext                   Disable sign extension operations

--- a/test/lit/help/wasm-ctor-eval.test
+++ b/test/lit/help/wasm-ctor-eval.test
@@ -45,6 +45,10 @@
 ;; CHECK-NEXT:   --experimental-poppy                 Parse wast files as Poppy IR for testing
 ;; CHECK-NEXT:                                        purposes.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --emit-module-names                  Emit module names, even if not
+;; CHECK-NEXT:                                        emitting the rest of the names
+;; CHECK-NEXT:                                        section
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-sign-ext                    Enable sign extension operations
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-sign-ext                   Disable sign extension operations

--- a/test/lit/help/wasm-ctor-eval.test
+++ b/test/lit/help/wasm-ctor-eval.test
@@ -45,9 +45,8 @@
 ;; CHECK-NEXT:   --experimental-poppy                 Parse wast files as Poppy IR for testing
 ;; CHECK-NEXT:                                        purposes.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --emit-module-names                  Emit module names, even if not
-;; CHECK-NEXT:                                        emitting the rest of the names
-;; CHECK-NEXT:                                        section
+;; CHECK-NEXT:   --emit-module-names                  Emit module names, even if not emitting
+;; CHECK-NEXT:                                        the rest of the names section
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-sign-ext                    Enable sign extension operations
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm-dis.test
+++ b/test/lit/help/wasm-dis.test
@@ -31,9 +31,8 @@
 ;; CHECK-NEXT:   --experimental-poppy                 Parse wast files as Poppy IR for testing
 ;; CHECK-NEXT:                                        purposes.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --emit-module-names                  Emit module names, even if not
-;; CHECK-NEXT:                                        emitting the rest of the names
-;; CHECK-NEXT:                                        section
+;; CHECK-NEXT:   --emit-module-names                  Emit module names, even if not emitting
+;; CHECK-NEXT:                                        the rest of the names section
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-sign-ext                    Enable sign extension operations
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm-dis.test
+++ b/test/lit/help/wasm-dis.test
@@ -31,6 +31,10 @@
 ;; CHECK-NEXT:   --experimental-poppy                 Parse wast files as Poppy IR for testing
 ;; CHECK-NEXT:                                        purposes.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --emit-module-names                  Emit module names, even if not
+;; CHECK-NEXT:                                        emitting the rest of the names
+;; CHECK-NEXT:                                        section
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-sign-ext                    Enable sign extension operations
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-sign-ext                   Disable sign extension operations

--- a/test/lit/help/wasm-emscripten-finalize.test
+++ b/test/lit/help/wasm-emscripten-finalize.test
@@ -73,9 +73,8 @@
 ;; CHECK-NEXT:   --experimental-poppy                 Parse wast files as Poppy IR for testing
 ;; CHECK-NEXT:                                        purposes.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --emit-module-names                  Emit module names, even if not
-;; CHECK-NEXT:                                        emitting the rest of the names
-;; CHECK-NEXT:                                        section
+;; CHECK-NEXT:   --emit-module-names                  Emit module names, even if not emitting
+;; CHECK-NEXT:                                        the rest of the names section
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-sign-ext                    Enable sign extension operations
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm-emscripten-finalize.test
+++ b/test/lit/help/wasm-emscripten-finalize.test
@@ -73,6 +73,10 @@
 ;; CHECK-NEXT:   --experimental-poppy                 Parse wast files as Poppy IR for testing
 ;; CHECK-NEXT:                                        purposes.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --emit-module-names                  Emit module names, even if not
+;; CHECK-NEXT:                                        emitting the rest of the names
+;; CHECK-NEXT:                                        section
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-sign-ext                    Enable sign extension operations
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-sign-ext                   Disable sign extension operations

--- a/test/lit/help/wasm-merge.test
+++ b/test/lit/help/wasm-merge.test
@@ -68,9 +68,8 @@
 ;; CHECK-NEXT:   --experimental-poppy                 Parse wast files as Poppy IR for testing
 ;; CHECK-NEXT:                                        purposes.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --emit-module-names                  Emit module names, even if not
-;; CHECK-NEXT:                                        emitting the rest of the names
-;; CHECK-NEXT:                                        section
+;; CHECK-NEXT:   --emit-module-names                  Emit module names, even if not emitting
+;; CHECK-NEXT:                                        the rest of the names section
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-sign-ext                    Enable sign extension operations
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm-merge.test
+++ b/test/lit/help/wasm-merge.test
@@ -68,6 +68,10 @@
 ;; CHECK-NEXT:   --experimental-poppy                 Parse wast files as Poppy IR for testing
 ;; CHECK-NEXT:                                        purposes.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --emit-module-names                  Emit module names, even if not
+;; CHECK-NEXT:                                        emitting the rest of the names
+;; CHECK-NEXT:                                        section
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-sign-ext                    Enable sign extension operations
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-sign-ext                   Disable sign extension operations

--- a/test/lit/help/wasm-metadce.test
+++ b/test/lit/help/wasm-metadce.test
@@ -698,6 +698,10 @@
 ;; CHECK-NEXT:   --experimental-poppy                          Parse wast files as Poppy IR for
 ;; CHECK-NEXT:                                                 testing purposes.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --emit-module-names                           Emit module names, even if not
+;; CHECK-NEXT:                                                 emitting the rest of the names
+;; CHECK-NEXT:                                                 section
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-sign-ext                             Enable sign extension operations
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-sign-ext                            Disable sign extension

--- a/test/lit/help/wasm-opt.test
+++ b/test/lit/help/wasm-opt.test
@@ -98,6 +98,10 @@
 ;; CHECK-NEXT:   --output-source-map-url,-osu                  Emit specified string as source
 ;; CHECK-NEXT:                                                 map URL
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --emit-module-names                           Emit module names, even if not
+;; CHECK-NEXT:                                                 emitting the rest of the names
+;; CHECK-NEXT:                                                 section
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --experimental-new-eh                         Deprecated; same as
 ;; CHECK-NEXT:                                                 --emit-exnref
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm-opt.test
+++ b/test/lit/help/wasm-opt.test
@@ -98,10 +98,6 @@
 ;; CHECK-NEXT:   --output-source-map-url,-osu                  Emit specified string as source
 ;; CHECK-NEXT:                                                 map URL
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --emit-module-names                           Emit module names, even if not
-;; CHECK-NEXT:                                                 emitting the rest of the names
-;; CHECK-NEXT:                                                 section
-;; CHECK-NEXT:
 ;; CHECK-NEXT:   --experimental-new-eh                         Deprecated; same as
 ;; CHECK-NEXT:                                                 --emit-exnref
 ;; CHECK-NEXT:
@@ -737,6 +733,10 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --experimental-poppy                          Parse wast files as Poppy IR for
 ;; CHECK-NEXT:                                                 testing purposes.
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --emit-module-names                           Emit module names, even if not
+;; CHECK-NEXT:                                                 emitting the rest of the names
+;; CHECK-NEXT:                                                 section
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-sign-ext                             Enable sign extension operations
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm-reduce.test
+++ b/test/lit/help/wasm-reduce.test
@@ -121,9 +121,8 @@
 ;; CHECK-NEXT:   --experimental-poppy                 Parse wast files as Poppy IR for testing
 ;; CHECK-NEXT:                                        purposes.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --emit-module-names                  Emit module names, even if not
-;; CHECK-NEXT:                                        emitting the rest of the names
-;; CHECK-NEXT:                                        section
+;; CHECK-NEXT:   --emit-module-names                  Emit module names, even if not emitting
+;; CHECK-NEXT:                                        the rest of the names section
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-sign-ext                    Enable sign extension operations
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm-reduce.test
+++ b/test/lit/help/wasm-reduce.test
@@ -121,6 +121,10 @@
 ;; CHECK-NEXT:   --experimental-poppy                 Parse wast files as Poppy IR for testing
 ;; CHECK-NEXT:                                        purposes.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --emit-module-names                  Emit module names, even if not
+;; CHECK-NEXT:                                        emitting the rest of the names
+;; CHECK-NEXT:                                        section
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-sign-ext                    Enable sign extension operations
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-sign-ext                   Disable sign extension operations

--- a/test/lit/help/wasm-split.test
+++ b/test/lit/help/wasm-split.test
@@ -173,9 +173,8 @@
 ;; CHECK-NEXT:   --experimental-poppy                 Parse wast files as Poppy IR for testing
 ;; CHECK-NEXT:                                        purposes.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --emit-module-names                  Emit module names, even if not
-;; CHECK-NEXT:                                        emitting the rest of the names
-;; CHECK-NEXT:                                        section
+;; CHECK-NEXT:   --emit-module-names                  Emit module names, even if not emitting
+;; CHECK-NEXT:                                        the rest of the names section
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-sign-ext                    Enable sign extension operations
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm-split.test
+++ b/test/lit/help/wasm-split.test
@@ -124,15 +124,6 @@
 ;; CHECK-NEXT:                                        memory created to store profile
 ;; CHECK-NEXT:                                        information.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --emit-module-names                  [split, multi-split, instrument] Emit
-;; CHECK-NEXT:                                        module names, even if not emitting the
-;; CHECK-NEXT:                                        rest of the names section. Can help
-;; CHECK-NEXT:                                        differentiate the modules in stack
-;; CHECK-NEXT:                                        traces. This option will be removed once
-;; CHECK-NEXT:                                        simpler ways of naming modules are widely
-;; CHECK-NEXT:                                        available. See
-;; CHECK-NEXT:                                        https://bugs.chromium.org/p/v8/issues/detail?id=11808.
-;; CHECK-NEXT:
 ;; CHECK-NEXT:   --initial-table                      [split, instrument] A hack to ensure the
 ;; CHECK-NEXT:                                        split and instrumented modules have the
 ;; CHECK-NEXT:                                        same table size when using Emscripten's
@@ -181,6 +172,10 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --experimental-poppy                 Parse wast files as Poppy IR for testing
 ;; CHECK-NEXT:                                        purposes.
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --emit-module-names                  Emit module names, even if not
+;; CHECK-NEXT:                                        emitting the rest of the names
+;; CHECK-NEXT:                                        section
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-sign-ext                    Enable sign extension operations
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm2js.test
+++ b/test/lit/help/wasm2js.test
@@ -662,6 +662,10 @@
 ;; CHECK-NEXT:   --experimental-poppy                          Parse wast files as Poppy IR for
 ;; CHECK-NEXT:                                                 testing purposes.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --emit-module-names                           Emit module names, even if not
+;; CHECK-NEXT:                                                 emitting the rest of the names
+;; CHECK-NEXT:                                                 section
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-sign-ext                             Enable sign extension operations
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-sign-ext                            Disable sign extension


### PR DESCRIPTION
The `wasm-split` command has this `--emit-module-names` flag already and this adds it to `wasm-opt` as well.

Wasm runtimes may not know the URL where a wasm file came from, it may only be given the bytes.
If so, then e.g. V8 prints a wasm-runtime-specific hash of the wasm bytes in stack traces. If a stack trace has
frames of different wasm modules, these hashes do not allow mapping the frames back to the original wasm files.

If we have the ability to keep module names, then it would print the module name (**) (instead of the hash) --
which would allow a stack trace decoding tool to tie the module name back to the right wasm module of an app.

(**) It prefers the wasm file url. If that isn't available it falls back to module name. If that isn't available it falls back to hash of wasm bytes.

See also https://issues.chromium.org/issues/42201791