### PR TITLE
Merge `Module['parseTextWithFeatures']` into `Module['parseText']`

### DIFF
--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -3382,20 +3382,13 @@ Module['readBinaryWithFeatures'] = function(data, features) {
   return wrapModule(ptr);
 };
 
-// Parses text format to a module
-Module['parseText'] = function(text) {
+// Parses s-expression text format to a module with the given feature set enabled, defaulting to MVP
+Module['parseText'] = function(text, features = Module['Features']['MVP']) {
   const buffer = _malloc(text.length + 1);
   stringToAscii(text, buffer);
-  const ptr = handleFatalError(() => Module['_BinaryenModuleParse'](buffer));
-  _free(buffer);
-  return wrapModule(ptr);
-};
-
-// Parses text format to a module with the given feature set enabled
-Module['parseTextWithFeatures'] = function(text, features) {
-  const buffer = _malloc(text.length + 1);
-  stringToAscii(text, buffer);
-  const ptr = handleFatalError(() => Module['_BinaryenModuleParseWithFeatures'](buffer, features));
+  const ptr = features === undefined
+    ? handleFatalError(() => Module['_BinaryenModuleParse'](buffer))
+    : handleFatalError(() => Module['_BinaryenModuleParseWithFeatures'](buffer, features));
   _free(buffer);
   return wrapModule(ptr);
 };

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -3382,7 +3382,7 @@ Module['readBinaryWithFeatures'] = function(data, features) {
   return wrapModule(ptr);
 };
 
-// Parses s-expression text format to a module with the given feature set enabled
+// Parses text format to a module with the given feature set enabled.
 Module['parseText'] = function(text, features) {
   const buffer = _malloc(text.length + 1);
   stringToAscii(text, buffer);

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -3382,8 +3382,8 @@ Module['readBinaryWithFeatures'] = function(data, features) {
   return wrapModule(ptr);
 };
 
-// Parses s-expression text format to a module with the given feature set enabled, defaulting to MVP
-Module['parseText'] = function(text, features = Module['Features']['MVP']) {
+// Parses s-expression text format to a module with the given feature set enabled
+Module['parseText'] = function(text, features) {
   const buffer = _malloc(text.length + 1);
   stringToAscii(text, buffer);
   const ptr = features === undefined

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -1135,14 +1135,14 @@ function test_parsing_with_features() {
     (global $g anyref (ref.null any))
   )`;
 
-  module = binaryen.parseTextWithFeatures(text, binaryen.Features.All);
+  module = binaryen.parseText(text, binaryen.Features.All);
   assert(module.validate());
   console.log("module loaded from text form with features:");
   console.log(module.emitText());
   module.dispose();
 
   // parse with MVP features, which should fail
-  module = binaryen.parseTextWithFeatures(text, binaryen.Features.MVP);
+  module = binaryen.parseText(text, binaryen.Features.MVP);
   console.log("validation with MVP features: " + module.validate());
   module.dispose();
 }


### PR DESCRIPTION
deletes `Module['parseTextWithFeatures']` in favor of `Module['parseText']` with an optional `features` parameter.

any code calling the former should update accordingly.

follow-up to https://github.com/WebAssembly/binaryen/pull/8872#discussion_r3562364680