### PR TITLE
[NFC] Add module context to CFG construction

### DIFF
--- a/src/analysis/cfg.cpp
+++ b/src/analysis/cfg.cpp
@@ -23,6 +23,10 @@
 namespace wasm::analysis {
 
 CFG CFG::fromFunction(Function* func) {
+  return CFG::fromFunction(func, nullptr);
+}
+
+CFG CFG::fromFunction(Function* func, Module* wasm) {
   struct CFGBuilder : CFGWalker<CFGBuilder,
                                 UnifiedExpressionVisitor<CFGBuilder>,
                                 std::vector<Expression*>> {
@@ -34,7 +38,11 @@ CFG CFG::fromFunction(Function* func) {
   };
 
   CFGBuilder builder;
-  builder.walkFunction(func);
+  if (wasm) {
+    builder.walkFunctionInModule(func, wasm);
+  } else {
+    builder.walkFunction(func);
+  }
 
   size_t numBlocks = builder.basicBlocks.size();
 

--- a/src/analysis/cfg.cpp
+++ b/src/analysis/cfg.cpp
@@ -22,10 +22,6 @@
 
 namespace wasm::analysis {
 
-CFG CFG::fromFunction(Function* func) {
-  return CFG::fromFunction(func, nullptr);
-}
-
 CFG CFG::fromFunction(Function* func, Module* wasm) {
   struct CFGBuilder : CFGWalker<CFGBuilder,
                                 UnifiedExpressionVisitor<CFGBuilder>,

--- a/src/analysis/cfg.h
+++ b/src/analysis/cfg.h
@@ -78,8 +78,7 @@ struct CFG {
 
   const BasicBlock& operator[](size_t i) const { return *(begin() + i); }
 
-  static CFG fromFunction(Function* func);
-  static CFG fromFunction(Function* func, Module* wasm);
+  static CFG fromFunction(Function* func, Module* wasm = nullptr);
 
   void print(std::ostream& os, Module* wasm = nullptr) const;
 

--- a/src/analysis/cfg.h
+++ b/src/analysis/cfg.h
@@ -79,6 +79,7 @@ struct CFG {
   const BasicBlock& operator[](size_t i) const { return *(begin() + i); }
 
   static CFG fromFunction(Function* func);
+  static CFG fromFunction(Function* func, Module* wasm);
 
   void print(std::ostream& os, Module* wasm = nullptr) const;
 

--- a/test/gtest/cfg.cpp
+++ b/test/gtest/cfg.cpp
@@ -172,7 +172,7 @@ TEST_F(CFGTest, CallBlockWithModuleWithoutEH) {
   Module wasm;
   parseWast(wasm, moduleText);
 
-  CFG cfg = CFG::fromFunction(wasm.getFunction("foo"), wasm);
+  CFG cfg = CFG::fromFunction(wasm.getFunction("foo"), &wasm);
 
   std::stringstream ss;
   cfg.print(ss);

--- a/test/gtest/cfg.cpp
+++ b/test/gtest/cfg.cpp
@@ -139,6 +139,47 @@ TEST_F(CFGTest, CallBlock) {
   EXPECT_EQ(ss.str(), cfgText);
 }
 
+TEST_F(CFGTest, CallBlockWithModuleWithoutEH) {
+  // When a module is provided, the CFG can use its feature set to know that
+  // calls do not throw unless EH is enabled.
+  auto moduleText = R"wasm(
+    (module
+      (func $foo
+        (drop
+          (i32.const 0)
+        )
+        (call $bar)
+        (drop
+          (i32.const 1)
+        )
+      )
+      (func $bar)
+    )
+  )wasm";
+
+  auto cfgText = R"cfg(;; preds: [], succs: []
+;; entry
+;; exit
+0:
+  0: i32.const 0
+  1: drop
+  2: call $bar
+  3: i32.const 1
+  4: drop
+  5: block
+)cfg";
+
+  Module wasm;
+  parseWast(wasm, moduleText);
+
+  CFG cfg = CFG::fromFunction(wasm.getFunction("foo"), wasm);
+
+  std::stringstream ss;
+  cfg.print(ss);
+
+  EXPECT_EQ(ss.str(), cfgText);
+}
+
 TEST_F(CFGTest, Empty) {
   // Check that we create a correct CFG for an empty function.
   auto moduleText = R"wasm(


### PR DESCRIPTION
Allow analysis CFG creation to receive module context so CFG traversal can respect module features when building control flow.