### PR TITLE
[wasm2c] Only run clang-tidy-diff on files that are compiled

### DIFF
--- a/scripts/clang-tidy-diff.sh
+++ b/scripts/clang-tidy-diff.sh
@@ -24,7 +24,7 @@ function realpath() {
 
 CLANG_DIR=$(dirname $(dirname $(realpath $CLANG_TIDY)))
 CLANG_TIDY_DIFF=$CLANG_DIR/share/clang/clang-tidy-diff.py
-ARG="-quiet -p1 -iregex=src/.*\.(cpp|cc|c\+\+|cxx|c|cl|h|hpp|m|mm)"
+ARG="-quiet -p1 -only-check-in-db -iregex=src/.*\.(cpp|cc|c\+\+|cxx|c|cl|h|hpp|m|mm)"
 if [ ! -e "$CLANG_TIDY_DIFF" ]; then
   echo "Failed to find clang-tidy-diff.py ($CLANG_TIDY_DIFF)"
   exit 1

--- a/src/tools/wasm2c/CMakeLists.txt
+++ b/src/tools/wasm2c/CMakeLists.txt
@@ -1,5 +1,4 @@
 set(PREBUILT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/prebuilt)
-set(WASM_RT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/wasm-rt)
 
 set(WASM2C_TEMPLATE_SOURCES
     ${PREBUILT_DIR}/wasm2c_header_top.cpp
@@ -14,27 +13,3 @@ set(WASM2C_TEMPLATE_SOURCES
 binaryen_add_executable(wasm2c "wasm2c-builder.cpp;assertion-emitter.cpp;wasm2c.cpp;${WASM2C_TEMPLATE_SOURCES}")
 # TODO: https://github.com/WebAssembly/binaryen/issues/8775 - stop using picosha2
 target_include_directories(wasm2c PRIVATE ${PROJECT_SOURCE_DIR}/third_party/picosha2 ${PROJECT_SOURCE_DIR}/src/tools/wasm2c)
-
-set(WASM_RT_SOURCES
-  ${WASM_RT_DIR}/wasm-rt-exceptions-impl.c
-  ${WASM_RT_DIR}/wasm-rt-impl.c
-  ${WASM_RT_DIR}/wasm-rt-mem-impl.c
-)
-
-set(WASM_RT_INCLUDES
-  ${WASM_RT_DIR}/wasm-rt-exceptions.h
-  ${WASM_RT_DIR}/wasm-rt.h
-  ${WASM_RT_DIR}/wasm-rt-impl.h
-  ${WASM_RT_DIR}/wasm-rt-impl-tableops.inc
-  ${WASM_RT_DIR}/wasm-rt-mem-impl-helper.inc
-)
-
-set_source_files_properties(${WASM_RT_SOURCES}
-    PROPERTIES LANGUAGE C
-)
-
-set_source_files_properties(${WASM_RT_INCLUDES}
-    PROPERTIES LANGUAGE C
-)
-
-add_library(wasm-rt ${WASM_RT_SOURCES})


### PR DESCRIPTION
Also, remove the wasm-rt CMake library that was only added so that clang-tidy-diff would know these files are C, not C++.