### PR TITLE
ConstraintAnalysis: Do not add something already known to be true when ANDing

### DIFF
--- a/src/ir/constraint.cpp
+++ b/src/ir/constraint.cpp
@@ -134,7 +134,13 @@ void AndedConstraintSet::approximateAnd(const Constraint& c) {
     return;
   }
 
-  if (proves(c) == False) {
+  auto result = proves(c);
+  if (result == True) {
+    // We already prove c to be true, so it adds nothing.
+    // TODO: we could also see if c proves us true, and replace things we
+    //       already have with c when possible
+    return;
+  } else if (result == False) {
     // We are now a contradiction.
     isContradiction = true;
     return;

--- a/test/gtest/constraint.cpp
+++ b/test/gtest/constraint.cpp
@@ -207,5 +207,17 @@ TEST(ConstraintTest, TestMaxCapacity) {
   EXPECT_EQ(s.proves(not40), Unknown);
 }
 
+TEST(ConstraintTest, TestDeduplication) {
+  Constraint eq10{Eq, {Literal(int32_t(10))}};
+
+  AndedConstraintSet s;
+  EXPECT_EQ(s.size(), 0);
+  s.set(eq10);
+  EXPECT_EQ(s.size(), 1);
+  // The size does not increase when we add eq10 again.
+  s.approximateAnd(eq10);
+  EXPECT_EQ(s.size(), 1);
+}
+
 // TODO: test an approximateOr of { x = 10 } and { x >= 0 }, once we support
 //       inequalities


### PR DESCRIPTION
If `X -> Y` (X proves Y), then we can avoid adding Y when doing `X && Y`

(Formally, if `Y -> Z` (Y proves something useful Z) then `X -> Y -> Z` so
X proves it already.)