### PR TITLE
NFC: Fix gmock integration in unit tests

### DIFF
--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -37,18 +37,11 @@ set(unittest_SOURCES
   type-builder.cpp
   wat-lexer.cpp
   validator.cpp
+  source-map.cpp
 )
 
 if(BUILD_FUZZTEST)
   set(unittest_SOURCES ${unittest_SOURCES} type-domains.cpp)
-else()
-  # source-map.cpp uses the gmock-matchers.h header, which is included with the
-  # "standard" upstream gtest library, but not with the one bundled into the
-  # fuzztest library (and the gmock included with upstream gtest seems
-  # incompatible with the one in fuzztest). For now we work around this by just
-  # excluding source-map.cpp from the fuzztest build, but if we start using
-  # gmock more we should figure out what the right way to hande this is.
-  set(unittest_SOURCES ${unittest_SOURCES} source-map.cpp)
 endif()
 
 # suffix_tree.cpp includes LLVM header using std::iterator (deprecated in C++17)
@@ -61,6 +54,7 @@ include(GoogleTest)
 binaryen_add_executable(binaryen-unittests "${unittest_SOURCES}")
 if(BUILD_FUZZTEST)
   link_fuzztest(binaryen-unittests)
+  target_link_libraries(binaryen-unittests PRIVATE gmock)
   gtest_discover_tests(binaryen-unittests)
 else()
   target_link_libraries(binaryen-unittests PRIVATE gtest gtest_main)


### PR DESCRIPTION
Tested with the following code which passes (in arena.cpp, not in source-map.cpp which would have already worked previously due to how it was handled in the build file):


```c++
#include "gmock/gmock-matchers.h"
...
EXPECT_THAT(1, ::testing::Eq(1));
```

This was written by Gemini. I didn't quite understand the fix but I figured it's worth doing to make tests easier to write. Below is Gemini's description of the fix.

---

Previously, when `BUILD_FUZZTEST=ON`, the `fuzztest` dependency would download its own newer version of `googletest` (v1.14.0) via CMake `FetchContent`. The `gmock` headers bundled in Binaryen's `third_party/googletest/googlemock` were incompatible with this newer `googletest`. This caused compilation failures for tests using `gmock`. As a workaround, `source-map.cpp` was completely excluded from the test suite during fuzztest builds.

This fix works because `fuzztest`'s `FetchContent` actually makes the `gmock` target available as well. By linking `binaryen-unittests` against the `gmock` target when `BUILD_FUZZTEST=ON`, CMake correctly configures the include paths to use the newly fetched `gmock` headers instead of the bundled ones, seamlessly resolving the incompatibility.

- Unconditionally include `source-map.cpp` in unit tests, rather than conditionally disabling it when `BUILD_FUZZTEST` is ON.
- Link against the `gmock` target for `binaryen-unittests` when `BUILD_FUZZTEST` is ON.