### PR TITLE
update param of `BinaryenRefNull` to take `BinaryenHeapType`

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -1740,7 +1740,8 @@ BinaryenExpressionRef BinaryenTableGrow(BinaryenModuleRef module,
                                         BinaryenExpressionRef delta) {
   if (value == nullptr) {
     auto tableType = (*(Module*)module).getTableOrNull(name)->type;
-    value = BinaryenRefNull(module, (BinaryenHeapType)tableType.getHeapType().getID());
+    value = BinaryenRefNull(module,
+                            (BinaryenHeapType)tableType.getHeapType().getID());
   }
   return static_cast<Expression*>(
     Builder(*(Module*)module)

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -1663,11 +1663,10 @@ BinaryenExpressionRef BinaryenPop(BinaryenModuleRef module, BinaryenType type) {
 }
 
 BinaryenExpressionRef BinaryenRefNull(BinaryenModuleRef module,
-                                      BinaryenType type) {
-  Type type_(type);
-  assert(type_.isNullable());
+                                      BinaryenHeapType heaptype) {
+  HeapType heaptype_(heaptype);
   return static_cast<Expression*>(
-    Builder(*(Module*)module).makeRefNull(type_.getHeapType()));
+    Builder(*(Module*)module).makeRefNull(heaptype_));
 }
 
 BinaryenExpressionRef BinaryenRefIsNull(BinaryenModuleRef module,
@@ -1741,7 +1740,7 @@ BinaryenExpressionRef BinaryenTableGrow(BinaryenModuleRef module,
                                         BinaryenExpressionRef delta) {
   if (value == nullptr) {
     auto tableType = (*(Module*)module).getTableOrNull(name)->type;
-    value = BinaryenRefNull(module, (BinaryenType)tableType.getID());
+    value = BinaryenRefNull(module, (BinaryenHeapType)tableType.getHeapType().getID());
   }
   return static_cast<Expression*>(
     Builder(*(Module*)module)

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -52,6 +52,26 @@ function initializeConstants() {
     Module[entry[0]] = Module['_BinaryenType' + entry[1]]();
   });
 
+  [
+    ['func', 'Func'],
+    ['extern', 'Ext'],
+    ['any', 'Any'],
+    ['eq', 'Eq'],
+    ['i31', 'I31'],
+    ['struct', 'Struct'],
+    ['array', 'Array'],
+    ['string', 'String'],
+    /*
+    TODO: Reconcile with `none` above (line 32).
+    Maybe keep this as 'none' and change the above to 'void'?
+    ['none', 'None'],
+    */
+    ['noextern', 'Noext'],
+    ['nofunc', 'Nofunc'],
+  ].forEach(entry => {
+    Module[entry[0]] = Module['_BinaryenHeapType' + entry[1]]();
+  });
+
   [ ['notPacked', 'NotPacked'],
     ['i8', 'Int8'],
     ['i16', 'Int16']

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -2438,8 +2438,8 @@ function wrapModule(module, self = {}) {
   };
 
   self['ref'] = {
-    'null'(type) {
-      return Module['_BinaryenRefNull'](module, type);
+    'null'(heaptype) {
+      return Module['_BinaryenRefNull'](module, heaptype);
     },
     'is_null'(value) {
       return Module['_BinaryenRefIsNull'](module, value);

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -603,13 +603,13 @@ function test_core() {
     module.return_call_indirect("t0", makeInt32(2449), [ makeInt32(13), makeInt64(37, 0), makeFloat32(1.3), makeFloat64(3.7) ], iIfF, binaryen.i32),
 
     // Reference types
-    module.ref.is_null(module.ref.null(binaryen.externref)),
-    module.ref.is_null(module.ref.null(binaryen.funcref)),
+    module.ref.is_null(module.ref.null(binaryen.extern)),
+    module.ref.is_null(module.ref.null(binaryen.func)),
     module.ref.is_null(module.ref.func("foobar", foobarType)),
-    module.select(temp10, module.ref.null(binaryen.funcref), module.ref.func("foobar", foobarType)),
+    module.select(temp10, module.ref.null(binaryen.func), module.ref.func("foobar", foobarType)),
 
     // GC
-    module.ref.eq(module.ref.null(binaryen.eqref), module.ref.null(binaryen.eqref)),
+    module.ref.eq(module.ref.null(binaryen.eq), module.ref.null(binaryen.eq)),
 
     // Exception handling
     module.try(

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -485,9 +485,9 @@ void test_core() {
                         temp15 = makeInt32(module, 110),
                         temp16 = makeInt64(module, 111);
   BinaryenExpressionRef externrefExpr =
-    BinaryenRefNull(module, BinaryenTypeNullExternref());
+    BinaryenRefNull(module, BinaryenHeapTypeNoext());
   BinaryenExpressionRef funcrefExpr =
-    BinaryenRefNull(module, BinaryenTypeNullFuncref());
+    BinaryenRefNull(module, BinaryenHeapTypeNofunc());
   funcrefExpr =
     BinaryenRefFunc(module, "kitchen()sinker", kitchenSinkerRefType);
   BinaryenExpressionRef i31refExpr =
@@ -1065,21 +1065,21 @@ void test_core() {
     BinaryenSelect(
       module,
       temp10,
-      BinaryenRefNull(module, BinaryenTypeNullFuncref()),
+      BinaryenRefNull(module, BinaryenHeapTypeNofunc()),
       BinaryenRefFunc(module, "kitchen()sinker", kitchenSinkerRefType)),
     // GC
     BinaryenRefEq(module,
-                  BinaryenRefNull(module, BinaryenTypeNullref()),
-                  BinaryenRefNull(module, BinaryenTypeNullref())),
+                  BinaryenRefNull(module, BinaryenHeapTypeNone()),
+                  BinaryenRefNull(module, BinaryenHeapTypeNone())),
     BinaryenRefAs(module,
                   BinaryenRefAsNonNull(),
-                  BinaryenRefNull(module, BinaryenTypeNullref())),
+                  BinaryenRefNull(module, BinaryenHeapTypeNone())),
     BinaryenRefAs(module,
                   BinaryenRefAsAnyConvertExtern(),
-                  BinaryenRefNull(module, BinaryenTypeNullExternref())),
+                  BinaryenRefNull(module, BinaryenHeapTypeNoext())),
     BinaryenRefAs(module,
                   BinaryenRefAsExternConvertAny(),
-                  BinaryenRefNull(module, BinaryenTypeNullref())),
+                  BinaryenRefNull(module, BinaryenHeapTypeNone())),
     // Exception handling
     BinaryenTry(module, NULL, tryBody, catchTags, 1, catchBodies, 2, NULL),
     // (try $try_outer
@@ -1360,7 +1360,7 @@ void test_core() {
     BinaryenArrayNew(module,
                      BinaryenTypeGetHeapType(funcArray),
                      makeInt32(module, 0),
-                     BinaryenRefNull(module, BinaryenTypeNullFuncref())));
+                     BinaryenRefNull(module, BinaryenHeapTypeNofunc())));
   BinaryenAddGlobal(
     module,
     "i32Struct-global",
@@ -1429,7 +1429,7 @@ void test_core() {
   BinaryenTableSizeSetTable(tablesize, table);
 
   BinaryenExpressionRef valueExpr =
-    BinaryenRefNull(module, BinaryenTypeNullFuncref());
+    BinaryenRefNull(module, BinaryenHeapTypeNofunc());
   BinaryenExpressionRef sizeExpr = makeInt32(module, 0);
   BinaryenExpressionRef growExpr =
     BinaryenTableGrow(module, "0", valueExpr, sizeExpr);


### PR DESCRIPTION
According to the [WASM spec](https://webassembly.github.io/spec/core/syntax/instructions.html#reference-instructions), the `(ref.null <ht>)` instruction takes a heap type as an argument, not a reference type. This PR updates `BinaryenRefNull` to align with that.

The parameter is changed from a `BinaryenType` to a `BinaryenHeapType` and removes the nullable assertion. This puts the onus on the caller to make sure they are passing in a correct type.

This is a breaking change and would require callers to be more careful about their arguments, but it provides for a more spec-aligned and predictable API.

### Problem Statement
As an example of a problem it solves: say you’re using GC and you define your own custom heap type (example in JS):
```wasm
(type $NumberUnion (struct
	(field $tag   i8)
	(field $int   i64)
	(field $float f64)
))
```
```js
const tb = new binaryen.TypeBuilder();
tb.setStructType(0, [
	{type: binaryen.i32, packedType: "i8"},
	{type: binaryen.i64, packedType: "notPacked"},
	{type: binaryen.f64, packedType: "notPacked"},
]);
const heaptypes = tb.buildAndDispose();
const ht_NumberUnion = heaptypes[0];
```
and then you want to create a null-ref expression `(ref.null $NumberUnion)` in your module code:
```js
const mod = new binaryen.Module();
mod.ref.null(ht_NumberUnion); // error: `BinaryenRefNull` currently only accepts ref types
```
To fix, you have to create your own nullable ref type first:
```js
mod.ref.null(binaryen.getTypeFromHeapType(ht_NumberUnion, true));
```

With this PR’s proposed change, you can now just call `BinaryenRefNull` passing in your heap type.