### PR TITLE
[wasm-split] Use escapes names for manifest files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Current Trunk
 - Add acqrel ordering support for atomic fences (#8845). Breaks the C API;
   `BinaryenAtomicFence` now takes a memory order param. Use
   `BinaryenMemoryOrderSeqCst()` to preserve the original behavior.
+- wasm-split's --manifest option now takes a manifest file with escaped function
+  names instead of unescaped ones, e.g., `foo\20bar` instead of `foo bar`.
 
 v130
 ----

--- a/src/tools/wasm-split/wasm-split.cpp
+++ b/src/tools/wasm-split/wasm-split.cpp
@@ -431,7 +431,7 @@ void multiSplitModule(const WasmSplitOptions& options) {
       }
       continue;
     }
-    Name name = Names::escape(line);
+    Name name(line);
     if (newSection) {
       if (name.endsWith(":")) {
         name = name.substr(0, name.size() - 1);

--- a/test/lit/wasm-split/multi-split-escape-names.wast.manifest
+++ b/test/lit/wasm-split/multi-split-escape-names.wast.manifest
@@ -1,8 +1,8 @@
 1:
-wasm::Type::getFeatures() const
+wasm::Type::getFeatures\28\29\20const
 
 2:
-wasm::Literal::Literal(std::__2::array<wasm::Literal, 4ul> const&)
+wasm::Literal::Literal\28std::__2::array<wasm::Literal\2c\204ul>\20const&\29
 
 3:
-std::operator<<(std::__2::basic_ostream<char, std::__2::char_traits<char>>&, wasm::Module&)
+std::operator<<\28std::__2::basic_ostream<char\2c\20std::__2::char_traits<char>>&\2c\20wasm::Module&\29


### PR DESCRIPTION
This changes the wasm-split's manifest file format from unescaped function names to escaped ones. This allows us to specify all characters including newlines within function names.