### PR TITLE
[wasm-merge] Unescape names in --output-manifest

### DIFF
--- a/src/tools/wasm-merge.cpp
+++ b/src/tools/wasm-merge.cpp
@@ -917,7 +917,7 @@ Input source maps can be specified by adding an -ism option right after the modu
 
       manifest << moduleName << "\n";
       for (auto func : funcs) {
-        manifest << func << "\n";
+        manifest << Names::unescape(func.toString()) << "\n";
       }
       manifest << "\n";
     }

--- a/test/lit/merge/manifest-unescape.wat
+++ b/test/lit/merge/manifest-unescape.wat
@@ -4,5 +4,4 @@
 ;; CHECK:      second
 ;; CHECK-NEXT: foo bar
 
-(module
-)
+(module)

--- a/test/lit/merge/manifest-unescape.wat
+++ b/test/lit/merge/manifest-unescape.wat
@@ -1,0 +1,8 @@
+;; RUN: wasm-merge %s first %s.second second --output-manifest %t.manifest -o %t.wasm
+;; RUN: cat %t.manifest | filecheck %s
+
+;; CHECK:      second
+;; CHECK-NEXT: foo bar
+
+(module
+)

--- a/test/lit/merge/manifest-unescape.wat.second
+++ b/test/lit/merge/manifest-unescape.wat.second
@@ -1,0 +1,5 @@
+(module
+  (func $foo\20bar (export "foo bar")
+    nop
+  )
+)


### PR DESCRIPTION
`--output-manifest` currently prints escaped names as they are. If we use this directly in wasm-split, it will be escaped again: https://github.com/WebAssembly/binaryen/blob/8a34ba8bb0a21def76ee6f4ec2ff43b59d9e7317/src/tools/wasm-split/wasm-split.cpp#L433

So if there was a name `foo bar`, wasm-merge reads it as `foo\20bar`, and prints it as is to the output manifest file. wasm-split reads it, unescape this again to `foo\5c20bar`, which is not what we want.