### PR TITLE
Validate remaining FP16 instruction features

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -1235,6 +1235,11 @@ void FunctionValidator::visitLoad(Load* curr) {
                  curr,
                  "SIMD operations require SIMD [--enable-simd]");
   }
+  if (curr->type == Type::f32 && curr->bytes == 2) {
+    shouldBeTrue(getModule()->features.hasFP16(),
+                 curr,
+                 "FP16 operations require FP16 [--enable-fp16]");
+  }
   validateMemBytes(curr->bytes, curr->type, curr);
   validateOffset(curr->offset, memory, curr);
   validateAlignment(
@@ -1279,6 +1284,11 @@ void FunctionValidator::visitStore(Store* curr) {
     shouldBeTrue(getModule()->features.hasSIMD(),
                  curr,
                  "SIMD operations require SIMD [--enable-simd]");
+  }
+  if (curr->valueType == Type::f32 && curr->bytes == 2) {
+    shouldBeTrue(getModule()->features.hasFP16(),
+                 curr,
+                 "FP16 operations require FP16 [--enable-fp16]");
   }
   validateMemBytes(curr->bytes, curr->valueType, curr);
   validateOffset(curr->offset, memory, curr);
@@ -2341,6 +2351,13 @@ void FunctionValidator::visitUnary(Unary* curr) {
     case FloorVecF16x8:
     case TruncVecF16x8:
     case NearestVecF16x8:
+    case PromoteLowVecF16x8ToVecF32x4:
+    case DemoteZeroVecF32x4ToVecF16x8:
+    case DemoteZeroVecF64x2ToVecF16x8:
+    case TruncSatSVecF16x8ToVecI16x8:
+    case TruncSatUVecF16x8ToVecI16x8:
+    case ConvertSVecI16x8ToVecF16x8:
+    case ConvertUVecI16x8ToVecF16x8:
       shouldBeTrue(getModule()->features.hasFP16(),
                    curr,
                    "FP16 operations require FP16 [--enable-fp16]");
@@ -2395,17 +2412,10 @@ void FunctionValidator::visitUnary(Unary* curr) {
     case TruncSatZeroUVecF64x2ToVecI32x4:
     case DemoteZeroVecF64x2ToVecF32x4:
     case PromoteLowVecF32x4ToVecF64x2:
-    case PromoteLowVecF16x8ToVecF32x4:
-    case DemoteZeroVecF32x4ToVecF16x8:
-    case DemoteZeroVecF64x2ToVecF16x8:
     case RelaxedTruncSVecF32x4ToVecI32x4:
     case RelaxedTruncUVecF32x4ToVecI32x4:
     case RelaxedTruncZeroSVecF64x2ToVecI32x4:
     case RelaxedTruncZeroUVecF64x2ToVecI32x4:
-    case TruncSatSVecF16x8ToVecI16x8:
-    case TruncSatUVecF16x8ToVecI16x8:
-    case ConvertSVecI16x8ToVecF16x8:
-    case ConvertUVecI16x8ToVecF16x8:
       shouldBeEqual(curr->type, Type(Type::v128), curr, "expected v128 type");
       shouldBeEqual(
         curr->value->type, Type(Type::v128), curr, "expected v128 operand");

--- a/test/lit/validation/fp16-memory.wast
+++ b/test/lit/validation/fp16-memory.wast
@@ -1,0 +1,12 @@
+;; RUN: foreach %s %t not wasm-opt 2>&1 | filecheck %s
+;; RUN: foreach %s %t wasm-opt --enable-fp16 -o /dev/null
+
+;; CHECK: FP16 operations require FP16 [--enable-fp16]
+(module
+  (memory 1)
+  (func (result f32) (f32.load_f16 (i32.const 0))))
+
+;; CHECK: FP16 operations require FP16 [--enable-fp16]
+(module
+  (memory 1)
+  (func (param f32) (f32.store_f16 (i32.const 0) (local.get 0))))

--- a/test/lit/validation/fp16-unary.wast
+++ b/test/lit/validation/fp16-unary.wast
@@ -1,0 +1,30 @@
+;; RUN: foreach %s %t not wasm-opt --enable-simd 2>&1 | filecheck %s
+;; RUN: foreach %s %t wasm-opt --enable-simd --enable-fp16 -o /dev/null
+
+;; CHECK: FP16 operations require FP16 [--enable-fp16]
+(module (func (param v128) (result v128)
+  (f32x4.promote_low_f16x8 (local.get 0))))
+
+;; CHECK: FP16 operations require FP16 [--enable-fp16]
+(module (func (param v128) (result v128)
+  (f16x8.demote_f32x4_zero (local.get 0))))
+
+;; CHECK: FP16 operations require FP16 [--enable-fp16]
+(module (func (param v128) (result v128)
+  (f16x8.demote_f64x2_zero (local.get 0))))
+
+;; CHECK: FP16 operations require FP16 [--enable-fp16]
+(module (func (param v128) (result v128)
+  (i16x8.trunc_sat_f16x8_s (local.get 0))))
+
+;; CHECK: FP16 operations require FP16 [--enable-fp16]
+(module (func (param v128) (result v128)
+  (i16x8.trunc_sat_f16x8_u (local.get 0))))
+
+;; CHECK: FP16 operations require FP16 [--enable-fp16]
+(module (func (param v128) (result v128)
+  (f16x8.convert_i16x8_s (local.get 0))))
+
+;; CHECK: FP16 operations require FP16 [--enable-fp16]
+(module (func (param v128) (result v128)
+  (f16x8.convert_i16x8_u (local.get 0))))


### PR DESCRIPTION
Fixes #8313
## Summary
- Move seven unguarded FP16 unary conversion case labels into the existing FP16-guarded fallthrough group in `visitUnary`
- Require FP16 for `f32.load_f16` and `f32.store_f16` in `visitLoad`/`visitStore`
- Add lit regression tests: 7 independent unary modules + 2 independent memory modules via `foreach`
The SIMDTernary madd/nmadd case from the original report was fixed by #8403; this PR closes the remaining identifiable FP16 validation gaps found by audit.

## Test plan
- [x] `build-clang/bin/binaryen-lit test/lit/validation/fp16-unary.wast -v`
- [x] `build-clang/bin/binaryen-lit test/lit/validation/fp16-memory.wast -v`
- [x] `build-clang/bin/binaryen-lit test/lit/validation -v`
- [x] `./check.py --binaryen-bin build-clang/bin validator`