### PR TITLE
Fix typing in RemoveRelaxedSIMD

### DIFF
--- a/src/passes/RemoveRelaxedSIMD.cpp
+++ b/src/passes/RemoveRelaxedSIMD.cpp
@@ -40,6 +40,7 @@ struct RemoveRelaxedSIMD : WalkerPass<PostWalker<RemoveRelaxedSIMD>> {
       ChildLocalizer(curr, getFunction(), *getModule(), getPassOptions())
         .getChildrenReplacement();
     block->list.push_back(Builder(*getModule()).makeUnreachable());
+    block->type = Type::unreachable;
     replaceCurrent(block);
   }
 

--- a/test/lit/passes/remove-relaxed-simd.wast
+++ b/test/lit/passes/remove-relaxed-simd.wast
@@ -192,4 +192,21 @@
       )
     )
   )
+
+  ;; CHECK:      (func $nested (type $1) (result v128)
+  ;; CHECK-NEXT:  (block
+  ;; CHECK-NEXT:   (unreachable)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (unreachable)
+  ;; CHECK-NEXT: )
+  (func $nested (result v128)
+    (f32x4.relaxed_min
+      (v128.const i32x4 0x00000000 0x00000000 0x00000000 0x00000000)
+      (f32x4.relaxed_madd
+        (v128.const i32x4 0x00000000 0x00000000 0x00000000 0x00000000)
+        (v128.const i32x4 0x00000000 0x00000000 0x00000000 0x00000000)
+        (v128.const i32x4 0x00000000 0x00000000 0x00000000 0x00000000)
+      )
+    )
+  )
 )


### PR DESCRIPTION
When RemoveRelaxedSIMD replaced a relaxed SIMD instruction with a block ending in `(unreachable)`, it previously failed to set that block's type to `Type::unreachable`. When the block's parent was another relaxed SIMD instruction, the incorrect type caused an assertion failure.
