### PR TITLE
[JS API] Expose BinaryenStringConst

### DIFF
--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -2612,6 +2612,15 @@ function wrapModule(module, self = {}) {
   };
   
   // TODO: string.*
+  self['string'] = {
+    /**
+     * Creates a new string from the literal string contents.
+     * This instruction is constant and can be used in global variable initializers.
+     */
+    'const'(value) {
+      return preserveStack(() => Module['_BinaryenStringConst'](module, strToStack(value)));
+    }
+  };
 
   // 'Module' operations
   self['addFunction'] = function(name, params, results, varTypes, body) {

--- a/test/binaryen.js/gc.js
+++ b/test/binaryen.js/gc.js
@@ -19,7 +19,7 @@ var arrayType = binaryen.getTypeFromHeapType(arrayHeapType, true);
 var funcArrayType = binaryen.getTypeFromHeapType(funcArrayHeapType, true);
 
 var module = new binaryen.Module();
-module.setFeatures(binaryen.Features.ReferenceTypes | binaryen.Features.BulkMemory | binaryen.Features.GC);
+module.setFeatures(binaryen.Features.ReferenceTypes | binaryen.Features.BulkMemory | binaryen.Features.GC | binaryen.Features.Strings);
 
 module.addFunction("add", binaryen.createType([binaryen.i32, binaryen.i32]), binaryen.i32, [],
   module.i32.add(
@@ -157,7 +157,10 @@ var valueList = [
     module.i32.const(0),
     module.i32.const(1),
     module.i32.const(2)
-  )
+  ),
+
+  // string
+  module.string.const("hello 🌎"),
 ];
 module.addFunction("main", binaryen.none, binaryen.none, [],
   module.block(

--- a/test/binaryen.js/gc.js.txt
+++ b/test/binaryen.js/gc.js.txt
@@ -111,6 +111,9 @@
    (i32.const 1)
    (i32.const 2)
   )
+  (drop
+   (string.const "hello \f0\9f\8c\8e")
+  )
  )
 )
 


### PR DESCRIPTION
Exposes the `BinaryenStringConst` API via a new `Module#string.const()` method.

Usage:
```js
const mod = new binaryen.Module();
const expr = mod.string.const("a JavaScript string value");
```

Supersedes #8160.