### PR TITLE
Remove unused variables. NFC

### DIFF
--- a/src/cfg/Relooper.cpp
+++ b/src/cfg/Relooper.cpp
@@ -333,7 +333,6 @@ wasm::Expression* Block::Render(RelooperBuilder& Builder, bool InLoop) {
     auto Base = std::string("switch$") + std::to_string(Id);
     auto SwitchDefault = wasm::Name(Base + "$default");
     auto SwitchLeave = wasm::Name(Base + "$leave");
-    std::map<Block*, wasm::Name> BlockNameMap;
     auto* Outer = Builder.makeBlock();
     auto* Inner = Outer;
     std::vector<wasm::Name> Table;

--- a/src/passes/GenerateDynCalls.cpp
+++ b/src/passes/GenerateDynCalls.cpp
@@ -58,7 +58,6 @@ struct GenerateDynCalls : public WalkerPass<PostWalker<GenerateDynCalls>> {
                              return segment->table == table->name;
                            });
     if (it != segments.end()) {
-      std::vector<Name> tableSegmentData;
       ElementUtils::iterElementSegmentFunctionNames(
         it->get(), [&](Name name, Index) {
           generateDynCallThunk(wasm->getFunction(name)->type.getHeapType());

--- a/src/passes/ReorderLocals.cpp
+++ b/src/passes/ReorderLocals.cpp
@@ -132,7 +132,6 @@ struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
     reIndexer.walk(curr->body);
     // apply to the names
     auto oldLocalNames = curr->localNames;
-    auto oldLocalIndices = curr->localIndices;
     curr->localNames.clear();
     curr->localIndices.clear();
     for (size_t i = 0; i < newToOld.size(); i++) {

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -1540,8 +1540,6 @@ static bool canEval(Module& wasm) {
 //
 
 int main(int argc, const char* argv[]) {
-  Name entry;
-  std::vector<std::string> passes;
   bool emitBinary = true;
   bool debugInfo = false;
   String::Split ctors;

--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -416,8 +416,6 @@ public:
 //
 
 int main(int argc, const char* argv[]) {
-  Name entry;
-  std::vector<std::string> passes;
   bool emitBinary = true;
   bool debugInfo = false;
   std::string graphFile;

--- a/src/tools/wasm-shell.cpp
+++ b/src/tools/wasm-shell.cpp
@@ -655,9 +655,6 @@ struct Shell {
 };
 
 int main(int argc, const char* argv[]) {
-  Name entry;
-  std::set<size_t> skipped;
-
   // Read stdin by default.
   std::string infile = "-";
   Options options("wasm-shell", "Execute .wast files");


### PR DESCRIPTION
These were preventing the latest version of llvm from building binaryen.

This was triggered by https://github.com/llvm/llvm-project/pull/203084

See https://logs.chromium.org/logs/emscripten-releases/buildbucket/cr-buildbucket/8674381472972128657/+/u/Build_Binaryen/stdout