### PR TITLE
[JS API] merge `Module['readBinaryWithFeatures']` into `Module['readBinary']`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ Current Trunk
 -------------
 
 - [JS API] support `BinaryenStringConst` (#8951)
-- [JS API] Merge `Module['readBinaryWithFeatures']` into `Module['readBinary']`
+- [JS API] Replace `Module['readBinaryWithFeatures']` with an
+  optional `features` parameter to `Module['readBinary']` (#8954)
 
 v131
 ----
@@ -25,8 +26,8 @@ v131
 - Add acqrel ordering support for atomic fences (#8845). Breaks the C API;
   `BinaryenAtomicFence` now takes a memory order param. Use
   `BinaryenMemoryOrderSeqCst()` to preserve the original behavior.
-- [JS API] Merge `Module['parseTextWithFeatures']` into `Module['parseText']`
-  (#8901)
+- [JS API] Replace `Module['parseTextWithFeatures']` with an
+  optional `features` parameter to `Module['parseText']` (#8901)
 - Add a ConstraintAnalysis pass (#8853)
 
 v130

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ full changeset diff at the end of each section.
 Current Trunk
 -------------
 
+- [JS API] support `BinaryenStringConst` (#8951)
+- [JS API] Merge `Module['readBinaryWithFeatures']` into `Module['readBinary']`
+
 v131
 ----
 

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -3368,30 +3368,23 @@ function handleFatalError(func) {
   }
 }
 
-// Parses a binary to a module
-
 // If building with Emscripten ASSERTIONS, there is a property added to
 // Module to guard against users mistakening using the removed readBinary()
 // API. We must defuse that carefully.
 Object.defineProperty(Module, 'readBinary', { writable: true });
 
-Module['readBinary'] = function(data) {
+// Parses a binary to a module with the given feature set enabled. `features` defaults to MVP.
+Module['readBinary'] = function(data, features) {
   const buffer = _malloc(data.length);
   HEAP8.set(data, buffer);
-  const ptr = handleFatalError(() => Module['_BinaryenModuleRead'](buffer, data.length));
+  const ptr = features === undefined
+    ? handleFatalError(() => Module['_BinaryenModuleRead'](buffer, data.length))
+    : handleFatalError(() => Module['_BinaryenModuleReadWithFeatures'](buffer, data.length, features));
   _free(buffer);
   return wrapModule(ptr);
 };
 
-Module['readBinaryWithFeatures'] = function(data, features) {
-  const buffer = _malloc(data.length);
-  HEAP8.set(data, buffer);
-  const ptr = handleFatalError(() => Module['_BinaryenModuleReadWithFeatures'](buffer, data.length, features));
-  _free(buffer);
-  return wrapModule(ptr);
-};
-
-// Parses text format to a module with the given feature set enabled.
+// Parses text format to a module with the given feature set enabled. `features` defaults to MVP.
 Module['parseText'] = function(text, features) {
   const buffer = _malloc(text.length + 1);
   stringToAscii(text, buffer);

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -1059,14 +1059,14 @@ function test_binaries_with_features() {
   binaryen.setDebugInfo(false);
   module.dispose();
 
-  module = binaryen.readBinaryWithFeatures(buffer, features);
+  module = binaryen.readBinary(buffer, features);
 
   assert(module.validate());
   console.log("module loaded from binary with features:");
   console.log(module.emitText());
   module.dispose();
 
-  module = binaryen.readBinaryWithFeatures(buffer, binaryen.Features.MVP);
+  module = binaryen.readBinary(buffer, binaryen.Features.MVP);
   assert(!module.validate());
   module.dispose();
 }


### PR DESCRIPTION
Removes method `binaryen.readBinaryWithFeatures()` in favor of `binaryen.readBinary()`, which now supports a `features` parameter that defaults to MVP if omitted.

This aligns cleanly with #8901, which removed `parseTextWithFeatures` in favor of `parseText`.