### PR TITLE
[wasm2c] Set the wasm-rt library as STATIC and EXCLUDE_FROM_ALL

### DIFF
--- a/src/tools/wasm2c/CMakeLists.txt
+++ b/src/tools/wasm2c/CMakeLists.txt
@@ -37,4 +37,4 @@ set_source_files_properties(${WASM_RT_INCLUDES}
     PROPERTIES LANGUAGE C
 )
 
-add_library(wasm-rt ${WASM_RT_SOURCES})
+add_library(wasm-rt STATIC EXCLUDE_FROM_ALL ${WASM_RT_SOURCES})


### PR DESCRIPTION
We don't actually need this to get built or used. The CMake rule exists only so that clang-tidy knows these files are C, not C++.