### PR TITLE
Add BYN_WARN_UNUSED macro and apply to Name and IString

### DIFF
--- a/src/compiler-support.h
+++ b/src/compiler-support.h
@@ -31,4 +31,10 @@
 #define WASM_BUILTIN_UNREACHABLE __assume(false)
 #endif
 
+#if defined(__GNUC__) || defined(__clang__)
+#define BYN_WARN_UNUSED [[gnu::warn_unused]]
+#else
+#define BYN_WARN_UNUSED
+#endif
+
 #endif // wasm_compiler_support_h

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -898,7 +898,6 @@ struct InfoCollector
   }
 
   void visitCall(Call* curr) {
-    Name targetName;
     if (!Intrinsics(*getModule()).isCallWithoutEffects(curr)) {
       // This is just a normal call.
       handleDirectCall(curr, curr->target);

--- a/src/support/istring.h
+++ b/src/support/istring.h
@@ -31,7 +31,7 @@
 
 namespace wasm {
 
-struct IString {
+struct BYN_WARN_UNUSED IString {
 private:
   static const char* interned(std::string_view s);
 

--- a/src/support/name.h
+++ b/src/support/name.h
@@ -31,7 +31,7 @@ namespace wasm {
 // TODO: as an optimization, IString values < some threshold could be considered
 //       numerical indices directly.
 
-struct Name : public IString {
+struct BYN_WARN_UNUSED Name : public IString {
   Name() : IString() {}
   Name(std::string_view str) : IString(str) {}
   Name(const char* str) : IString(str) {}

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -74,7 +74,6 @@ willRemoveDebugInfo(const std::vector<OptimizationOptions::PassInfo>& passes) {
 //
 
 int main(int argc, const char* argv[]) {
-  Name entry;
   bool emitBinary = true;
   bool converge = false;
   bool fuzzExecBefore = false;


### PR DESCRIPTION
Define `BYN_WARN_UNUSED` using `[[gnu::warn_unused]]` for GCC/Clang and fallback for other compilers. Annotating `IString` and `Name` with this attribute allows compilers to report unused variable diagnostics for default-constructed instances regardless of non-trivial constructors.

Followup to #8972.

Once this lands we can extend this to other types to get better coverage.