### PR TITLE
Remove use of std::aligned_storage. NFC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,9 +250,6 @@ if(MSVC)
 
   # workaround for https://github.com/WebAssembly/binaryen/issues/3661
   add_compile_flag("/D_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING")
-  # Visual Studio 2018 15.8 implemented conformant support for std::aligned_storage, but the conformant support is only enabled when the following flag is passed, to avoid
-  # breaking backwards compatibility with code that relied on the non-conformant behavior (the old nonconformant behavior is not used with Binaryen)
-  add_compile_flag("/D_ENABLE_EXTENDED_ALIGNED_STORAGE")
   # Don't warn about using "strdup" as a reserved name.
   add_compile_flag("/D_CRT_NONSTDC_NO_DEPRECATE")
 

--- a/third_party/llvm-project/include/llvm/ADT/FunctionExtras.h
+++ b/third_party/llvm-project/include/llvm/ADT/FunctionExtras.h
@@ -112,8 +112,7 @@ class unique_function<ReturnT(ParamTs...)> {
 
     // For in-line storage, we just provide an aligned character buffer. We
     // provide three pointers worth of storage here.
-    typename std::aligned_storage<InlineStorageSize, alignof(void *)>::type
-        InlineStorage;
+    alignas(void *) mutable std::byte InlineStorage[InlineStorageSize];
   } StorageUnion;
 
   // A compressed pointer to either our dispatching callback or our table of


### PR DESCRIPTION
This is deprecated in C++23.  See https://github.com/llvm/llvm-project/pull/94169

This also allows us to remove the `/D_ENABLE_EXTENDED_ALIGNED_STORAGE` from `CMakeLists.txt` which was originally added back in e8ac331501. Back then we also used in this in `src/mixed_arena.h` but that usage was removed in #1846.