### PR TITLE
[support] ParentIndexIterator: Add subscript and friend plus operators

### DIFF
--- a/src/support/parent_index_iterator.h
+++ b/src/support/parent_index_iterator.h
@@ -24,8 +24,8 @@ namespace wasm {
 
 // A helper for defining iterators that contain references to some parent object
 // and indices into that parent object. Provides operator implementations for
-// equality, inequality, index updates, and index differences, but not for
-// dereferencing.
+// equality, inequality, index updates, index differences, and subscripting,
+// but not for dereferencing (`operator*` or `operator->`).
 //
 // Users of this utility should subclass ParentIndexIterator<...> and define the
 // following members in the subclass:
@@ -96,6 +96,10 @@ template<typename Parent, typename Iterator> struct ParentIndexIterator {
   Iterator operator+(difference_type off) const {
     return Iterator(self()) += off;
   }
+  friend Iterator operator+(difference_type off,
+                            const ParentIndexIterator& it) {
+    return it + off;
+  }
   Iterator& operator-=(difference_type off) {
     index -= off;
     return self();
@@ -106,6 +110,9 @@ template<typename Parent, typename Iterator> struct ParentIndexIterator {
   difference_type operator-(const Iterator& other) const {
     assert(parent == other.parent);
     return index - other.index;
+  }
+  decltype(auto) operator[](difference_type off) const {
+    return *(self() + off);
   }
 };
 

--- a/test/gtest/inplace_vector.cpp
+++ b/test/gtest/inplace_vector.cpp
@@ -110,3 +110,15 @@ TEST_F(InplaceVectorTest, Insert) {
   EXPECT_EQ(vec.size(), 6u);
   EXPECT_EQ(vec[5], 50);
 }
+
+TEST_F(InplaceVectorTest, SortAndIteratorOps) {
+  inplace_vector<int, 5> vec{40, 10, 50, 20, 30};
+
+  // Test iterator subscripting and friend operator+
+  EXPECT_EQ(vec.begin()[1], 10);
+  EXPECT_EQ(*(2 + vec.begin()), 50);
+
+  // Test std::sort on inplace_vector iterators
+  std::sort(vec.begin(), vec.end());
+  EXPECT_EQ(vec, (inplace_vector<int, 5>{10, 20, 30, 40, 50}));
+}


### PR DESCRIPTION
`ParentIndexIterator` declares `using iterator_category =` `std::random_access_iterator_tag;`, but did not provide the subscript operator (`operator[]`) or friend commutative addition (`friend operator+(difference_type, const ParentIndexIterator&)`).

When #8912 introduced `std::sort(begin(), end())` on `AndedConstraintSet` (which inherits from `inplace_vector`), building `binaryen` failed on the Chromium `emscripten-releases` macOS builders with:

```
  error: type 'wasm::inplace_vector<...>::Iterator' does not provide a subscript operator
```

This failure did not show up on Binaryen's CI because `libstdc++` implements `std::sort` using pointer/iterator addition and dereferencing (`*(first + child)`). In contrast, on macOS with `-stdlib=libc++`, `libc++` implements `std::sort` (`std::__sift_down`) using `__first[__child]` and `__first[__start]`, which requires `operator[]`.

This commit adds `decltype(auto) operator[]` and `friend operator+` to `ParentIndexIterator` to satisfy `RandomAccessIterator` requirements.