### PR TITLE
Consistent header guards. NFC

### DIFF
--- a/src/passes/call-utils.h
+++ b/src/passes/call-utils.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef wasm_ir_function_h
-#define wasm_ir_function_h
+#ifndef wasm_passes_call_utils_h
+#define wasm_passes_call_utils_h
 
 #include <variant>
 
@@ -153,4 +153,4 @@ convertToDirectCalls(T* curr,
 
 } // namespace wasm::CallUtils
 
-#endif // wasm_ir_function_h
+#endif // wasm_passes_call_utils_h

--- a/src/wasm-annotations.h
+++ b/src/wasm-annotations.h
@@ -18,8 +18,8 @@
 // Support for code annotations.
 //
 
-#ifndef wasm_annotations_h
-#define wasm_annotations_h
+#ifndef wasm_wasm_annotations_h
+#define wasm_wasm_annotations_h
 
 #include "support/name.h"
 
@@ -34,4 +34,4 @@ extern const Name ToolchainInlineHint;
 
 } // namespace wasm::Annotations
 
-#endif // wasm_annotations_h
+#endif // wasm_wasm_annotations_h

--- a/src/wasm-features.h
+++ b/src/wasm-features.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef wasm_features_h
-#define wasm_features_h
+#ifndef wasm_wasm_features_h
+#define wasm_wasm_features_h
 
 #include <stdint.h>
 #include <string>
@@ -259,4 +259,4 @@ struct FeatureSet {
 
 } // namespace wasm
 
-#endif // wasm_features_h
+#endif // wasm_wasm_features_h

--- a/src/wasm-stack.h
+++ b/src/wasm-stack.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef wasm_stack_h
-#define wasm_stack_h
+#ifndef wasm_wasm_stack_h
+#define wasm_wasm_stack_h
 
 #include "ir/branch-utils.h"
 #include "ir/find_all.h"
@@ -656,4 +656,4 @@ namespace std {
 std::ostream& operator<<(std::ostream& o, wasm::StackInst& inst);
 } // namespace std
 
-#endif // wasm_stack_h
+#endif // wasm_wasm_stack_h


### PR DESCRIPTION
One bad offender here was src/passes/call-utils.h