### PR TITLE
Fix alignment in relaxed atomics spec test

### DIFF
--- a/scripts/test/generate_atomic_spec_test.py
+++ b/scripts/test/generate_atomic_spec_test.py
@@ -224,7 +224,7 @@ def bin_statement_lines(template: Template, mem_idx: int, mem_ptr_type: ValueTyp
 
     has_ordering = ordering is not None
     has_mem_idx = mem_idx is not None
-    raw_alignment = int(math.log2(mem_ptr_type.value // 8))
+    raw_alignment = int(math.log2(template.value_type.value // 8))
     alignment = raw_alignment | (has_ordering << 4) | (has_mem_idx << 6)
     comment = f"Alignment of {raw_alignment}" \
               f'{" with bit 4 set indicating that an ordering immediate follows" if has_ordering else ""}' \

--- a/test/spec/relaxed-atomics.wast
+++ b/test/spec/relaxed-atomics.wast
@@ -642,14 +642,14 @@
 
     "\42\00" ;; (i64.const 0)
     "\fe\10" ;; i32.atomic.load
-    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
     "\42\00" ;; (i64.const 0)
     "\fe\10" ;; i32.atomic.load
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
@@ -657,7 +657,7 @@
 
     "\42\00" ;; (i64.const 0)
     "\fe\10" ;; i32.atomic.load
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -665,34 +665,34 @@
 
     "\41\00" ;; (i32.const 0)
     "\fe\11" ;; i64.atomic.load
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\fe\11" ;; i64.atomic.load
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\fe\11" ;; i64.atomic.load
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\fe\11" ;; i64.atomic.load
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\fe\11" ;; i64.atomic.load
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
@@ -700,7 +700,7 @@
 
     "\41\00" ;; (i32.const 0)
     "\fe\11" ;; i64.atomic.load
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -731,34 +731,34 @@
 
     "\41\00" ;; (i32.const 0)
     "\fe\12" ;; i32.atomic.load8_u
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\fe\12" ;; i32.atomic.load8_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\fe\12" ;; i32.atomic.load8_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\fe\12" ;; i32.atomic.load8_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\fe\12" ;; i32.atomic.load8_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
@@ -766,7 +766,7 @@
 
     "\41\00" ;; (i32.const 0)
     "\fe\12" ;; i32.atomic.load8_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -797,34 +797,34 @@
 
     "\41\00" ;; (i32.const 0)
     "\fe\13" ;; i32.atomic.load16_u
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\fe\13" ;; i32.atomic.load16_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\fe\13" ;; i32.atomic.load16_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\fe\13" ;; i32.atomic.load16_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\fe\13" ;; i32.atomic.load16_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
@@ -832,7 +832,7 @@
 
     "\41\00" ;; (i32.const 0)
     "\fe\13" ;; i32.atomic.load16_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -863,34 +863,34 @@
 
     "\41\00" ;; (i32.const 0)
     "\fe\14" ;; i64.atomic.load8_u
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\fe\14" ;; i64.atomic.load8_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\fe\14" ;; i64.atomic.load8_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\fe\14" ;; i64.atomic.load8_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\fe\14" ;; i64.atomic.load8_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
@@ -898,7 +898,7 @@
 
     "\41\00" ;; (i32.const 0)
     "\fe\14" ;; i64.atomic.load8_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -929,34 +929,34 @@
 
     "\41\00" ;; (i32.const 0)
     "\fe\15" ;; i64.atomic.load16_u
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\fe\15" ;; i64.atomic.load16_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\fe\15" ;; i64.atomic.load16_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\fe\15" ;; i64.atomic.load16_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\fe\15" ;; i64.atomic.load16_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
@@ -964,7 +964,7 @@
 
     "\41\00" ;; (i32.const 0)
     "\fe\15" ;; i64.atomic.load16_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -995,34 +995,34 @@
 
     "\41\00" ;; (i32.const 0)
     "\fe\16" ;; i64.atomic.load32_u
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\fe\16" ;; i64.atomic.load32_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\fe\16" ;; i64.atomic.load32_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\fe\16" ;; i64.atomic.load32_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\fe\16" ;; i64.atomic.load32_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
@@ -1030,7 +1030,7 @@
 
     "\41\00" ;; (i32.const 0)
     "\fe\16" ;; i64.atomic.load32_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -1105,14 +1105,14 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\17" ;; i32.atomic.store
-    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
 
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\17" ;; i32.atomic.store
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
@@ -1120,7 +1120,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\17" ;; i32.atomic.store
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -1128,34 +1128,34 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\18" ;; i64.atomic.store
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\18" ;; i64.atomic.store
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\18" ;; i64.atomic.store
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\18" ;; i64.atomic.store
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\18" ;; i64.atomic.store
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
@@ -1163,7 +1163,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\18" ;; i64.atomic.store
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -1237,14 +1237,14 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\19" ;; i32.atomic.store8
-    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
 
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\19" ;; i32.atomic.store8
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
@@ -1252,7 +1252,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\19" ;; i32.atomic.store8
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -1303,14 +1303,14 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\1a" ;; i32.atomic.store16
-    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
 
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\1a" ;; i32.atomic.store16
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
@@ -1318,7 +1318,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\1a" ;; i32.atomic.store16
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -1326,34 +1326,34 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\1b" ;; i64.atomic.store8
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\1b" ;; i64.atomic.store8
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\1b" ;; i64.atomic.store8
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\1b" ;; i64.atomic.store8
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\1b" ;; i64.atomic.store8
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
@@ -1361,7 +1361,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\1b" ;; i64.atomic.store8
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -1392,34 +1392,34 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\1c" ;; i64.atomic.store16
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\1c" ;; i64.atomic.store16
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\1c" ;; i64.atomic.store16
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\1c" ;; i64.atomic.store16
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\1c" ;; i64.atomic.store16
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
@@ -1427,7 +1427,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\1c" ;; i64.atomic.store16
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -1458,34 +1458,34 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\1d" ;; i64.atomic.store32
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\1d" ;; i64.atomic.store32
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\1d" ;; i64.atomic.store32
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\1d" ;; i64.atomic.store32
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\1d" ;; i64.atomic.store32
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\01" ;; acqrel memory ordering
     "\00" ;; offset
@@ -1493,7 +1493,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\1d" ;; i64.atomic.store32
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -1573,56 +1573,56 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\1e" ;; i32.atomic.rmw.add
-    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\42\00" ;; (i64.const 0)
-    "\41\33" ;; (i32.const 51)
-    "\fe\1e" ;; i32.atomic.rmw.add
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
-    "\11" ;; acqrel memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\42\00" ;; (i64.const 0)
-    "\41\33" ;; (i32.const 51)
-    "\fe\1e" ;; i32.atomic.rmw.add
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
-    "\00" ;; seqcst memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\1f" ;; i64.atomic.rmw.add
-    "\02" ;; Alignment of 2
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\1f" ;; i64.atomic.rmw.add
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
-    "\11" ;; acqrel memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\1f" ;; i64.atomic.rmw.add
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
-    "\00" ;; seqcst memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\1f" ;; i64.atomic.rmw.add
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\01" ;; memory index
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\42\00" ;; (i64.const 0)
+    "\41\33" ;; (i32.const 51)
+    "\fe\1e" ;; i32.atomic.rmw.add
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\01" ;; memory index
+    "\11" ;; acqrel memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\42\00" ;; (i64.const 0)
+    "\41\33" ;; (i32.const 51)
+    "\fe\1e" ;; i32.atomic.rmw.add
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\01" ;; memory index
+    "\00" ;; seqcst memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\1f" ;; i64.atomic.rmw.add
+    "\03" ;; Alignment of 3
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\1f" ;; i64.atomic.rmw.add
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
+    "\11" ;; acqrel memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\1f" ;; i64.atomic.rmw.add
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
+    "\00" ;; seqcst memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\1f" ;; i64.atomic.rmw.add
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -1630,7 +1630,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\1f" ;; i64.atomic.rmw.add
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -1639,7 +1639,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\1f" ;; i64.atomic.rmw.add
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -1723,7 +1723,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\20" ;; i32.atomic.rmw8.add_u
-    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -1731,7 +1731,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\20" ;; i32.atomic.rmw8.add_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -1740,7 +1740,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\20" ;; i32.atomic.rmw8.add_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -1798,65 +1798,40 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\21" ;; i32.atomic.rmw16.add_u
-    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\42\00" ;; (i64.const 0)
-    "\41\33" ;; (i32.const 51)
-    "\fe\21" ;; i32.atomic.rmw16.add_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
-    "\11" ;; acqrel memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\42\00" ;; (i64.const 0)
-    "\41\33" ;; (i32.const 51)
-    "\fe\21" ;; i32.atomic.rmw16.add_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
-    "\00" ;; seqcst memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\22" ;; i64.atomic.rmw8.add_u
-    "\02" ;; Alignment of 2
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\22" ;; i64.atomic.rmw8.add_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
-    "\11" ;; acqrel memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\22" ;; i64.atomic.rmw8.add_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
-    "\00" ;; seqcst memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\22" ;; i64.atomic.rmw8.add_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
-    "\00" ;; memory index
+    "\01" ;; memory index
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\42\00" ;; (i64.const 0)
+    "\41\33" ;; (i32.const 51)
+    "\fe\21" ;; i32.atomic.rmw16.add_u
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\01" ;; memory index
+    "\11" ;; acqrel memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\42\00" ;; (i64.const 0)
+    "\41\33" ;; (i32.const 51)
+    "\fe\21" ;; i32.atomic.rmw16.add_u
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\01" ;; memory index
+    "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\22" ;; i64.atomic.rmw8.add_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\00" ;; memory index
+    "\03" ;; Alignment of 3
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\22" ;; i64.atomic.rmw8.add_u
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -1864,90 +1839,40 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\22" ;; i64.atomic.rmw8.add_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\00" ;; memory index
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\22" ;; i64.atomic.rmw8.add_u
     "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
+    "\00" ;; memory index
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\22" ;; i64.atomic.rmw8.add_u
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\00" ;; memory index
+    "\11" ;; acqrel memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\22" ;; i64.atomic.rmw8.add_u
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\00" ;; memory index
+    "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
     "\42\00" ;; (i64.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\22" ;; i64.atomic.rmw8.add_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
-    "\11" ;; acqrel memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\42\00" ;; (i64.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\22" ;; i64.atomic.rmw8.add_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
-    "\00" ;; seqcst memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\23" ;; i64.atomic.rmw16.add_u
-    "\02" ;; Alignment of 2
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\23" ;; i64.atomic.rmw16.add_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
-    "\11" ;; acqrel memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\23" ;; i64.atomic.rmw16.add_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
-    "\00" ;; seqcst memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\23" ;; i64.atomic.rmw16.add_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
-    "\00" ;; memory index
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\23" ;; i64.atomic.rmw16.add_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\00" ;; memory index
-    "\11" ;; acqrel memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\23" ;; i64.atomic.rmw16.add_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\00" ;; memory index
-    "\00" ;; seqcst memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\42\00" ;; (i64.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\23" ;; i64.atomic.rmw16.add_u
     "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
@@ -1955,6 +1880,81 @@
 
     "\42\00" ;; (i64.const 0)
     "\42\33" ;; (i64.const 51)
+    "\fe\22" ;; i64.atomic.rmw8.add_u
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\01" ;; memory index
+    "\11" ;; acqrel memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\42\00" ;; (i64.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\22" ;; i64.atomic.rmw8.add_u
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\01" ;; memory index
+    "\00" ;; seqcst memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\23" ;; i64.atomic.rmw16.add_u
+    "\03" ;; Alignment of 3
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\23" ;; i64.atomic.rmw16.add_u
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
+    "\11" ;; acqrel memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\23" ;; i64.atomic.rmw16.add_u
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
+    "\00" ;; seqcst memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\23" ;; i64.atomic.rmw16.add_u
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\00" ;; memory index
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\23" ;; i64.atomic.rmw16.add_u
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\00" ;; memory index
+    "\11" ;; acqrel memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\23" ;; i64.atomic.rmw16.add_u
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\00" ;; memory index
+    "\00" ;; seqcst memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\42\00" ;; (i64.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\23" ;; i64.atomic.rmw16.add_u
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\01" ;; memory index
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\42\00" ;; (i64.const 0)
+    "\42\33" ;; (i64.const 51)
     "\fe\23" ;; i64.atomic.rmw16.add_u
     "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
@@ -1974,14 +1974,14 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\24" ;; i64.atomic.rmw32.add_u
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\24" ;; i64.atomic.rmw32.add_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -1989,7 +1989,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\24" ;; i64.atomic.rmw32.add_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -1997,7 +1997,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\24" ;; i64.atomic.rmw32.add_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -2005,7 +2005,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\24" ;; i64.atomic.rmw32.add_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -2014,7 +2014,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\24" ;; i64.atomic.rmw32.add_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -2098,7 +2098,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\25" ;; i32.atomic.rmw.sub
-    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -2106,7 +2106,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\25" ;; i32.atomic.rmw.sub
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -2115,7 +2115,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\25" ;; i32.atomic.rmw.sub
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -2124,14 +2124,14 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\26" ;; i64.atomic.rmw.sub
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\26" ;; i64.atomic.rmw.sub
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -2139,7 +2139,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\26" ;; i64.atomic.rmw.sub
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -2147,7 +2147,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\26" ;; i64.atomic.rmw.sub
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -2155,7 +2155,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\26" ;; i64.atomic.rmw.sub
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -2164,7 +2164,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\26" ;; i64.atomic.rmw.sub
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -2248,7 +2248,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\27" ;; i32.atomic.rmw8.sub_u
-    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -2256,7 +2256,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\27" ;; i32.atomic.rmw8.sub_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -2265,7 +2265,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\27" ;; i32.atomic.rmw8.sub_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -2323,65 +2323,40 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\28" ;; i32.atomic.rmw16.sub_u
-    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\42\00" ;; (i64.const 0)
-    "\41\33" ;; (i32.const 51)
-    "\fe\28" ;; i32.atomic.rmw16.sub_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
-    "\11" ;; acqrel memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\42\00" ;; (i64.const 0)
-    "\41\33" ;; (i32.const 51)
-    "\fe\28" ;; i32.atomic.rmw16.sub_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
-    "\00" ;; seqcst memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\29" ;; i64.atomic.rmw8.sub_u
-    "\02" ;; Alignment of 2
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\29" ;; i64.atomic.rmw8.sub_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
-    "\11" ;; acqrel memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\29" ;; i64.atomic.rmw8.sub_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
-    "\00" ;; seqcst memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\29" ;; i64.atomic.rmw8.sub_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
-    "\00" ;; memory index
+    "\01" ;; memory index
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\42\00" ;; (i64.const 0)
+    "\41\33" ;; (i32.const 51)
+    "\fe\28" ;; i32.atomic.rmw16.sub_u
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\01" ;; memory index
+    "\11" ;; acqrel memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\42\00" ;; (i64.const 0)
+    "\41\33" ;; (i32.const 51)
+    "\fe\28" ;; i32.atomic.rmw16.sub_u
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\01" ;; memory index
+    "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\29" ;; i64.atomic.rmw8.sub_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\00" ;; memory index
+    "\03" ;; Alignment of 3
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\29" ;; i64.atomic.rmw8.sub_u
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -2389,90 +2364,40 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\29" ;; i64.atomic.rmw8.sub_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\00" ;; memory index
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\29" ;; i64.atomic.rmw8.sub_u
     "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
+    "\00" ;; memory index
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\29" ;; i64.atomic.rmw8.sub_u
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\00" ;; memory index
+    "\11" ;; acqrel memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\29" ;; i64.atomic.rmw8.sub_u
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\00" ;; memory index
+    "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
     "\42\00" ;; (i64.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\29" ;; i64.atomic.rmw8.sub_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
-    "\11" ;; acqrel memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\42\00" ;; (i64.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\29" ;; i64.atomic.rmw8.sub_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
-    "\00" ;; seqcst memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\2a" ;; i64.atomic.rmw16.sub_u
-    "\02" ;; Alignment of 2
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\2a" ;; i64.atomic.rmw16.sub_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
-    "\11" ;; acqrel memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\2a" ;; i64.atomic.rmw16.sub_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
-    "\00" ;; seqcst memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\2a" ;; i64.atomic.rmw16.sub_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
-    "\00" ;; memory index
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\2a" ;; i64.atomic.rmw16.sub_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\00" ;; memory index
-    "\11" ;; acqrel memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\2a" ;; i64.atomic.rmw16.sub_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\00" ;; memory index
-    "\00" ;; seqcst memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\42\00" ;; (i64.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\2a" ;; i64.atomic.rmw16.sub_u
     "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
@@ -2480,6 +2405,81 @@
 
     "\42\00" ;; (i64.const 0)
     "\42\33" ;; (i64.const 51)
+    "\fe\29" ;; i64.atomic.rmw8.sub_u
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\01" ;; memory index
+    "\11" ;; acqrel memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\42\00" ;; (i64.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\29" ;; i64.atomic.rmw8.sub_u
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\01" ;; memory index
+    "\00" ;; seqcst memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\2a" ;; i64.atomic.rmw16.sub_u
+    "\03" ;; Alignment of 3
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\2a" ;; i64.atomic.rmw16.sub_u
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
+    "\11" ;; acqrel memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\2a" ;; i64.atomic.rmw16.sub_u
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
+    "\00" ;; seqcst memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\2a" ;; i64.atomic.rmw16.sub_u
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\00" ;; memory index
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\2a" ;; i64.atomic.rmw16.sub_u
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\00" ;; memory index
+    "\11" ;; acqrel memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\2a" ;; i64.atomic.rmw16.sub_u
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\00" ;; memory index
+    "\00" ;; seqcst memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\42\00" ;; (i64.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\2a" ;; i64.atomic.rmw16.sub_u
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\01" ;; memory index
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\42\00" ;; (i64.const 0)
+    "\42\33" ;; (i64.const 51)
     "\fe\2a" ;; i64.atomic.rmw16.sub_u
     "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
@@ -2499,14 +2499,14 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\2b" ;; i64.atomic.rmw32.sub_u
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\2b" ;; i64.atomic.rmw32.sub_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -2514,7 +2514,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\2b" ;; i64.atomic.rmw32.sub_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -2522,7 +2522,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\2b" ;; i64.atomic.rmw32.sub_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -2530,7 +2530,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\2b" ;; i64.atomic.rmw32.sub_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -2539,7 +2539,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\2b" ;; i64.atomic.rmw32.sub_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -2623,7 +2623,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\2c" ;; i32.atomic.rmw.and
-    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -2631,7 +2631,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\2c" ;; i32.atomic.rmw.and
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -2640,7 +2640,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\2c" ;; i32.atomic.rmw.and
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -2649,14 +2649,14 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\2d" ;; i64.atomic.rmw.and
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\2d" ;; i64.atomic.rmw.and
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -2664,7 +2664,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\2d" ;; i64.atomic.rmw.and
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -2672,7 +2672,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\2d" ;; i64.atomic.rmw.and
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -2680,7 +2680,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\2d" ;; i64.atomic.rmw.and
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -2689,7 +2689,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\2d" ;; i64.atomic.rmw.and
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -2773,7 +2773,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\2e" ;; i32.atomic.rmw8.and_u
-    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -2781,7 +2781,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\2e" ;; i32.atomic.rmw8.and_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -2790,7 +2790,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\2e" ;; i32.atomic.rmw8.and_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -2848,65 +2848,40 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\2f" ;; i32.atomic.rmw16.and_u
-    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\42\00" ;; (i64.const 0)
-    "\41\33" ;; (i32.const 51)
-    "\fe\2f" ;; i32.atomic.rmw16.and_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
-    "\11" ;; acqrel memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\42\00" ;; (i64.const 0)
-    "\41\33" ;; (i32.const 51)
-    "\fe\2f" ;; i32.atomic.rmw16.and_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
-    "\00" ;; seqcst memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\30" ;; i64.atomic.rmw8.and_u
-    "\02" ;; Alignment of 2
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\30" ;; i64.atomic.rmw8.and_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
-    "\11" ;; acqrel memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\30" ;; i64.atomic.rmw8.and_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
-    "\00" ;; seqcst memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\30" ;; i64.atomic.rmw8.and_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
-    "\00" ;; memory index
+    "\01" ;; memory index
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\42\00" ;; (i64.const 0)
+    "\41\33" ;; (i32.const 51)
+    "\fe\2f" ;; i32.atomic.rmw16.and_u
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\01" ;; memory index
+    "\11" ;; acqrel memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\42\00" ;; (i64.const 0)
+    "\41\33" ;; (i32.const 51)
+    "\fe\2f" ;; i32.atomic.rmw16.and_u
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\01" ;; memory index
+    "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\30" ;; i64.atomic.rmw8.and_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\00" ;; memory index
+    "\03" ;; Alignment of 3
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\30" ;; i64.atomic.rmw8.and_u
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -2914,90 +2889,40 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\30" ;; i64.atomic.rmw8.and_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\00" ;; memory index
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\30" ;; i64.atomic.rmw8.and_u
     "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
+    "\00" ;; memory index
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\30" ;; i64.atomic.rmw8.and_u
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\00" ;; memory index
+    "\11" ;; acqrel memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\30" ;; i64.atomic.rmw8.and_u
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\00" ;; memory index
+    "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
     "\42\00" ;; (i64.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\30" ;; i64.atomic.rmw8.and_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
-    "\11" ;; acqrel memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\42\00" ;; (i64.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\30" ;; i64.atomic.rmw8.and_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
-    "\00" ;; seqcst memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\31" ;; i64.atomic.rmw16.and_u
-    "\02" ;; Alignment of 2
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\31" ;; i64.atomic.rmw16.and_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
-    "\11" ;; acqrel memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\31" ;; i64.atomic.rmw16.and_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
-    "\00" ;; seqcst memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\31" ;; i64.atomic.rmw16.and_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
-    "\00" ;; memory index
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\31" ;; i64.atomic.rmw16.and_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\00" ;; memory index
-    "\11" ;; acqrel memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\31" ;; i64.atomic.rmw16.and_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\00" ;; memory index
-    "\00" ;; seqcst memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\42\00" ;; (i64.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\31" ;; i64.atomic.rmw16.and_u
     "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
@@ -3005,6 +2930,81 @@
 
     "\42\00" ;; (i64.const 0)
     "\42\33" ;; (i64.const 51)
+    "\fe\30" ;; i64.atomic.rmw8.and_u
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\01" ;; memory index
+    "\11" ;; acqrel memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\42\00" ;; (i64.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\30" ;; i64.atomic.rmw8.and_u
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\01" ;; memory index
+    "\00" ;; seqcst memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\31" ;; i64.atomic.rmw16.and_u
+    "\03" ;; Alignment of 3
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\31" ;; i64.atomic.rmw16.and_u
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
+    "\11" ;; acqrel memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\31" ;; i64.atomic.rmw16.and_u
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
+    "\00" ;; seqcst memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\31" ;; i64.atomic.rmw16.and_u
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\00" ;; memory index
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\31" ;; i64.atomic.rmw16.and_u
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\00" ;; memory index
+    "\11" ;; acqrel memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\31" ;; i64.atomic.rmw16.and_u
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\00" ;; memory index
+    "\00" ;; seqcst memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\42\00" ;; (i64.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\31" ;; i64.atomic.rmw16.and_u
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\01" ;; memory index
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\42\00" ;; (i64.const 0)
+    "\42\33" ;; (i64.const 51)
     "\fe\31" ;; i64.atomic.rmw16.and_u
     "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
@@ -3024,14 +3024,14 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\32" ;; i64.atomic.rmw32.and_u
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\32" ;; i64.atomic.rmw32.and_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -3039,7 +3039,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\32" ;; i64.atomic.rmw32.and_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -3047,7 +3047,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\32" ;; i64.atomic.rmw32.and_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -3055,7 +3055,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\32" ;; i64.atomic.rmw32.and_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -3064,7 +3064,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\32" ;; i64.atomic.rmw32.and_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -3148,7 +3148,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\33" ;; i32.atomic.rmw.or
-    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -3156,7 +3156,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\33" ;; i32.atomic.rmw.or
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -3165,7 +3165,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\33" ;; i32.atomic.rmw.or
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -3174,14 +3174,14 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\34" ;; i64.atomic.rmw.or
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\34" ;; i64.atomic.rmw.or
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -3189,7 +3189,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\34" ;; i64.atomic.rmw.or
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -3197,7 +3197,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\34" ;; i64.atomic.rmw.or
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -3205,7 +3205,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\34" ;; i64.atomic.rmw.or
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -3214,7 +3214,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\34" ;; i64.atomic.rmw.or
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -3298,7 +3298,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\35" ;; i32.atomic.rmw8.or_u
-    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -3306,7 +3306,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\35" ;; i32.atomic.rmw8.or_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -3315,7 +3315,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\35" ;; i32.atomic.rmw8.or_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -3373,65 +3373,40 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\36" ;; i32.atomic.rmw16.or_u
-    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\42\00" ;; (i64.const 0)
-    "\41\33" ;; (i32.const 51)
-    "\fe\36" ;; i32.atomic.rmw16.or_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
-    "\11" ;; acqrel memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\42\00" ;; (i64.const 0)
-    "\41\33" ;; (i32.const 51)
-    "\fe\36" ;; i32.atomic.rmw16.or_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
-    "\00" ;; seqcst memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\37" ;; i64.atomic.rmw8.or_u
-    "\02" ;; Alignment of 2
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\37" ;; i64.atomic.rmw8.or_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
-    "\11" ;; acqrel memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\37" ;; i64.atomic.rmw8.or_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
-    "\00" ;; seqcst memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\37" ;; i64.atomic.rmw8.or_u
     "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
-    "\00" ;; memory index
+    "\01" ;; memory index
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\42\00" ;; (i64.const 0)
+    "\41\33" ;; (i32.const 51)
+    "\fe\36" ;; i32.atomic.rmw16.or_u
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\01" ;; memory index
+    "\11" ;; acqrel memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\42\00" ;; (i64.const 0)
+    "\41\33" ;; (i32.const 51)
+    "\fe\36" ;; i32.atomic.rmw16.or_u
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\01" ;; memory index
+    "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\37" ;; i64.atomic.rmw8.or_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\00" ;; memory index
+    "\03" ;; Alignment of 3
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\37" ;; i64.atomic.rmw8.or_u
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -3439,90 +3414,40 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\37" ;; i64.atomic.rmw8.or_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\00" ;; memory index
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
-    "\42\00" ;; (i64.const 0)
+    "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\37" ;; i64.atomic.rmw8.or_u
     "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
+    "\00" ;; memory index
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\37" ;; i64.atomic.rmw8.or_u
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\00" ;; memory index
+    "\11" ;; acqrel memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\37" ;; i64.atomic.rmw8.or_u
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\00" ;; memory index
+    "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
 
     "\42\00" ;; (i64.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\37" ;; i64.atomic.rmw8.or_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
-    "\11" ;; acqrel memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\42\00" ;; (i64.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\37" ;; i64.atomic.rmw8.or_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\01" ;; memory index
-    "\00" ;; seqcst memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\38" ;; i64.atomic.rmw16.or_u
-    "\02" ;; Alignment of 2
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\38" ;; i64.atomic.rmw16.or_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
-    "\11" ;; acqrel memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\38" ;; i64.atomic.rmw16.or_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
-    "\00" ;; seqcst memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\38" ;; i64.atomic.rmw16.or_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
-    "\00" ;; memory index
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\38" ;; i64.atomic.rmw16.or_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\00" ;; memory index
-    "\11" ;; acqrel memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\41\00" ;; (i32.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\38" ;; i64.atomic.rmw16.or_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
-    "\00" ;; memory index
-    "\00" ;; seqcst memory ordering
-    "\00" ;; offset
-    "\1a" ;; drop
-
-    "\42\00" ;; (i64.const 0)
-    "\42\33" ;; (i64.const 51)
-    "\fe\38" ;; i64.atomic.rmw16.or_u
     "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
@@ -3530,6 +3455,81 @@
 
     "\42\00" ;; (i64.const 0)
     "\42\33" ;; (i64.const 51)
+    "\fe\37" ;; i64.atomic.rmw8.or_u
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\01" ;; memory index
+    "\11" ;; acqrel memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\42\00" ;; (i64.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\37" ;; i64.atomic.rmw8.or_u
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\01" ;; memory index
+    "\00" ;; seqcst memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\38" ;; i64.atomic.rmw16.or_u
+    "\03" ;; Alignment of 3
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\38" ;; i64.atomic.rmw16.or_u
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
+    "\11" ;; acqrel memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\38" ;; i64.atomic.rmw16.or_u
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
+    "\00" ;; seqcst memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\38" ;; i64.atomic.rmw16.or_u
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\00" ;; memory index
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\38" ;; i64.atomic.rmw16.or_u
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\00" ;; memory index
+    "\11" ;; acqrel memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\41\00" ;; (i32.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\38" ;; i64.atomic.rmw16.or_u
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\00" ;; memory index
+    "\00" ;; seqcst memory ordering
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\42\00" ;; (i64.const 0)
+    "\42\33" ;; (i64.const 51)
+    "\fe\38" ;; i64.atomic.rmw16.or_u
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\01" ;; memory index
+    "\00" ;; offset
+    "\1a" ;; drop
+
+    "\42\00" ;; (i64.const 0)
+    "\42\33" ;; (i64.const 51)
     "\fe\38" ;; i64.atomic.rmw16.or_u
     "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
@@ -3549,14 +3549,14 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\39" ;; i64.atomic.rmw32.or_u
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\39" ;; i64.atomic.rmw32.or_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -3564,7 +3564,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\39" ;; i64.atomic.rmw32.or_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -3572,7 +3572,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\39" ;; i64.atomic.rmw32.or_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -3580,7 +3580,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\39" ;; i64.atomic.rmw32.or_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -3589,7 +3589,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\39" ;; i64.atomic.rmw32.or_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -3673,7 +3673,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\3a" ;; i32.atomic.rmw.xor
-    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -3681,7 +3681,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\3a" ;; i32.atomic.rmw.xor
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -3690,7 +3690,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\3a" ;; i32.atomic.rmw.xor
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -3699,14 +3699,14 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\3b" ;; i64.atomic.rmw.xor
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\3b" ;; i64.atomic.rmw.xor
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -3714,7 +3714,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\3b" ;; i64.atomic.rmw.xor
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -3722,7 +3722,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\3b" ;; i64.atomic.rmw.xor
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -3730,7 +3730,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\3b" ;; i64.atomic.rmw.xor
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -3739,7 +3739,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\3b" ;; i64.atomic.rmw.xor
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -3823,7 +3823,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\3c" ;; i32.atomic.rmw8.xor_u
-    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -3831,7 +3831,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\3c" ;; i32.atomic.rmw8.xor_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -3840,7 +3840,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\3c" ;; i32.atomic.rmw8.xor_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -3898,7 +3898,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\3d" ;; i32.atomic.rmw16.xor_u
-    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -3906,7 +3906,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\3d" ;; i32.atomic.rmw16.xor_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -3915,7 +3915,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\3d" ;; i32.atomic.rmw16.xor_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -3924,14 +3924,14 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\3e" ;; i64.atomic.rmw8.xor_u
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\3e" ;; i64.atomic.rmw8.xor_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -3939,7 +3939,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\3e" ;; i64.atomic.rmw8.xor_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -3947,7 +3947,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\3e" ;; i64.atomic.rmw8.xor_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -3955,7 +3955,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\3e" ;; i64.atomic.rmw8.xor_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -3964,7 +3964,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\3e" ;; i64.atomic.rmw8.xor_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -3999,14 +3999,14 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\3f" ;; i64.atomic.rmw16.xor_u
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\3f" ;; i64.atomic.rmw16.xor_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -4014,7 +4014,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\3f" ;; i64.atomic.rmw16.xor_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -4022,7 +4022,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\3f" ;; i64.atomic.rmw16.xor_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -4030,7 +4030,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\3f" ;; i64.atomic.rmw16.xor_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -4039,7 +4039,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\3f" ;; i64.atomic.rmw16.xor_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -4074,14 +4074,14 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\40" ;; i64.atomic.rmw32.xor_u
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\40" ;; i64.atomic.rmw32.xor_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -4089,7 +4089,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\40" ;; i64.atomic.rmw32.xor_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -4097,7 +4097,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\40" ;; i64.atomic.rmw32.xor_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -4105,7 +4105,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\40" ;; i64.atomic.rmw32.xor_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -4114,7 +4114,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\40" ;; i64.atomic.rmw32.xor_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -4198,7 +4198,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\41" ;; i32.atomic.rmw.xchg
-    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -4206,7 +4206,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\41" ;; i32.atomic.rmw.xchg
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -4215,7 +4215,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\41" ;; i32.atomic.rmw.xchg
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -4224,14 +4224,14 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\42" ;; i64.atomic.rmw.xchg
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\42" ;; i64.atomic.rmw.xchg
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -4239,7 +4239,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\42" ;; i64.atomic.rmw.xchg
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -4247,7 +4247,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\42" ;; i64.atomic.rmw.xchg
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -4255,7 +4255,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\42" ;; i64.atomic.rmw.xchg
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -4264,7 +4264,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\42" ;; i64.atomic.rmw.xchg
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -4348,7 +4348,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\43" ;; i32.atomic.rmw8.xchg_u
-    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -4356,7 +4356,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\43" ;; i32.atomic.rmw8.xchg_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -4365,7 +4365,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\43" ;; i32.atomic.rmw8.xchg_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -4423,7 +4423,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\44" ;; i32.atomic.rmw16.xchg_u
-    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -4431,7 +4431,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\44" ;; i32.atomic.rmw16.xchg_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -4440,7 +4440,7 @@
     "\42\00" ;; (i64.const 0)
     "\41\33" ;; (i32.const 51)
     "\fe\44" ;; i32.atomic.rmw16.xchg_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -4449,14 +4449,14 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\45" ;; i64.atomic.rmw8.xchg_u
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\45" ;; i64.atomic.rmw8.xchg_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -4464,7 +4464,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\45" ;; i64.atomic.rmw8.xchg_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -4472,7 +4472,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\45" ;; i64.atomic.rmw8.xchg_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -4480,7 +4480,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\45" ;; i64.atomic.rmw8.xchg_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -4489,7 +4489,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\45" ;; i64.atomic.rmw8.xchg_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -4524,14 +4524,14 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\46" ;; i64.atomic.rmw16.xchg_u
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\46" ;; i64.atomic.rmw16.xchg_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -4539,7 +4539,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\46" ;; i64.atomic.rmw16.xchg_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -4547,7 +4547,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\46" ;; i64.atomic.rmw16.xchg_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -4555,7 +4555,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\46" ;; i64.atomic.rmw16.xchg_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -4564,7 +4564,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\46" ;; i64.atomic.rmw16.xchg_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -4599,14 +4599,14 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\47" ;; i64.atomic.rmw32.xchg_u
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
     "\1a" ;; drop
 
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\47" ;; i64.atomic.rmw32.xchg_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -4614,7 +4614,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\47" ;; i64.atomic.rmw32.xchg_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -4622,7 +4622,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\47" ;; i64.atomic.rmw32.xchg_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -4630,7 +4630,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\47" ;; i64.atomic.rmw32.xchg_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -4639,7 +4639,7 @@
     "\41\00" ;; (i32.const 0)
     "\42\33" ;; (i64.const 51)
     "\fe\47" ;; i64.atomic.rmw32.xchg_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -4730,7 +4730,7 @@
     "\41\33" ;; (i32.const 51)
     "\41\33" ;; (i32.const 51)
     "\fe\48" ;; i32.atomic.rmw.cmpxchg
-    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -4739,7 +4739,7 @@
     "\41\33" ;; (i32.const 51)
     "\41\33" ;; (i32.const 51)
     "\fe\48" ;; i32.atomic.rmw.cmpxchg
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -4749,7 +4749,7 @@
     "\41\33" ;; (i32.const 51)
     "\41\33" ;; (i32.const 51)
     "\fe\48" ;; i32.atomic.rmw.cmpxchg
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -4759,7 +4759,7 @@
     "\42\33" ;; (i64.const 51)
     "\42\33" ;; (i64.const 51)
     "\fe\49" ;; i64.atomic.rmw.cmpxchg
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
     "\1a" ;; drop
 
@@ -4767,7 +4767,7 @@
     "\42\33" ;; (i64.const 51)
     "\42\33" ;; (i64.const 51)
     "\fe\49" ;; i64.atomic.rmw.cmpxchg
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -4776,7 +4776,7 @@
     "\42\33" ;; (i64.const 51)
     "\42\33" ;; (i64.const 51)
     "\fe\49" ;; i64.atomic.rmw.cmpxchg
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -4785,7 +4785,7 @@
     "\42\33" ;; (i64.const 51)
     "\42\33" ;; (i64.const 51)
     "\fe\49" ;; i64.atomic.rmw.cmpxchg
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -4794,7 +4794,7 @@
     "\42\33" ;; (i64.const 51)
     "\42\33" ;; (i64.const 51)
     "\fe\49" ;; i64.atomic.rmw.cmpxchg
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -4804,7 +4804,7 @@
     "\42\33" ;; (i64.const 51)
     "\42\33" ;; (i64.const 51)
     "\fe\49" ;; i64.atomic.rmw.cmpxchg
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -4898,7 +4898,7 @@
     "\41\33" ;; (i32.const 51)
     "\41\33" ;; (i32.const 51)
     "\fe\4a" ;; i32.atomic.rmw8.cmpxchg_u
-    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -4907,7 +4907,7 @@
     "\41\33" ;; (i32.const 51)
     "\41\33" ;; (i32.const 51)
     "\fe\4a" ;; i32.atomic.rmw8.cmpxchg_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -4917,7 +4917,7 @@
     "\41\33" ;; (i32.const 51)
     "\41\33" ;; (i32.const 51)
     "\fe\4a" ;; i32.atomic.rmw8.cmpxchg_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -4982,7 +4982,7 @@
     "\41\33" ;; (i32.const 51)
     "\41\33" ;; (i32.const 51)
     "\fe\4b" ;; i32.atomic.rmw16.cmpxchg_u
-    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
+    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -4991,7 +4991,7 @@
     "\41\33" ;; (i32.const 51)
     "\41\33" ;; (i32.const 51)
     "\fe\4b" ;; i32.atomic.rmw16.cmpxchg_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -5001,7 +5001,7 @@
     "\41\33" ;; (i32.const 51)
     "\41\33" ;; (i32.const 51)
     "\fe\4b" ;; i32.atomic.rmw16.cmpxchg_u
-    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\01" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -5011,7 +5011,7 @@
     "\42\33" ;; (i64.const 51)
     "\42\33" ;; (i64.const 51)
     "\fe\4c" ;; i64.atomic.rmw8.cmpxchg_u
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
     "\1a" ;; drop
 
@@ -5019,7 +5019,7 @@
     "\42\33" ;; (i64.const 51)
     "\42\33" ;; (i64.const 51)
     "\fe\4c" ;; i64.atomic.rmw8.cmpxchg_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -5028,7 +5028,7 @@
     "\42\33" ;; (i64.const 51)
     "\42\33" ;; (i64.const 51)
     "\fe\4c" ;; i64.atomic.rmw8.cmpxchg_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -5037,7 +5037,7 @@
     "\42\33" ;; (i64.const 51)
     "\42\33" ;; (i64.const 51)
     "\fe\4c" ;; i64.atomic.rmw8.cmpxchg_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -5046,7 +5046,7 @@
     "\42\33" ;; (i64.const 51)
     "\42\33" ;; (i64.const 51)
     "\fe\4c" ;; i64.atomic.rmw8.cmpxchg_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -5056,7 +5056,7 @@
     "\42\33" ;; (i64.const 51)
     "\42\33" ;; (i64.const 51)
     "\fe\4c" ;; i64.atomic.rmw8.cmpxchg_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -5095,7 +5095,7 @@
     "\42\33" ;; (i64.const 51)
     "\42\33" ;; (i64.const 51)
     "\fe\4d" ;; i64.atomic.rmw16.cmpxchg_u
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
     "\1a" ;; drop
 
@@ -5103,7 +5103,7 @@
     "\42\33" ;; (i64.const 51)
     "\42\33" ;; (i64.const 51)
     "\fe\4d" ;; i64.atomic.rmw16.cmpxchg_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -5112,7 +5112,7 @@
     "\42\33" ;; (i64.const 51)
     "\42\33" ;; (i64.const 51)
     "\fe\4d" ;; i64.atomic.rmw16.cmpxchg_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -5121,7 +5121,7 @@
     "\42\33" ;; (i64.const 51)
     "\42\33" ;; (i64.const 51)
     "\fe\4d" ;; i64.atomic.rmw16.cmpxchg_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -5130,7 +5130,7 @@
     "\42\33" ;; (i64.const 51)
     "\42\33" ;; (i64.const 51)
     "\fe\4d" ;; i64.atomic.rmw16.cmpxchg_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -5140,7 +5140,7 @@
     "\42\33" ;; (i64.const 51)
     "\42\33" ;; (i64.const 51)
     "\fe\4d" ;; i64.atomic.rmw16.cmpxchg_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
@@ -5179,7 +5179,7 @@
     "\42\33" ;; (i64.const 51)
     "\42\33" ;; (i64.const 51)
     "\fe\4e" ;; i64.atomic.rmw32.cmpxchg_u
-    "\02" ;; Alignment of 2
+    "\03" ;; Alignment of 3
     "\00" ;; offset
     "\1a" ;; drop
 
@@ -5187,7 +5187,7 @@
     "\42\33" ;; (i64.const 51)
     "\42\33" ;; (i64.const 51)
     "\fe\4e" ;; i64.atomic.rmw32.cmpxchg_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -5196,7 +5196,7 @@
     "\42\33" ;; (i64.const 51)
     "\42\33" ;; (i64.const 51)
     "\fe\4e" ;; i64.atomic.rmw32.cmpxchg_u
-    "\12" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows
+    "\13" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows
     "\00" ;; seqcst memory ordering
     "\00" ;; offset
     "\1a" ;; drop
@@ -5205,7 +5205,7 @@
     "\42\33" ;; (i64.const 51)
     "\42\33" ;; (i64.const 51)
     "\fe\4e" ;; i64.atomic.rmw32.cmpxchg_u
-    "\42" ;; Alignment of 2 with bit 6 set indicating that a memory index immediate follows
+    "\43" ;; Alignment of 3 with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; offset
     "\1a" ;; drop
@@ -5214,7 +5214,7 @@
     "\42\33" ;; (i64.const 51)
     "\42\33" ;; (i64.const 51)
     "\fe\4e" ;; i64.atomic.rmw32.cmpxchg_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\11" ;; acqrel memory ordering
     "\00" ;; offset
@@ -5224,7 +5224,7 @@
     "\42\33" ;; (i64.const 51)
     "\42\33" ;; (i64.const 51)
     "\fe\4e" ;; i64.atomic.rmw32.cmpxchg_u
-    "\52" ;; Alignment of 2 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
+    "\53" ;; Alignment of 3 with bit 4 set indicating that an ordering immediate follows and with bit 6 set indicating that a memory index immediate follows
     "\00" ;; memory index
     "\00" ;; seqcst memory ordering
     "\00" ;; offset


### PR DESCRIPTION
The spec test intends to use the natural alignment for all instructions, but it's choosing an alignment based on the memory address type rather than the size of the load/store. This means that sometimes the alignment is too small (4 bytes for an 8-byte load/store in a 32-bit memory), and sometimes the alignment is too large (8 bytes for a 4-byte load/store in a 64-bit memory) both of which are a [validation error](https://github.com/stevenfontanella/threads/blob/f521d7b3c19bcc9097aad979b3b91837eab88d83/interpreter/valid/valid.ml#L206) (but are not in Binaryen today).

Use the size of the load/store as the alignment instead.

Spec reference:
<img width="737" height="216" alt="image" src="https://github.com/user-attachments/assets/b86de03e-1316-4c2c-9a12-80773fb88119" />
