### PR TITLE
[cmake] Simplify C++ standard enforcement using target_compile_features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,13 +10,7 @@ include(GNUInstallDirs)
 
 # The C++ standard whose features are required to build Binaryen.
 # Keep in sync with scripts/test/shared.py cxx_standard
-# The if condition allows embedding in a project with a higher default C++ standard set
-set(REQUIRED_CXX_STANDARD 20)
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD ${REQUIRED_CXX_STANDARD})
-elseif(CMAKE_CXX_STANDARD LESS ${REQUIRED_CXX_STANDARD})
-  message(SEND_ERROR "Building with C++ standards older than C++${REQUIRED_CXX_STANDARD} is not supported, change CMAKE_CXX_STANDARD to ${REQUIRED_CXX_STANDARD} or later")
-endif()
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -465,6 +459,7 @@ if(BUILD_SHARED_LIBS)
 else()
   message(STATUS "Building libbinaryen as statically linked library.")
 endif()
+target_compile_features(binaryen PUBLIC cxx_std_20)
 target_link_libraries(binaryen PUBLIC Threads::Threads)
 binaryen_setup_rpath(binaryen)
 if(BUILD_LLVM_DWARF)


### PR DESCRIPTION
Require C++20 directly on the `binaryen` target by adding
`cxx_std_20` to `target_compile_features`. This enables CMake to
automatically enforce that the compiler supports C++20 and propagates
the requirement to all consumers linking against `binaryen`.

Remove the manual `elseif(CMAKE_CXX_STANDARD LESS ...)` check and error
message from `CMakeLists.txt` since CMake now natively handles standard
validation and error reporting.

Also remove the `if(NOT CMAKE_CXX_STANDARD)` condition around
`set(CMAKE_CXX_STANDARD 20)` and its explanatory comment. The old
comment suggested the conditional allowed embedding in parent projects
with a higher default standard. However, variable assignments like
`set(CMAKE_CXX_STANDARD 20)` in a subdirectory (via `add_subdirectory`)
are strictly directory-scoped and do not leak into the parent project.
Furthermore, with `target_compile_features` enforcing `cxx_std_20` on
`binaryen`, any parent target linking against `binaryen` at a higher C++
standard (e.g., C++23) cleanly satisfies the feature requirement.
Therefore, unconditionally setting `CMAKE_CXX_STANDARD 20` for internal
Binaryen targets is completely safe and avoids inheriting incompatible
standards (< 20) from parent projects.