### PR TITLE
[Relaxed SIMD] Fix validation and fuzzer handling

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -864,9 +864,9 @@ class D8:
 
     @override
     def can_compare_to_self(self):
-        # With nans, VM differences can confuse us, so only very simple VMs
-        # can compare to themselves after opts in that case.
-        return not NANS
+        # With nans or relaxed SIMD, VM differences can confuse us, so only very
+        # simple VMs can compare to themselves after binaryen opts in that case.
+        return not NANS and all_disallowed(['relaxed-simd'])
 
     @override
     def can_compare_to_other(self, other):

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -864,8 +864,10 @@ class D8:
 
     @override
     def can_compare_to_self(self):
-        # With nans or relaxed SIMD, VM differences can confuse us, so only very
-        # simple VMs can compare to themselves after binaryen opts in that case.
+        # With nans or relaxed SIMD, VM differences can confuse us, including
+        # differences between binaryen and V8 (binaryen's behavior can get
+        # "baked" into the wasm when it precomputes code, so we cannot compare
+        # V8's output before binaryen opts and after binaryen opts).
         return not NANS and all_disallowed(['relaxed-simd'])
 
     @override

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -2052,7 +2052,7 @@ class Two(TestCaseHandler):
         # outputs from V8), and we must disallow features that don't even work
         # in V8.
         # TODO: relax some of these
-        if NANS or all_disallowed(['relaxed-simd']) or not all_disallowed(DISALLOWED_FEATURES_IN_V8):
+        if NANS or not all_disallowed(['relaxed-simd']) or not all_disallowed(DISALLOWED_FEATURES_IN_V8):
             return
 
         output = run_d8_wasm(wasm, args=[second_wasm])

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -2048,10 +2048,11 @@ class Two(TestCaseHandler):
         compare(output, optimized_output, 'Two-Opt')
 
         # If we can, also test in V8. We also cannot compare if there are NaNs
-        # (as optimizations can lead to different outputs), and we must
-        # disallow some features.
+        # or relaxed SIMD (as binaryen optimizations can lead to different
+        # outputs from V8), and we must disallow features that don't even work
+        # in V8.
         # TODO: relax some of these
-        if NANS or not all_disallowed(DISALLOWED_FEATURES_IN_V8):
+        if NANS or all_disallowed(['relaxed-simd']) or not all_disallowed(DISALLOWED_FEATURES_IN_V8):
             return
 
         output = run_d8_wasm(wasm, args=[second_wasm])

--- a/src/ir/features.h
+++ b/src/ir/features.h
@@ -173,7 +173,8 @@ inline FeatureSet get(BinaryOp op) {
     case RelaxedMinVecF64x2:
     case RelaxedMaxVecF64x2:
     case RelaxedSwizzleVecI8x16:
-    case RelaxedQ15MulrSVecI16x8: {
+    case RelaxedQ15MulrSVecI16x8:
+    case RelaxedDotI8x16I7x16SToVecI16x8: {
       ret.setSIMD();
       ret.setRelaxedSIMD();
       break;


### PR DESCRIPTION
1. An opcode was not noted as requiring the feature.
2. Like NaNs, we can't optimize wasms and then compare them, if relaxed SIMD is enabled.