### PR TITLE
Heap2Local: Handle unreachable code in adjustTypeFlowingThrough

### DIFF
--- a/src/passes/Heap2Local.cpp
+++ b/src/passes/Heap2Local.cpp
@@ -673,6 +673,7 @@ struct Struct2Local : PostWalker<Struct2Local> {
     // of our parent, since we know very specifically that only safe things
     // will end up using our value, like a StructGet or a Drop, which do not
     // care about non-nullability.
+    assert(curr->type.isRef());
     curr->type = Type(curr->type.getHeapType(), Nullable);
   }
 

--- a/src/passes/Heap2Local.cpp
+++ b/src/passes/Heap2Local.cpp
@@ -661,6 +661,11 @@ struct Struct2Local : PostWalker<Struct2Local> {
       return;
     }
 
+    if (curr->type == Type::unreachable) {
+      // We ended up with unreachable code, and have nothing to do.
+      return;
+    }
+
     // Our allocation passes through this expr. We must turn its type into a
     // nullable one, because we will remove things like RefAsNonNull of it,
     // which means we may no longer have a non-nullable value as our input,
@@ -668,7 +673,6 @@ struct Struct2Local : PostWalker<Struct2Local> {
     // of our parent, since we know very specifically that only safe things
     // will end up using our value, like a StructGet or a Drop, which do not
     // care about non-nullability.
-    assert(curr->type.isRef());
     curr->type = Type(curr->type.getHeapType(), Nullable);
   }
 

--- a/test/lit/passes/heap2local.wast
+++ b/test/lit/passes/heap2local.wast
@@ -4849,7 +4849,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $unreachable-flow
-    ;; The return flows into the br_if. This should not cause errors as wel
+    ;; The return flows into the br_if. This should not cause errors as we
     ;; optimize out the allocation.
     (drop
       (block $block (result arrayref)

--- a/test/lit/passes/heap2local.wast
+++ b/test/lit/passes/heap2local.wast
@@ -4808,3 +4808,59 @@
     )
   )
 )
+
+(module
+  (type $array (array (mut i32)))
+
+  ;; CHECK:      (type $0 (func))
+
+  ;; CHECK:      (func $unreachable-flow (type $0)
+  ;; CHECK-NEXT:  (local $0 i32)
+  ;; CHECK-NEXT:  (local $1 i32)
+  ;; CHECK-NEXT:  (local $2 i32)
+  ;; CHECK-NEXT:  (local $3 i32)
+  ;; CHECK-NEXT:  (local $4 i32)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block $block
+  ;; CHECK-NEXT:    (block
+  ;; CHECK-NEXT:     (drop
+  ;; CHECK-NEXT:      (block (result nullref)
+  ;; CHECK-NEXT:       (local.set $0
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (local.set $1
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (local.set $2
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (local.set $3
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (local.set $4
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (ref.null none)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (return)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $unreachable-flow
+    ;; The return flows into the br_if. This should not cause errors as wel
+    ;; optimize out the allocation.
+    (drop
+      (block $block (result arrayref)
+        (br_if $block
+          (array.new_default $array
+            (i32.const 5)
+          )
+          (return)
+        )
+      )
+    )
+  )
+)
+


### PR DESCRIPTION
If the type is unreachable, we must not change it.