### PR TITLE
Avoid generating ref.as_non_null for table initializers in fuzzer

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -993,6 +993,14 @@ void TranslateToFuzzReader::finalizeTable() {
         table->init = makeConst(table->type);
       }
     }
+
+    if (table->init && (!FindAll<RefAs>(table->init).list.empty() ||
+                        !FindAll<ContNew>(table->init).list.empty())) {
+      // Similar to in setupGlobals(), if we emit RefAs or ContNew for a table
+      // initializer, it's not valid. Switch to a safe type.
+      table->type = Type(HeapType::func, Nullable);
+      table->init = makeConst(table->type);
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #8911. `ref.as_non_null` is not a constant expression, so it's not allowed in table initializers. [Repro output with this PR](https://gist.github.com/stevenfontanella/0aae7640535f5c69ca595e9303b9bce8).

See the equivalent code in [setupGlobals](https://github.com/WebAssembly/binaryen/blob/108e796b9b0450e30f510a2f86974f6d4809e600/src/tools/fuzzing/fuzzing.cpp#L786-L798).