### PR TITLE
[Strings] Fix Tag types in StringLowering

### DIFF
--- a/src/passes/StringLowering.cpp
+++ b/src/passes/StringLowering.cpp
@@ -305,10 +305,11 @@ struct StringLowering : public StringGathering {
     // things like the types of parameters (which depend on the type of the
     // function, which must be modified either in TypeMapper - but as just
     // explained we cannot do that - or before it, which is what we do here).
-    for (auto& func : module->functions) {
-      if (func->type.getHeapType().getRecGroup().size() != 1 ||
-          !func->type.getFeatures().hasStrings()) {
-        continue;
+    auto fixType = [&](HeapType type) {
+      if (type.getRecGroup().size() != 1 ||
+          !type.getFeatures().hasStrings()) {
+        // This is ok as it is.
+        return type;
       }
 
       // Fix up the stringrefs in this type that uses strings and is in a
@@ -321,18 +322,26 @@ struct StringLowering : public StringGathering {
         }
         return t;
       };
-      for (auto param : func->type.getHeapType().getSignature().params) {
+      for (auto param : type.getSignature().params) {
         params.push_back(fix(param));
       }
-      for (auto result : func->type.getHeapType().getSignature().results) {
+      for (auto result : type.getSignature().results) {
         results.push_back(fix(result));
       }
 
       // In addition to doing the update, mark it in the map of updates for
       // TypeMapper, so RefFuncs with this type get updated.
-      auto old = func->type;
-      func->type = func->type.with(Signature(params, results));
-      updates[old.getHeapType()] = func->type.getHeapType();
+      HeapType newType = Signature(params, results);
+      updates[type] = newType;
+      return newType;
+    };
+
+    // Update functions and tags.
+    for (auto& func : module->functions) {
+      func->type = func->type.with(fixType(func->type.getHeapType()));
+    }
+    for (auto& tag : module->tags) {
+      tag->type = fixType(tag->type);
     }
 
     // Strings turn into externref.

--- a/src/passes/StringLowering.cpp
+++ b/src/passes/StringLowering.cpp
@@ -306,8 +306,7 @@ struct StringLowering : public StringGathering {
     // function, which must be modified either in TypeMapper - but as just
     // explained we cannot do that - or before it, which is what we do here).
     auto fixType = [&](HeapType type) {
-      if (type.getRecGroup().size() != 1 ||
-          !type.getFeatures().hasStrings()) {
+      if (type.getRecGroup().size() != 1 || !type.getFeatures().hasStrings()) {
         // This is ok as it is.
         return type;
       }

--- a/test/lit/passes/string-lowering_types.wast
+++ b/test/lit/passes/string-lowering_types.wast
@@ -136,3 +136,77 @@
     (unreachable)
   )
 )
+
+;; Check that we update tag types. The tag here has a string, and we must lower
+;; it out, even though in this module the tag type appears public (there is an
+;; exported table, which in open world makes all function types public).
+(module
+  (type $str (func (param (ref string))))
+
+  ;; CHECK:      (type $0 (array (mut i16)))
+
+  ;; CHECK:      (type $1 (func (param externref externref) (result i32)))
+
+  ;; CHECK:      (type $2 (func (param externref) (result i32)))
+
+  ;; CHECK:      (type $3 (func (param (ref extern))))
+
+  ;; CHECK:      (type $4 (func))
+
+  ;; CHECK:      (type $5 (func (param (ref null $0) i32 i32) (result (ref extern))))
+
+  ;; CHECK:      (type $6 (func (param i32) (result (ref extern))))
+
+  ;; CHECK:      (type $7 (func (param externref externref) (result (ref extern))))
+
+  ;; CHECK:      (type $8 (func (param externref (ref null $0) i32) (result i32)))
+
+  ;; CHECK:      (type $9 (func (param externref i32) (result i32)))
+
+  ;; CHECK:      (type $10 (func (param externref i32 i32) (result (ref extern))))
+
+  ;; CHECK:      (import "string.const" "0" (global $"string.const_\"whoops\"" (ref extern)))
+
+  ;; CHECK:      (import "wasm:js-string" "fromCharCodeArray" (func $fromCharCodeArray (type $5) (param (ref null $0) i32 i32) (result (ref extern))))
+
+  ;; CHECK:      (import "wasm:js-string" "fromCodePoint" (func $fromCodePoint (type $6) (param i32) (result (ref extern))))
+
+  ;; CHECK:      (import "wasm:js-string" "concat" (func $concat (type $7) (param externref externref) (result (ref extern))))
+
+  ;; CHECK:      (import "wasm:js-string" "intoCharCodeArray" (func $intoCharCodeArray (type $8) (param externref (ref null $0) i32) (result i32)))
+
+  ;; CHECK:      (import "wasm:js-string" "equals" (func $equals (type $1) (param externref externref) (result i32)))
+
+  ;; CHECK:      (import "wasm:js-string" "test" (func $test (type $2) (param externref) (result i32)))
+
+  ;; CHECK:      (import "wasm:js-string" "compare" (func $compare (type $1) (param externref externref) (result i32)))
+
+  ;; CHECK:      (import "wasm:js-string" "length" (func $length (type $2) (param externref) (result i32)))
+
+  ;; CHECK:      (import "wasm:js-string" "charCodeAt" (func $charCodeAt (type $9) (param externref i32) (result i32)))
+
+  ;; CHECK:      (import "wasm:js-string" "substring" (func $substring (type $10) (param externref i32 i32) (result (ref extern))))
+
+  ;; CHECK:      (table $table 1 1 funcref)
+
+  ;; CHECK:      (tag $tag (type $3) (param (ref extern)))
+  (tag $tag (type $str) (param (ref string)))
+
+  (table $table 1 1 funcref)
+
+  ;; CHECK:      (export "throw" (func $throw))
+
+  ;; CHECK:      (export "table" (table $table))
+  (export "table" (table $table))
+
+  ;; CHECK:      (func $throw (type $4)
+  ;; CHECK-NEXT:  (throw $tag
+  ;; CHECK-NEXT:   (global.get $"string.const_\"whoops\"")
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $throw (export "throw")
+    (throw $tag
+      (string.const "whoops")
+    )
+  )
+)


### PR DESCRIPTION
We need to handle signature types, even public ones, when lowering away the
string type. We did that for functions' types, but not tags'. This adds a loop over
tags as well.