### PR TITLE
[DebugInfo] Do not assert on an unmarked end of a span

### DIFF
--- a/src/wasm/wasm-debug.cpp
+++ b/src/wasm/wasm-debug.cpp
@@ -436,8 +436,12 @@ private:
   void add(Expression* expr, const BinaryLocations::Span span) {
     assert(!startMap.contains(span.start));
     startMap[span.start] = expr;
-    assert(!endMap.contains(span.end));
-    endMap[span.end] = expr;
+    // The end may be 0, which means we never noted an end for this expression.
+    // TODO: We are likely dropping some debug info in wasm-ir-builder.cpp
+    if (span.end) {
+      assert(!endMap.contains(span.end));
+      endMap[span.end] = expr;
+    }
   }
 
   void add(Expression* expr,


### PR DESCRIPTION
#8862 added binary tracking of Try, but it does not always fully work:
sometimes we note the start of a Try (this happens when we see a
Catch/CatchAll, and end the scope of the Try body), but we never
mark the end, because `push()` is not called on the Try in
`wasm-ir-builder.cpp`.

I could not quite figure out why `push()` is not called, and neither
could AI. It might be good to investigate this further, I left a
TODO, however, if we are dropping a little bit of debug info on
Try instructions then that is likely not a big deal, and also we were
doing it before #8862 anyhow.

Works around https://github.com/WebAssembly/binaryen/issues/8940