### PR TITLE
Fix ReFinalize in MakeSharedObjects

### DIFF
--- a/src/passes/MakeSharedObjects.cpp
+++ b/src/passes/MakeSharedObjects.cpp
@@ -134,7 +134,6 @@ struct MakeSharedObjects
     CallRefCollector collector(callRefTypes);
     collector.walk(curr->body);
     WalkerPass::walkFunction(curr);
-    ReFinalize().walkFunctionInModule(curr, getModule());
   }
 
   void visitCallRef(CallRef* curr) {
@@ -325,6 +324,7 @@ struct MakeSharedObjects
   void visitModule(Module* wasm) {
     rewriteTypes();
     addFunctionTable();
+    ReFinalize().run(getPassRunner(), wasm);
   }
 
   void rewriteTypes() {

--- a/test/lit/passes/make-shared-objects.wast
+++ b/test/lit/passes/make-shared-objects.wast
@@ -1424,3 +1424,23 @@
   ;; CHECK:      (import "" "" (global $g-sig (ref null (shared i31))))
   (import "" "" (global $g-sig (ref null $sig)))
 )
+
+(module
+  ;; Struct gets of signature fields must be properly refinalized to shared
+  ;; i31 after rewriteTypes rewrites the struct types to shared.
+  (type $sig (func))
+  ;; CHECK:      (type $struct (shared (struct (field (ref (shared i31))))))
+  (type $struct (struct (field (ref $sig))))
+  ;; CHECK:      (type $1 (func (param (ref $struct)) (result (ref (shared i31)))))
+
+  ;; CHECK:      (func $struct-get (type $1) (param $0 (ref $struct)) (result (ref (shared i31)))
+  ;; CHECK-NEXT:  (struct.get $struct 0
+  ;; CHECK-NEXT:   (local.get $0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $struct-get (param (ref $struct)) (result (ref $sig))
+    (struct.get $struct 0
+      (local.get 0)
+    )
+  )
+)


### PR DESCRIPTION
We need to refinalize after updating the types to make sure e.g. struct.get of a field that used to contain a function reference has the proper i31ref type.
