### PR TITLE
[wasm-merge] Make empty function names explicit with --output-manifest

### DIFF
--- a/src/tools/wasm-merge.cpp
+++ b/src/tools/wasm-merge.cpp
@@ -852,13 +852,13 @@ Input source maps can be specified by adding an -ism option right after the modu
       // The functions in the module have been renamed and copied rather than
       // moved, so we can get their final names directly. (We don't need this
       // for the first module because it does not appear in the manifest.)
-      auto& funcs = moduleFuncs[inputFileName];
-      for (auto& func : currModule->functions) {
-        if (!func->imported()) {
-          funcs.push_back(func->name);
-          // Even if  function name is empty, if we were to put it in the output
-          // manifest, it has to be emitted in the name section.
-          if (!manifestFile.empty()) {
+      if (!manifestFile.empty()) {
+        auto& funcs = moduleFuncs[inputFileName];
+        for (auto& func : currModule->functions) {
+          if (!func->imported()) {
+            funcs.push_back(func->name);
+            // Even if  function name is empty, if we were to put it in the
+            // output manifest, it has to be emitted in the name section.
             merged.getFunction(func->name)->hasExplicitName = true;
           }
         }

--- a/src/tools/wasm-merge.cpp
+++ b/src/tools/wasm-merge.cpp
@@ -857,7 +857,7 @@ Input source maps can be specified by adding an -ism option right after the modu
         for (auto& func : currModule->functions) {
           if (!func->imported()) {
             funcs.push_back(func->name);
-            // Even if  function name is empty, if we were to put it in the
+            // Even if the function name is empty, if we were to put it in the
             // output manifest, it has to be emitted in the name section.
             merged.getFunction(func->name)->hasExplicitName = true;
           }

--- a/src/tools/wasm-merge.cpp
+++ b/src/tools/wasm-merge.cpp
@@ -856,6 +856,11 @@ Input source maps can be specified by adding an -ism option right after the modu
       for (auto& func : currModule->functions) {
         if (!func->imported()) {
           funcs.push_back(func->name);
+          // Even if  function name is empty, if we were to put it in the output
+          // manifest, it has to be emitted in the name section.
+          if (!manifestFile.empty()) {
+            merged.getFunction(func->name)->hasExplicitName = true;
+          }
         }
       }
 

--- a/test/lit/merge/manifest-explicit-name.wat
+++ b/test/lit/merge/manifest-explicit-name.wat
@@ -1,0 +1,29 @@
+;; RUN: wasm-merge %s first %s second --rename-export-conflicts --output-manifest %t.manifest -o %t.wasm
+;; RUN: cat %t.manifest | filecheck %s
+;; RUN: wasm-dis %t.wasm -o - | filecheck %s --check-prefix MERGED
+
+;; This tests if the internal names of empty function names are correctly
+;; preserved in the name section so that they can match the names in the
+;; manifest file.
+
+;; CHECK:      second
+;; CHECK-NEXT: 0_1
+;; CHECK-NEXT:
+
+;; MERGED:      (module
+;; MERGED-NEXT:  (type $0 (func))
+;; MERGED-NEXT:  (export "foo" (func $0))
+;; MERGED-NEXT:  (export "foo_1" (func $0_1))
+;; MERGED-NEXT:  (func $0
+;; MERGED-NEXT:   (nop)
+;; MERGED-NEXT:  )
+;; MERGED-NEXT:  (func $0_1
+;; MERGED-NEXT:   (nop)
+;; MERGED-NEXT:  )
+;; MERGED-NEXT: )
+
+(module
+  (func (export "foo")
+    nop
+  )
+)


### PR DESCRIPTION
Even for empty function names, they will be written to a manifest file when `--output-manifest` is given. But currently we don't print their names in the name section, making them not searchable by wasm-split that use the manifest file.