### PR TITLE
Add a "relaxed" memory order

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -430,6 +430,9 @@ BinaryenExternalKind BinaryenExternalTag(void) {
 BINARYEN_API BinaryenMemoryOrder BinaryenMemoryOrderUnordered(void) {
   return static_cast<BinaryenMemoryOrder>(MemoryOrder::Unordered);
 }
+BINARYEN_API BinaryenMemoryOrder BinaryenMemoryOrderRelaxed(void) {
+  return static_cast<BinaryenMemoryOrder>(MemoryOrder::Relaxed);
+}
 BINARYEN_API BinaryenMemoryOrder BinaryenMemoryOrderAcqRel(void) {
   return static_cast<BinaryenMemoryOrder>(MemoryOrder::AcqRel);
 }

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -211,6 +211,9 @@ typedef uint8_t BinaryenMemoryOrder;
 
 BINARYEN_API BinaryenMemoryOrder BinaryenMemoryOrderUnordered(void);
 
+// Relaxed atomic memory operation.
+BINARYEN_API BinaryenMemoryOrder BinaryenMemoryOrderRelaxed(void);
+
 // Acquire/Release atomic memory operation; acquire for loads, release for
 // stores.
 BINARYEN_API BinaryenMemoryOrder BinaryenMemoryOrderAcqRel(void);

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -364,6 +364,12 @@ public:
     if (danglingPop) {
       return true;
     }
+    // Relaxed (or stronger) loads cannot be reordered after relaxed (or
+    // stronger) stores.
+    if (readOrder >= MemoryOrder::Relaxed &&
+        other.writeOrder >= MemoryOrder::Relaxed) {
+      return true;
+    }
     // Shared location accesses cannot be reordered after (but may be able to be
     // reordered before) release stores.
     if (other.writeOrder >= MemoryOrder::AcqRel &&

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -163,8 +163,8 @@ function initializeConstants() {
   Module['MemoryOrder'] = {};
   [ 'Unordered',
     'Relaxed',
-    'AcqRel'
-    'SeqCst',
+    'AcqRel',
+    'SeqCst'
    ].forEach(name => {
     Module['MemoryOrder'][name.toLowerCase()] = Module['_BinaryenMemoryOrder' + name]()
    });

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -162,8 +162,9 @@ function initializeConstants() {
   // MemoryOrder for atomic operations
   Module['MemoryOrder'] = {};
   [ 'Unordered',
-    'SeqCst',
+    'Relaxed',
     'AcqRel'
+    'SeqCst',
    ].forEach(name => {
     Module['MemoryOrder'][name.toLowerCase()] = Module['_BinaryenMemoryOrder' + name]()
    });

--- a/src/parser/parsers.h
+++ b/src/parser/parsers.h
@@ -900,7 +900,7 @@ Result<typename Ctx::MemTypeT> memtypeContinued(Ctx& ctx, Type addressType) {
   return ctx.makeMemType(addressType, *limits, shared, pageSizeLog2);
 }
 
-// memorder ::= 'seqcst' | 'acqrel'
+// memorder ::= 'seqcst' | 'acqrel' | 'relaxed'
 template<typename Ctx> MaybeResult<MemoryOrder> maybeMemOrder(Ctx& ctx) {
   if (ctx.in.takeKeyword("seqcst"sv)) {
     return MemoryOrder::SeqCst;
@@ -908,11 +908,14 @@ template<typename Ctx> MaybeResult<MemoryOrder> maybeMemOrder(Ctx& ctx) {
   if (ctx.in.takeKeyword("acqrel"sv)) {
     return MemoryOrder::AcqRel;
   }
+  if (ctx.in.takeKeyword("relaxed"sv)) {
+    return MemoryOrder::Relaxed;
+  }
 
   return {};
 }
 
-// memorder ::= '' | 'seqcst' | 'acqrel'
+// memorder ::= '' | 'seqcst' | 'acqrel' | 'relaxed'
 template<typename Ctx> Result<MemoryOrder> memorder(Ctx& ctx) {
   auto order = maybeMemOrder(ctx);
   CHECK_ERR(order);

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1913,6 +1913,7 @@ struct OptimizeInstructions
     trapOnNull(curr, curr->ref);
     // Relax acquire loads of unshared fields to unordered because they cannot
     // synchronize with other threads.
+    // TODO: Relax all other memory orderings as well.
     if (curr->order == MemoryOrder::AcqRel && curr->ref->type.isRef() &&
         !curr->ref->type.getHeapType().isShared()) {
       curr->order = MemoryOrder::Unordered;
@@ -1936,6 +1937,7 @@ struct OptimizeInstructions
 
     // Relax release stores of unshared fields to unordered because they cannot
     // synchronize with other threads.
+    // TODO: Relax all other memory orderings as well.
     if (curr->order == MemoryOrder::AcqRel && curr->ref->type.isRef() &&
         !curr->ref->type.getHeapType().isShared()) {
       curr->order = MemoryOrder::Unordered;

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -158,8 +158,10 @@ public:
       case MemoryOrder::SeqCst:
         // This can never be precomputed away because it synchronizes with other
         // threads.
+        // TODO: Unify with other memory orderings below.
         return Flow(NONCONSTANT_FLOW);
       case MemoryOrder::AcqRel:
+      case MemoryOrder::Relaxed:
         // This synchronizes only with writes to the same data, so it can still
         // be precomputed if the data is not shared with other threads.
         if (curr->ref->type.getHeapType().isShared()) {
@@ -201,8 +203,10 @@ public:
       case MemoryOrder::SeqCst:
         // This can never be precomputed away because it synchronizes with other
         // threads.
+        // TODO: Unify with other memory orderings below.
         return Flow(NONCONSTANT_FLOW);
       case MemoryOrder::AcqRel:
+      case MemoryOrder::Relaxed:
         // This synchronizes only with writes to the same data, so it can still
         // be precomputed if the data is not shared with other threads.
         if (curr->ref->type.getHeapType().isShared()) {

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2329,6 +2329,9 @@ struct PrintExpressionContents
       case MemoryOrder::AcqRel:
         o << " acqrel";
         break;
+      case MemoryOrder::Relaxed:
+        o << " relaxed";
+        break;
     }
   }
 
@@ -4041,6 +4044,9 @@ std::ostream& operator<<(std::ostream& os, wasm::MemoryOrder mo) {
   switch (mo) {
     case wasm::MemoryOrder::Unordered:
       os << "Unordered";
+      break;
+    case wasm::MemoryOrder::Relaxed:
+      os << "Relaxed";
       break;
     case wasm::MemoryOrder::SeqCst:
       os << "SeqCst";

--- a/src/passes/SafeHeap.cpp
+++ b/src/passes/SafeHeap.cpp
@@ -49,12 +49,16 @@ static Name getLoadName(Load* curr) {
       parts.push_back(std::to_string(curr->align));
       break;
     }
-    case MemoryOrder::SeqCst: {
-      parts.push_back("SC");
+    case MemoryOrder::Relaxed: {
+      parts.push_back("RLX");
       break;
     }
     case MemoryOrder::AcqRel: {
       parts.push_back("AR");
+      break;
+    }
+    case MemoryOrder::SeqCst: {
+      parts.push_back("SC");
       break;
     }
   }
@@ -70,12 +74,17 @@ static Name getStoreName(Store* curr) {
       parts.push_back(std::to_string(curr->align));
       break;
     }
-    case MemoryOrder::SeqCst: {
-      parts.push_back("SC");
+    case MemoryOrder::Relaxed: {
+      parts.push_back("RLX");
       break;
     }
     case MemoryOrder::AcqRel: {
       parts.push_back("AR");
+      break;
+    }
+    case MemoryOrder::SeqCst: {
+      parts.push_back("SC");
+      break;
     }
   }
   return "SAFE_HEAP_STORE_" + String::join(parts, "_");
@@ -229,13 +238,14 @@ struct SafeHeap : public Pass {
   void addGlobals(Module* module, FeatureSet features) {
     // load funcs
     Load load;
-    std::vector<MemoryOrder> memoryOrdersToGenerate(
-      features.hasAcquireReleaseAtomics()
-        ? std::initializer_list<MemoryOrder>{MemoryOrder::Unordered,
-                                             MemoryOrder::AcqRel,
-                                             MemoryOrder::SeqCst}
-        : std::initializer_list<MemoryOrder>{MemoryOrder::Unordered,
-                                             MemoryOrder::SeqCst});
+    std::vector<MemoryOrder> memoryOrdersToGenerate{MemoryOrder::Unordered,
+                                                    MemoryOrder::SeqCst};
+    if (features.hasRelaxedAtomics()) {
+      memoryOrdersToGenerate.push_back(MemoryOrder::Relaxed);
+    }
+    if (features.hasAcquireReleaseAtomics()) {
+      memoryOrdersToGenerate.push_back(MemoryOrder::AcqRel);
+    }
     for (Type type : {Type::i32, Type::i64, Type::f32, Type::f64, Type::v128}) {
       if (type == Type::v128 && !features.hasSIMD()) {
         continue;

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1235,6 +1235,7 @@ enum ASTNodes {
 
   OrderSeqCst = 0x0,
   OrderAcqRel = 0x1,
+  OrderRelaxed = 0x2,
   StructAtomicGet = 0x5c,
   StructAtomicGetS = 0x5d,
   StructAtomicGetU = 0x5e,

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -70,8 +70,9 @@ struct Address {
 
 enum class MemoryOrder : uint8_t {
   Unordered,
-  SeqCst,
+  Relaxed,
   AcqRel,
+  SeqCst,
 };
 
 enum class IRProfile { Normal, Poppy };

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2164,6 +2164,9 @@ void WasmBinaryWriter::writeMemoryOrder(MemoryOrder order, bool isRMW) {
     case MemoryOrder::AcqRel:
       code = BinaryConsts::OrderAcqRel;
       break;
+    case MemoryOrder::Relaxed:
+      code = BinaryConsts::OrderRelaxed;
+      break;
   }
   if (isRMW) {
     o << uint8_t((code << 4) | code);
@@ -5930,6 +5933,16 @@ MemoryOrder WasmBinaryReader::getMemoryOrder(bool isRMW) {
     case ((BinaryConsts::OrderAcqRel << 4) | BinaryConsts::OrderAcqRel):
       if (isRMW) {
         return MemoryOrder::AcqRel;
+      }
+      break;
+    case BinaryConsts::OrderRelaxed:
+      if (!isRMW) {
+        return MemoryOrder::Relaxed;
+      }
+      throwError("RMW memory orders must match");
+    case ((BinaryConsts::OrderRelaxed << 4) | BinaryConsts::OrderRelaxed):
+      if (isRMW) {
+        return MemoryOrder::Relaxed;
       }
       break;
   }

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -3541,7 +3541,8 @@ void BinaryInstWriter::emitMemoryAccess(size_t alignment,
     case MemoryOrder::Unordered:
     case MemoryOrder::SeqCst:
       break;
-    case MemoryOrder::AcqRel: {
+    case MemoryOrder::AcqRel:
+    case MemoryOrder::Relaxed: {
       shouldWriteMemoryOrder = true;
       alignmentBits |= BinaryConsts::HasMemoryOrderMask;
       break;

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -1226,6 +1226,13 @@ void FunctionValidator::visitLoad(Load* curr) {
                    "[--enable-acquire-release-atomics]");
       break;
     }
+    case MemoryOrder::Relaxed: {
+      shouldBeTrue(getModule()->features.hasRelaxedAtomics(),
+                   curr,
+                   "Relaxed operations require relaxed atomics "
+                   "[--enable-relaxed-atomics]");
+      break;
+    }
     case MemoryOrder::Unordered:
     case MemoryOrder::SeqCst:
       break;
@@ -1269,6 +1276,13 @@ void FunctionValidator::visitStore(Store* curr) {
                    curr,
                    "Acquire/release operations require relaxed atomics "
                    "[--enable-acquire-release-atomics]");
+      break;
+    }
+    case MemoryOrder::Relaxed: {
+      shouldBeTrue(getModule()->features.hasRelaxedAtomics(),
+                   curr,
+                   "Relaxed operations require relaxed atomics "
+                   "[--enable-relaxed-atomics]");
       break;
     }
     case MemoryOrder::Unordered:
@@ -1316,6 +1330,13 @@ void FunctionValidator::visitAtomicRMW(AtomicRMW* curr) {
                    "[--enable-acquire-release-atomics]");
       break;
     }
+    case MemoryOrder::Relaxed: {
+      shouldBeTrue(getModule()->features.hasRelaxedAtomics(),
+                   curr,
+                   "Relaxed operations require relaxed atomics "
+                   "[--enable-relaxed-atomics]");
+      break;
+    }
     // Unordered RMW should be impossible unless there's a bug in the parser.
     case MemoryOrder::Unordered: {
       shouldBeUnequal(curr->order,
@@ -1355,6 +1376,13 @@ void FunctionValidator::visitAtomicCmpxchg(AtomicCmpxchg* curr) {
                    curr,
                    "Acquire/release operations require relaxed atomics "
                    "[--enable-acquire-release-atomics]");
+      break;
+    }
+    case MemoryOrder::Relaxed: {
+      shouldBeTrue(getModule()->features.hasRelaxedAtomics(),
+                   curr,
+                   "Relaxed operations require relaxed atomics "
+                   "[--enable-relaxed-atomics]");
       break;
     }
     // Unordered cmpxchg should be impossible unless there's a bug in the
@@ -1453,6 +1481,13 @@ void FunctionValidator::visitAtomicFence(AtomicFence* curr) {
                    curr,
                    "Acquire/release operations require relaxed atomics "
                    "[--enable-acquire-release-atomics]");
+      break;
+    }
+    case MemoryOrder::Relaxed: {
+      shouldBeTrue(getModule()->features.hasRelaxedAtomics(),
+                   curr,
+                   "Relaxed operations require relaxed atomics "
+                   "[--enable-relaxed-atomics]");
       break;
     }
     case MemoryOrder::SeqCst:

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -2318,7 +2318,7 @@ void test_callref_and_types() {
   BinaryenModuleDispose(module);
 }
 
-void test_relaxed_atomics() {
+void test_acquire_release_atomics() {
   BinaryenModuleRef module = BinaryenModuleCreate();
   BinaryenModuleSetFeatures(module, BinaryenFeatureAll());
 
@@ -2396,6 +2396,84 @@ void test_relaxed_atomics() {
   BinaryenModuleDispose(module);
 }
 
+void test_relaxed_atomics() {
+  BinaryenModuleRef module = BinaryenModuleCreate();
+  BinaryenModuleSetFeatures(module, BinaryenFeatureAll());
+
+  BinaryenSetMemory(
+    module, 1, 1, "memory", NULL, NULL, NULL, NULL, NULL, 0, false, false, "0");
+
+  BinaryenExpressionRef load = BinaryenLoad(
+    module, 4, 0, 0, 0, BinaryenTypeInt32(), makeInt32(module, 0), "0");
+  BinaryenLoadSetMemoryOrder(load, BinaryenMemoryOrderRelaxed());
+  printf("Load memory order: %d\n", BinaryenLoadGetMemoryOrder(load));
+
+  BinaryenExpressionRef store = BinaryenStore(module,
+                                              4,
+                                              0,
+                                              0,
+                                              makeInt32(module, 0),
+                                              makeInt32(module, 1),
+                                              BinaryenTypeInt32(),
+                                              "0");
+  BinaryenStoreSetMemoryOrder(store, BinaryenMemoryOrderRelaxed());
+  printf("Store memory order: %d\n", BinaryenStoreGetMemoryOrder(store));
+
+  BinaryenExpressionRef rmw = BinaryenAtomicRMW(module,
+                                                BinaryenAtomicRMWAdd(),
+                                                4,
+                                                0,
+                                                makeInt32(module, 0),
+                                                makeInt32(module, 1),
+                                                BinaryenTypeInt32(),
+                                                "0",
+                                                BinaryenMemoryOrderSeqCst());
+  BinaryenAtomicRMWSetMemoryOrder(rmw, BinaryenMemoryOrderRelaxed());
+  printf("RMW memory order: %d\n", BinaryenAtomicRMWGetMemoryOrder(rmw));
+
+  BinaryenExpressionRef cmpxchg =
+    BinaryenAtomicCmpxchg(module,
+                          4,
+                          0,
+                          makeInt32(module, 0),
+                          makeInt32(module, 0),
+                          makeInt32(module, 1),
+                          BinaryenTypeInt32(),
+                          "0",
+                          BinaryenMemoryOrderSeqCst());
+  BinaryenAtomicCmpxchgSetMemoryOrder(cmpxchg, BinaryenMemoryOrderRelaxed());
+  printf("Cmpxchg memory order: %d\n",
+         BinaryenAtomicCmpxchgGetMemoryOrder(cmpxchg));
+
+  BinaryenExpressionRef fence =
+    BinaryenAtomicFence(module, BinaryenMemoryOrderSeqCst());
+  BinaryenAtomicFenceSetOrder(fence, BinaryenMemoryOrderRelaxed());
+  printf("Fence memory order: %d\n", BinaryenAtomicFenceGetOrder(fence));
+
+  BinaryenExpressionRef statements[] = {BinaryenDrop(module, load),
+                                        store,
+                                        BinaryenDrop(module, rmw),
+                                        BinaryenDrop(module, cmpxchg),
+                                        fence};
+
+  BinaryenExpressionRef value =
+    BinaryenBlock(module,
+                  "body",
+                  statements,
+                  sizeof(statements) / sizeof(BinaryenExpressionRef),
+                  BinaryenTypeAuto());
+
+  BinaryenFunctionRef tiny = BinaryenAddFunction(module,
+                                                 "relaxed-atomics",
+                                                 BinaryenTypeNone(),
+                                                 BinaryenTypeNone(),
+                                                 NULL,
+                                                 0,
+                                                 value);
+  BinaryenModulePrint(module);
+  BinaryenModuleDispose(module);
+}
+
 void test_wide_arithmetic() {
   BinaryenModuleRef module = BinaryenModuleCreate();
   BinaryenModuleSetFeatures(module, BinaryenFeatureWideArithmetic());
@@ -2451,6 +2529,7 @@ int main() {
   test_func_opt();
   test_typebuilder();
   test_callref_and_types();
+  test_acquire_release_atomics();
   test_relaxed_atomics();
   test_wide_arithmetic();
 

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -3135,6 +3135,43 @@ Fence memory order: 2
   )
  )
 )
+Load memory order: 1
+Store memory order: 1
+RMW memory order: 1
+Cmpxchg memory order: 1
+Fence memory order: 1
+(module
+ (type $0 (func))
+ (memory $0 1 1)
+ (export "memory" (memory $0))
+ (func $relaxed-atomics (type $0)
+  (block $body
+   (drop
+    (i32.atomic.load relaxed
+     (i32.const 0)
+    )
+   )
+   (i32.atomic.store relaxed
+    (i32.const 0)
+    (i32.const 1)
+   )
+   (drop
+    (i32.atomic.rmw.add relaxed
+     (i32.const 0)
+     (i32.const 1)
+    )
+   )
+   (drop
+    (i32.atomic.rmw.cmpxchg relaxed
+     (i32.const 0)
+     (i32.const 0)
+     (i32.const 1)
+    )
+   )
+   (atomic.fence relaxed)
+  )
+ )
+)
 (module
  (type $0 (func))
  (func $wide-arithmetic-test

--- a/test/lit/basic/relaxed-atomics.wast
+++ b/test/lit/basic/relaxed-atomics.wast
@@ -61,4 +61,26 @@
     (i32.const 1)
    ))
  )
+
+ ;; RTRIP:      (func $relaxed (type $0)
+ ;; RTRIP-NEXT:  (atomic.fence relaxed)
+ ;; RTRIP-NEXT:  (i32.atomic.store relaxed
+ ;; RTRIP-NEXT:   (i32.const 1)
+ ;; RTRIP-NEXT:   (i32.const 1)
+ ;; RTRIP-NEXT:  )
+ ;; RTRIP-NEXT:  (drop
+ ;; RTRIP-NEXT:   (i32.atomic.load relaxed
+ ;; RTRIP-NEXT:    (i32.const 1)
+ ;; RTRIP-NEXT:   )
+ ;; RTRIP-NEXT:  )
+ ;; RTRIP-NEXT: )
+ (func $relaxed
+   (atomic.fence relaxed)
+   (i32.atomic.store relaxed (i32.const 1) (i32.const 1))
+   (drop
+    (i32.atomic.load relaxed
+     (i32.const 1)
+    )
+   )
+ )
 )

--- a/test/lit/passes/safe-heap_enable-threads_enable-simd64_enable-relaxed-atomics.wast
+++ b/test/lit/passes/safe-heap_enable-threads_enable-simd64_enable-relaxed-atomics.wast
@@ -282,52 +282,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_AR (param $0 i64) (param $1 i64) (result i32)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.shr_s
-;; CHECK-NEXT:   (i32.shl
-;; CHECK-NEXT:    (i32.atomic.load8_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 24)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i32.const 24)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_SC (param $0 i64) (param $1 i64) (result i32)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -366,6 +320,52 @@
 ;; CHECK-NEXT:  (i32.shr_s
 ;; CHECK-NEXT:   (i32.shl
 ;; CHECK-NEXT:    (i32.atomic.load8_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 24)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i32.const 24)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_AR (param $0 i64) (param $1 i64) (result i32)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.shr_s
+;; CHECK-NEXT:   (i32.shl
+;; CHECK-NEXT:    (i32.atomic.load8_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i32.const 24)
@@ -414,46 +414,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_AR (param $0 i64) (param $1 i64) (result i32)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load8_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_SC (param $0 i64) (param $1 i64) (result i32)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -490,6 +450,46 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.load8_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_AR (param $0 i64) (param $1 i64) (result i32)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load8_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -585,63 +585,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_AR (param $0 i64) (param $1 i64) (result i32)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.shr_s
-;; CHECK-NEXT:   (i32.shl
-;; CHECK-NEXT:    (i32.atomic.load16_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 16)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i32.const 16)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_SC (param $0 i64) (param $1 i64) (result i32)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -691,6 +634,63 @@
 ;; CHECK-NEXT:  (i32.shr_s
 ;; CHECK-NEXT:   (i32.shl
 ;; CHECK-NEXT:    (i32.atomic.load16_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 16)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i32.const 16)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_AR (param $0 i64) (param $1 i64) (result i32)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.shr_s
+;; CHECK-NEXT:   (i32.shl
+;; CHECK-NEXT:    (i32.atomic.load16_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i32.const 16)
@@ -790,57 +790,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_AR (param $0 i64) (param $1 i64) (result i32)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load16_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_SC (param $0 i64) (param $1 i64) (result i32)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -888,6 +837,57 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.load16_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_AR (param $0 i64) (param $1 i64) (result i32)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load16_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -1034,57 +1034,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_AR (param $0 i64) (param $1 i64) (result i32)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_SC (param $0 i64) (param $1 i64) (result i32)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -1136,6 +1085,57 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_AR (param $0 i64) (param $1 i64) (result i32)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load acqrel
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_1 (param $0 i64) (param $1 i64) (result i64)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -1173,52 +1173,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.load8_s
 ;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_AR (param $0 i64) (param $1 i64) (result i64)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load8_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 56)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 56)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
@@ -1268,6 +1222,52 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_AR (param $0 i64) (param $1 i64) (result i64)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load8_u acqrel
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 56)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 56)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_1 (param $0 i64) (param $1 i64) (result i64)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -1308,46 +1308,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_AR (param $0 i64) (param $1 i64) (result i64)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load8_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_SC (param $0 i64) (param $1 i64) (result i64)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -1384,6 +1344,46 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load8_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_AR (param $0 i64) (param $1 i64) (result i64)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load8_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -1479,63 +1479,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_AR (param $0 i64) (param $1 i64) (result i64)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load16_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 48)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 48)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_SC (param $0 i64) (param $1 i64) (result i64)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -1585,6 +1528,63 @@
 ;; CHECK-NEXT:  (i64.shr_s
 ;; CHECK-NEXT:   (i64.shl
 ;; CHECK-NEXT:    (i64.atomic.load16_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 48)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 48)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_AR (param $0 i64) (param $1 i64) (result i64)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load16_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i64.const 48)
@@ -1684,57 +1684,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_AR (param $0 i64) (param $1 i64) (result i64)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load16_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_SC (param $0 i64) (param $1 i64) (result i64)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -1782,6 +1731,57 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load16_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_AR (param $0 i64) (param $1 i64) (result i64)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load16_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -1928,63 +1928,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_AR (param $0 i64) (param $1 i64) (result i64)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load32_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 32)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 32)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_SC (param $0 i64) (param $1 i64) (result i64)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -2034,6 +1977,63 @@
 ;; CHECK-NEXT:  (i64.shr_s
 ;; CHECK-NEXT:   (i64.shl
 ;; CHECK-NEXT:    (i64.atomic.load32_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 32)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 32)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_AR (param $0 i64) (param $1 i64) (result i64)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load32_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i64.const 32)
@@ -2184,57 +2184,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_AR (param $0 i64) (param $1 i64) (result i64)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load32_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_SC (param $0 i64) (param $1 i64) (result i64)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -2282,6 +2231,57 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load32_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_AR (param $0 i64) (param $1 i64) (result i64)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load32_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -2479,57 +2479,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_AR (param $0 i64) (param $1 i64) (result i64)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_SC (param $0 i64) (param $1 i64) (result i64)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -2577,6 +2526,57 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_AR (param $0 i64) (param $1 i64) (result i64)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -3201,47 +3201,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_AR (param $0 i64) (param $1 i64) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store8 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_SC (param $0 i64) (param $1 i64) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -3278,6 +3237,47 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_AR (param $0 i64) (param $1 i64) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3376,58 +3376,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_AR (param $0 i64) (param $1 i64) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store16 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_SC (param $0 i64) (param $1 i64) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -3475,6 +3423,58 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_AR (param $0 i64) (param $1 i64) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3625,58 +3625,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_AR (param $0 i64) (param $1 i64) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_SC (param $0 i64) (param $1 i64) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -3729,6 +3677,58 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_AR (param $0 i64) (param $1 i64) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_1 (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -3770,47 +3770,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_AR (param $0 i64) (param $1 i64) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store8 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_SC (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -3847,6 +3806,47 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_AR (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3945,58 +3945,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_AR (param $0 i64) (param $1 i64) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store16 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_SC (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -4044,6 +3992,58 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_AR (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -4194,58 +4194,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_AR (param $0 i64) (param $1 i64) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store32 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_SC (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -4293,6 +4241,58 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store32
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_AR (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -4495,58 +4495,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_AR (param $0 i64) (param $1 i64) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_SC (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -4594,6 +4542,58 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_AR (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -5276,52 +5276,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_AR (param $0 i64) (param $1 i64) (result i32)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.shr_s
-;; CHECK-NEXT:   (i32.shl
-;; CHECK-NEXT:    (i32.atomic.load8_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 24)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i32.const 24)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_SC (param $0 i64) (param $1 i64) (result i32)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -5360,6 +5314,52 @@
 ;; CHECK-NEXT:  (i32.shr_s
 ;; CHECK-NEXT:   (i32.shl
 ;; CHECK-NEXT:    (i32.atomic.load8_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 24)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i32.const 24)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_AR (param $0 i64) (param $1 i64) (result i32)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.shr_s
+;; CHECK-NEXT:   (i32.shl
+;; CHECK-NEXT:    (i32.atomic.load8_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i32.const 24)
@@ -5408,46 +5408,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_AR (param $0 i64) (param $1 i64) (result i32)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load8_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_SC (param $0 i64) (param $1 i64) (result i32)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -5484,6 +5444,46 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.load8_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_AR (param $0 i64) (param $1 i64) (result i32)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load8_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -5579,63 +5579,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_AR (param $0 i64) (param $1 i64) (result i32)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.shr_s
-;; CHECK-NEXT:   (i32.shl
-;; CHECK-NEXT:    (i32.atomic.load16_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 16)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i32.const 16)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_SC (param $0 i64) (param $1 i64) (result i32)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -5685,6 +5628,63 @@
 ;; CHECK-NEXT:  (i32.shr_s
 ;; CHECK-NEXT:   (i32.shl
 ;; CHECK-NEXT:    (i32.atomic.load16_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 16)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i32.const 16)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_AR (param $0 i64) (param $1 i64) (result i32)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.shr_s
+;; CHECK-NEXT:   (i32.shl
+;; CHECK-NEXT:    (i32.atomic.load16_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i32.const 16)
@@ -5784,57 +5784,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_AR (param $0 i64) (param $1 i64) (result i32)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load16_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_SC (param $0 i64) (param $1 i64) (result i32)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -5882,6 +5831,57 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.load16_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_AR (param $0 i64) (param $1 i64) (result i32)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load16_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -6028,57 +6028,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_AR (param $0 i64) (param $1 i64) (result i32)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_SC (param $0 i64) (param $1 i64) (result i32)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -6130,6 +6079,57 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_AR (param $0 i64) (param $1 i64) (result i32)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load acqrel
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_1 (param $0 i64) (param $1 i64) (result i64)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -6167,52 +6167,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.load8_s
 ;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_AR (param $0 i64) (param $1 i64) (result i64)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load8_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 56)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 56)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
@@ -6262,6 +6216,52 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_AR (param $0 i64) (param $1 i64) (result i64)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load8_u acqrel
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 56)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 56)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_1 (param $0 i64) (param $1 i64) (result i64)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -6302,46 +6302,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_AR (param $0 i64) (param $1 i64) (result i64)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load8_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_SC (param $0 i64) (param $1 i64) (result i64)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -6378,6 +6338,46 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load8_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_AR (param $0 i64) (param $1 i64) (result i64)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load8_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -6473,63 +6473,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_AR (param $0 i64) (param $1 i64) (result i64)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load16_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 48)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 48)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_SC (param $0 i64) (param $1 i64) (result i64)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -6579,6 +6522,63 @@
 ;; CHECK-NEXT:  (i64.shr_s
 ;; CHECK-NEXT:   (i64.shl
 ;; CHECK-NEXT:    (i64.atomic.load16_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 48)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 48)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_AR (param $0 i64) (param $1 i64) (result i64)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load16_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i64.const 48)
@@ -6678,57 +6678,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_AR (param $0 i64) (param $1 i64) (result i64)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load16_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_SC (param $0 i64) (param $1 i64) (result i64)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -6776,6 +6725,57 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load16_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_AR (param $0 i64) (param $1 i64) (result i64)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load16_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -6922,63 +6922,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_AR (param $0 i64) (param $1 i64) (result i64)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load32_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 32)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 32)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_SC (param $0 i64) (param $1 i64) (result i64)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -7028,6 +6971,63 @@
 ;; CHECK-NEXT:  (i64.shr_s
 ;; CHECK-NEXT:   (i64.shl
 ;; CHECK-NEXT:    (i64.atomic.load32_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 32)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 32)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_AR (param $0 i64) (param $1 i64) (result i64)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load32_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i64.const 32)
@@ -7178,57 +7178,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_AR (param $0 i64) (param $1 i64) (result i64)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load32_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_SC (param $0 i64) (param $1 i64) (result i64)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -7276,6 +7225,57 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load32_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_AR (param $0 i64) (param $1 i64) (result i64)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load32_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -7473,57 +7473,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_AR (param $0 i64) (param $1 i64) (result i64)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_SC (param $0 i64) (param $1 i64) (result i64)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -7571,6 +7520,57 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_AR (param $0 i64) (param $1 i64) (result i64)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -8195,47 +8195,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_AR (param $0 i64) (param $1 i64) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store8 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_SC (param $0 i64) (param $1 i64) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -8272,6 +8231,47 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_AR (param $0 i64) (param $1 i64) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -8370,58 +8370,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_AR (param $0 i64) (param $1 i64) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store16 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_SC (param $0 i64) (param $1 i64) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -8469,6 +8417,58 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_AR (param $0 i64) (param $1 i64) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -8619,58 +8619,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_AR (param $0 i64) (param $1 i64) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_SC (param $0 i64) (param $1 i64) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -8723,6 +8671,58 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_AR (param $0 i64) (param $1 i64) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_1 (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -8764,47 +8764,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_AR (param $0 i64) (param $1 i64) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store8 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_SC (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -8841,6 +8800,47 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_AR (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -8939,58 +8939,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_AR (param $0 i64) (param $1 i64) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store16 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_SC (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -9038,6 +8986,58 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_AR (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -9188,58 +9188,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_AR (param $0 i64) (param $1 i64) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store32 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_SC (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -9287,6 +9235,58 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store32
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_AR (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -9489,58 +9489,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_AR (param $0 i64) (param $1 i64) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_SC (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -9588,6 +9536,58 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_AR (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -10274,52 +10274,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_AR (param $0 i64) (param $1 i64) (result i32)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.shr_s
-;; CHECK-NEXT:   (i32.shl
-;; CHECK-NEXT:    (i32.atomic.load8_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 24)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i32.const 24)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_SC (param $0 i64) (param $1 i64) (result i32)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -10358,6 +10312,52 @@
 ;; CHECK-NEXT:  (i32.shr_s
 ;; CHECK-NEXT:   (i32.shl
 ;; CHECK-NEXT:    (i32.atomic.load8_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 24)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i32.const 24)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_AR (param $0 i64) (param $1 i64) (result i32)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.shr_s
+;; CHECK-NEXT:   (i32.shl
+;; CHECK-NEXT:    (i32.atomic.load8_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i32.const 24)
@@ -10406,46 +10406,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_AR (param $0 i64) (param $1 i64) (result i32)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load8_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_SC (param $0 i64) (param $1 i64) (result i32)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -10482,6 +10442,46 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.load8_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_AR (param $0 i64) (param $1 i64) (result i32)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load8_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -10577,63 +10577,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_AR (param $0 i64) (param $1 i64) (result i32)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.shr_s
-;; CHECK-NEXT:   (i32.shl
-;; CHECK-NEXT:    (i32.atomic.load16_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 16)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i32.const 16)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_SC (param $0 i64) (param $1 i64) (result i32)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -10683,6 +10626,63 @@
 ;; CHECK-NEXT:  (i32.shr_s
 ;; CHECK-NEXT:   (i32.shl
 ;; CHECK-NEXT:    (i32.atomic.load16_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 16)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i32.const 16)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_AR (param $0 i64) (param $1 i64) (result i32)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.shr_s
+;; CHECK-NEXT:   (i32.shl
+;; CHECK-NEXT:    (i32.atomic.load16_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i32.const 16)
@@ -10782,57 +10782,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_AR (param $0 i64) (param $1 i64) (result i32)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load16_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_SC (param $0 i64) (param $1 i64) (result i32)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -10880,6 +10829,57 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.load16_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_AR (param $0 i64) (param $1 i64) (result i32)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load16_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -11026,57 +11026,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_AR (param $0 i64) (param $1 i64) (result i32)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_SC (param $0 i64) (param $1 i64) (result i32)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -11128,6 +11077,57 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_AR (param $0 i64) (param $1 i64) (result i32)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load acqrel
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_1 (param $0 i64) (param $1 i64) (result i64)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -11165,52 +11165,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.load8_s
 ;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_AR (param $0 i64) (param $1 i64) (result i64)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load8_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 56)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 56)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
@@ -11260,6 +11214,52 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_AR (param $0 i64) (param $1 i64) (result i64)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load8_u acqrel
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 56)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 56)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_1 (param $0 i64) (param $1 i64) (result i64)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -11300,46 +11300,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_AR (param $0 i64) (param $1 i64) (result i64)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load8_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_SC (param $0 i64) (param $1 i64) (result i64)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -11376,6 +11336,46 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load8_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_AR (param $0 i64) (param $1 i64) (result i64)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load8_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -11471,63 +11471,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_AR (param $0 i64) (param $1 i64) (result i64)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load16_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 48)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 48)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_SC (param $0 i64) (param $1 i64) (result i64)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -11577,6 +11520,63 @@
 ;; CHECK-NEXT:  (i64.shr_s
 ;; CHECK-NEXT:   (i64.shl
 ;; CHECK-NEXT:    (i64.atomic.load16_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 48)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 48)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_AR (param $0 i64) (param $1 i64) (result i64)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load16_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i64.const 48)
@@ -11676,57 +11676,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_AR (param $0 i64) (param $1 i64) (result i64)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load16_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_SC (param $0 i64) (param $1 i64) (result i64)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -11774,6 +11723,57 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load16_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_AR (param $0 i64) (param $1 i64) (result i64)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load16_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -11920,63 +11920,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_AR (param $0 i64) (param $1 i64) (result i64)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load32_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 32)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 32)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_SC (param $0 i64) (param $1 i64) (result i64)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -12026,6 +11969,63 @@
 ;; CHECK-NEXT:  (i64.shr_s
 ;; CHECK-NEXT:   (i64.shl
 ;; CHECK-NEXT:    (i64.atomic.load32_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 32)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 32)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_AR (param $0 i64) (param $1 i64) (result i64)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load32_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i64.const 32)
@@ -12176,57 +12176,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_AR (param $0 i64) (param $1 i64) (result i64)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load32_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_SC (param $0 i64) (param $1 i64) (result i64)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -12274,6 +12223,57 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load32_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_AR (param $0 i64) (param $1 i64) (result i64)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load32_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -12471,57 +12471,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_AR (param $0 i64) (param $1 i64) (result i64)
-;; CHECK-NEXT:  (local $2 i64)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i64.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_SC (param $0 i64) (param $1 i64) (result i64)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
@@ -12569,6 +12518,57 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_AR (param $0 i64) (param $1 i64) (result i64)
+;; CHECK-NEXT:  (local $2 i64)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i64.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -13193,47 +13193,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_AR (param $0 i64) (param $1 i64) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store8 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_SC (param $0 i64) (param $1 i64) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -13270,6 +13229,47 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_AR (param $0 i64) (param $1 i64) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -13368,58 +13368,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_AR (param $0 i64) (param $1 i64) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store16 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_SC (param $0 i64) (param $1 i64) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -13467,6 +13415,58 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_AR (param $0 i64) (param $1 i64) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -13617,58 +13617,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_AR (param $0 i64) (param $1 i64) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_SC (param $0 i64) (param $1 i64) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -13721,6 +13669,58 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_AR (param $0 i64) (param $1 i64) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_1 (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -13762,47 +13762,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_AR (param $0 i64) (param $1 i64) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store8 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_SC (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -13839,6 +13798,47 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_AR (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -13937,58 +13937,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_AR (param $0 i64) (param $1 i64) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store16 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_SC (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -14036,6 +13984,58 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_AR (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -14186,58 +14186,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_AR (param $0 i64) (param $1 i64) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store32 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_SC (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -14285,6 +14233,58 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store32
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_AR (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -14487,58 +14487,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_AR (param $0 i64) (param $1 i64) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_SC (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -14586,6 +14534,58 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_AR (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )

--- a/test/lit/passes/safe-heap_enable-threads_enable-simd_enable-relaxed-atomics.wast
+++ b/test/lit/passes/safe-heap_enable-threads_enable-simd_enable-relaxed-atomics.wast
@@ -282,52 +282,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.shr_s
-;; CHECK-NEXT:   (i32.shl
-;; CHECK-NEXT:    (i32.atomic.load8_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 24)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i32.const 24)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -366,6 +320,52 @@
 ;; CHECK-NEXT:  (i32.shr_s
 ;; CHECK-NEXT:   (i32.shl
 ;; CHECK-NEXT:    (i32.atomic.load8_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 24)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i32.const 24)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.shr_s
+;; CHECK-NEXT:   (i32.shl
+;; CHECK-NEXT:    (i32.atomic.load8_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i32.const 24)
@@ -414,46 +414,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load8_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -490,6 +450,46 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.load8_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load8_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -583,61 +583,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.shr_s
-;; CHECK-NEXT:   (i32.shl
-;; CHECK-NEXT:    (i32.atomic.load16_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 16)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i32.const 16)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -685,6 +630,61 @@
 ;; CHECK-NEXT:  (i32.shr_s
 ;; CHECK-NEXT:   (i32.shl
 ;; CHECK-NEXT:    (i32.atomic.load16_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 16)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i32.const 16)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.shr_s
+;; CHECK-NEXT:   (i32.shl
+;; CHECK-NEXT:    (i32.atomic.load16_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i32.const 16)
@@ -782,55 +782,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load16_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -876,6 +827,55 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.load16_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load16_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -1018,55 +1018,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -1116,6 +1067,55 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load acqrel
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_1 (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -1153,52 +1153,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.load8_s
 ;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load8_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 56)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 56)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
@@ -1248,6 +1202,52 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load8_u acqrel
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 56)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 56)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_1 (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -1288,46 +1288,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load8_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -1364,6 +1324,46 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load8_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load8_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -1457,61 +1457,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load16_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 48)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 48)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -1559,6 +1504,61 @@
 ;; CHECK-NEXT:  (i64.shr_s
 ;; CHECK-NEXT:   (i64.shl
 ;; CHECK-NEXT:    (i64.atomic.load16_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 48)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 48)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load16_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i64.const 48)
@@ -1656,55 +1656,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load16_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -1750,6 +1701,55 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load16_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load16_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -1892,61 +1892,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load32_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 32)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 32)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -1994,6 +1939,61 @@
 ;; CHECK-NEXT:  (i64.shr_s
 ;; CHECK-NEXT:   (i64.shl
 ;; CHECK-NEXT:    (i64.atomic.load32_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 32)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 32)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load32_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i64.const 32)
@@ -2140,55 +2140,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load32_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -2234,6 +2185,55 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load32_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load32_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -2425,55 +2425,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -2519,6 +2470,55 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -3125,47 +3125,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_AR (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store8 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_SC (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3202,6 +3161,47 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3298,56 +3298,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_AR (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store16 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_SC (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3393,6 +3343,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3539,56 +3539,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_AR (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_SC (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3639,6 +3589,56 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_1 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3680,47 +3680,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_AR (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store8 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_SC (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3757,6 +3716,47 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3853,56 +3853,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_AR (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store16 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_SC (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3948,6 +3898,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -4094,56 +4094,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_AR (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store32 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_SC (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -4189,6 +4139,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store32
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -4385,56 +4385,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_AR (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_SC (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -4480,6 +4430,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -5144,52 +5144,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.shr_s
-;; CHECK-NEXT:   (i32.shl
-;; CHECK-NEXT:    (i32.atomic.load8_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 24)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i32.const 24)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -5228,6 +5182,52 @@
 ;; CHECK-NEXT:  (i32.shr_s
 ;; CHECK-NEXT:   (i32.shl
 ;; CHECK-NEXT:    (i32.atomic.load8_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 24)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i32.const 24)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.shr_s
+;; CHECK-NEXT:   (i32.shl
+;; CHECK-NEXT:    (i32.atomic.load8_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i32.const 24)
@@ -5276,46 +5276,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load8_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -5352,6 +5312,46 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.load8_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load8_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -5445,61 +5445,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.shr_s
-;; CHECK-NEXT:   (i32.shl
-;; CHECK-NEXT:    (i32.atomic.load16_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 16)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i32.const 16)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -5547,6 +5492,61 @@
 ;; CHECK-NEXT:  (i32.shr_s
 ;; CHECK-NEXT:   (i32.shl
 ;; CHECK-NEXT:    (i32.atomic.load16_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 16)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i32.const 16)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.shr_s
+;; CHECK-NEXT:   (i32.shl
+;; CHECK-NEXT:    (i32.atomic.load16_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i32.const 16)
@@ -5644,55 +5644,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load16_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -5738,6 +5689,55 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.load16_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load16_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -5880,55 +5880,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -5978,6 +5929,55 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load acqrel
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_1 (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -6015,52 +6015,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.load8_s
 ;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load8_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 56)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 56)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
@@ -6110,6 +6064,52 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load8_u acqrel
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 56)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 56)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_1 (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -6150,46 +6150,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load8_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -6226,6 +6186,46 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load8_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load8_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -6319,61 +6319,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load16_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 48)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 48)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -6421,6 +6366,61 @@
 ;; CHECK-NEXT:  (i64.shr_s
 ;; CHECK-NEXT:   (i64.shl
 ;; CHECK-NEXT:    (i64.atomic.load16_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 48)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 48)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load16_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i64.const 48)
@@ -6518,55 +6518,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load16_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -6612,6 +6563,55 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load16_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load16_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -6754,61 +6754,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load32_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 32)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 32)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -6856,6 +6801,61 @@
 ;; CHECK-NEXT:  (i64.shr_s
 ;; CHECK-NEXT:   (i64.shl
 ;; CHECK-NEXT:    (i64.atomic.load32_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 32)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 32)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load32_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i64.const 32)
@@ -7002,55 +7002,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load32_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -7096,6 +7047,55 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load32_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load32_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -7287,55 +7287,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -7381,6 +7332,55 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -7987,47 +7987,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_AR (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store8 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_SC (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -8064,6 +8023,47 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -8160,56 +8160,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_AR (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store16 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_SC (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -8255,6 +8205,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -8401,56 +8401,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_AR (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_SC (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -8501,6 +8451,56 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_1 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -8542,47 +8542,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_AR (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store8 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_SC (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -8619,6 +8578,47 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -8715,56 +8715,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_AR (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store16 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_SC (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -8810,6 +8760,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -8956,56 +8956,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_AR (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store32 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_SC (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -9051,6 +9001,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store32
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -9247,56 +9247,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_AR (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_SC (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -9342,6 +9292,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -10010,52 +10010,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.shr_s
-;; CHECK-NEXT:   (i32.shl
-;; CHECK-NEXT:    (i32.atomic.load8_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 24)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i32.const 24)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -10094,6 +10048,52 @@
 ;; CHECK-NEXT:  (i32.shr_s
 ;; CHECK-NEXT:   (i32.shl
 ;; CHECK-NEXT:    (i32.atomic.load8_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 24)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i32.const 24)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.shr_s
+;; CHECK-NEXT:   (i32.shl
+;; CHECK-NEXT:    (i32.atomic.load8_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i32.const 24)
@@ -10142,46 +10142,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load8_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -10218,6 +10178,46 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.load8_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load8_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -10311,61 +10311,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.shr_s
-;; CHECK-NEXT:   (i32.shl
-;; CHECK-NEXT:    (i32.atomic.load16_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 16)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i32.const 16)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -10413,6 +10358,61 @@
 ;; CHECK-NEXT:  (i32.shr_s
 ;; CHECK-NEXT:   (i32.shl
 ;; CHECK-NEXT:    (i32.atomic.load16_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 16)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i32.const 16)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.shr_s
+;; CHECK-NEXT:   (i32.shl
+;; CHECK-NEXT:    (i32.atomic.load16_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i32.const 16)
@@ -10510,55 +10510,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load16_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -10604,6 +10555,55 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.load16_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load16_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -10746,55 +10746,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -10844,6 +10795,55 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load acqrel
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_1 (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -10881,52 +10881,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.load8_s
 ;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load8_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 56)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 56)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
@@ -10976,6 +10930,52 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load8_u acqrel
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 56)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 56)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_1 (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -11016,46 +11016,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load8_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -11092,6 +11052,46 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load8_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load8_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -11185,61 +11185,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load16_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 48)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 48)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -11287,6 +11232,61 @@
 ;; CHECK-NEXT:  (i64.shr_s
 ;; CHECK-NEXT:   (i64.shl
 ;; CHECK-NEXT:    (i64.atomic.load16_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 48)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 48)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load16_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i64.const 48)
@@ -11384,55 +11384,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load16_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -11478,6 +11429,55 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load16_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load16_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -11620,61 +11620,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load32_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 32)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 32)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -11722,6 +11667,61 @@
 ;; CHECK-NEXT:  (i64.shr_s
 ;; CHECK-NEXT:   (i64.shl
 ;; CHECK-NEXT:    (i64.atomic.load32_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 32)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 32)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load32_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i64.const 32)
@@ -11868,55 +11868,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load32_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -11962,6 +11913,55 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load32_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load32_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -12153,55 +12153,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -12247,6 +12198,55 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -12853,47 +12853,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_AR (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store8 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_SC (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -12930,6 +12889,47 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -13026,56 +13026,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_AR (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store16 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_SC (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -13121,6 +13071,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -13267,56 +13267,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_AR (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_SC (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -13367,6 +13317,56 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_1 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -13408,47 +13408,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_AR (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store8 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_SC (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -13485,6 +13444,47 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -13581,56 +13581,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_AR (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store16 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_SC (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -13676,6 +13626,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -13822,56 +13822,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_AR (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store32 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_SC (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -13917,6 +13867,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store32
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -14113,56 +14113,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_AR (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_SC (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -14208,6 +14158,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )

--- a/test/lit/passes/safe-heap_low-memory-unused_enable-threads_enable-simd_enable-relaxed-atomics.wast
+++ b/test/lit/passes/safe-heap_low-memory-unused_enable-threads_enable-simd_enable-relaxed-atomics.wast
@@ -282,52 +282,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.shr_s
-;; CHECK-NEXT:   (i32.shl
-;; CHECK-NEXT:    (i32.atomic.load8_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 24)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i32.const 24)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -366,6 +320,52 @@
 ;; CHECK-NEXT:  (i32.shr_s
 ;; CHECK-NEXT:   (i32.shl
 ;; CHECK-NEXT:    (i32.atomic.load8_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 24)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i32.const 24)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.shr_s
+;; CHECK-NEXT:   (i32.shl
+;; CHECK-NEXT:    (i32.atomic.load8_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i32.const 24)
@@ -414,46 +414,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load8_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -490,6 +450,46 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.load8_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load8_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -583,61 +583,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.shr_s
-;; CHECK-NEXT:   (i32.shl
-;; CHECK-NEXT:    (i32.atomic.load16_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 16)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i32.const 16)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -685,6 +630,61 @@
 ;; CHECK-NEXT:  (i32.shr_s
 ;; CHECK-NEXT:   (i32.shl
 ;; CHECK-NEXT:    (i32.atomic.load16_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 16)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i32.const 16)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.shr_s
+;; CHECK-NEXT:   (i32.shl
+;; CHECK-NEXT:    (i32.atomic.load16_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i32.const 16)
@@ -782,55 +782,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load16_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -876,6 +827,55 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.load16_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load16_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -1018,55 +1018,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -1116,6 +1067,55 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load acqrel
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_1 (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -1153,52 +1153,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.load8_s
 ;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load8_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 56)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 56)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
@@ -1248,6 +1202,52 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load8_u acqrel
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 56)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 56)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_1 (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -1288,46 +1288,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load8_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -1364,6 +1324,46 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load8_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load8_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -1457,61 +1457,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load16_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 48)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 48)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -1559,6 +1504,61 @@
 ;; CHECK-NEXT:  (i64.shr_s
 ;; CHECK-NEXT:   (i64.shl
 ;; CHECK-NEXT:    (i64.atomic.load16_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 48)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 48)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load16_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i64.const 48)
@@ -1656,55 +1656,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load16_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -1750,6 +1701,55 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load16_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load16_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -1892,61 +1892,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load32_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 32)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 32)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -1994,6 +1939,61 @@
 ;; CHECK-NEXT:  (i64.shr_s
 ;; CHECK-NEXT:   (i64.shl
 ;; CHECK-NEXT:    (i64.atomic.load32_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 32)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 32)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load32_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i64.const 32)
@@ -2140,55 +2140,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load32_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -2234,6 +2185,55 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load32_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load32_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -2425,55 +2425,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -2519,6 +2470,55 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -3125,47 +3125,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_AR (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store8 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_SC (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3202,6 +3161,47 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3298,56 +3298,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_AR (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store16 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_SC (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3393,6 +3343,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3539,56 +3539,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_AR (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_SC (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3639,6 +3589,56 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_1 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3680,47 +3680,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_AR (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store8 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_SC (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3757,6 +3716,47 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3853,56 +3853,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_AR (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store16 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_SC (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3948,6 +3898,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -4094,56 +4094,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_AR (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store32 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_SC (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -4189,6 +4139,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store32
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -4385,56 +4385,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_AR (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_SC (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -4480,6 +4430,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -5144,52 +5144,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.shr_s
-;; CHECK-NEXT:   (i32.shl
-;; CHECK-NEXT:    (i32.atomic.load8_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 24)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i32.const 24)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -5228,6 +5182,52 @@
 ;; CHECK-NEXT:  (i32.shr_s
 ;; CHECK-NEXT:   (i32.shl
 ;; CHECK-NEXT:    (i32.atomic.load8_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 24)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i32.const 24)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.shr_s
+;; CHECK-NEXT:   (i32.shl
+;; CHECK-NEXT:    (i32.atomic.load8_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i32.const 24)
@@ -5276,46 +5276,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load8_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -5352,6 +5312,46 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.load8_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load8_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -5445,61 +5445,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.shr_s
-;; CHECK-NEXT:   (i32.shl
-;; CHECK-NEXT:    (i32.atomic.load16_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 16)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i32.const 16)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -5547,6 +5492,61 @@
 ;; CHECK-NEXT:  (i32.shr_s
 ;; CHECK-NEXT:   (i32.shl
 ;; CHECK-NEXT:    (i32.atomic.load16_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 16)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i32.const 16)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.shr_s
+;; CHECK-NEXT:   (i32.shl
+;; CHECK-NEXT:    (i32.atomic.load16_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i32.const 16)
@@ -5644,55 +5644,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load16_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -5738,6 +5689,55 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.load16_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load16_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -5880,55 +5880,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -5978,6 +5929,55 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load acqrel
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_1 (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -6015,52 +6015,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.load8_s
 ;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load8_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 56)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 56)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
@@ -6110,6 +6064,52 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load8_u acqrel
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 56)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 56)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_1 (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -6150,46 +6150,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load8_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -6226,6 +6186,46 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load8_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load8_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -6319,61 +6319,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load16_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 48)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 48)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -6421,6 +6366,61 @@
 ;; CHECK-NEXT:  (i64.shr_s
 ;; CHECK-NEXT:   (i64.shl
 ;; CHECK-NEXT:    (i64.atomic.load16_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 48)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 48)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load16_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i64.const 48)
@@ -6518,55 +6518,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load16_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -6612,6 +6563,55 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load16_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load16_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -6754,61 +6754,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load32_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 32)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 32)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -6856,6 +6801,61 @@
 ;; CHECK-NEXT:  (i64.shr_s
 ;; CHECK-NEXT:   (i64.shl
 ;; CHECK-NEXT:    (i64.atomic.load32_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 32)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 32)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load32_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i64.const 32)
@@ -7002,55 +7002,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load32_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -7096,6 +7047,55 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load32_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load32_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -7287,55 +7287,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -7381,6 +7332,55 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -7987,47 +7987,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_AR (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store8 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_SC (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -8064,6 +8023,47 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -8160,56 +8160,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_AR (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store16 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_SC (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -8255,6 +8205,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -8401,56 +8401,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_AR (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_SC (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -8501,6 +8451,56 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_1 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -8542,47 +8542,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_AR (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store8 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_SC (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -8619,6 +8578,47 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -8715,56 +8715,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_AR (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store16 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_SC (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -8810,6 +8760,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -8956,56 +8956,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_AR (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store32 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_SC (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -9051,6 +9001,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store32
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -9247,56 +9247,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_AR (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_SC (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -9342,6 +9292,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -10010,52 +10010,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.shr_s
-;; CHECK-NEXT:   (i32.shl
-;; CHECK-NEXT:    (i32.atomic.load8_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 24)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i32.const 24)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -10094,6 +10048,52 @@
 ;; CHECK-NEXT:  (i32.shr_s
 ;; CHECK-NEXT:   (i32.shl
 ;; CHECK-NEXT:    (i32.atomic.load8_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 24)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i32.const 24)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.shr_s
+;; CHECK-NEXT:   (i32.shl
+;; CHECK-NEXT:    (i32.atomic.load8_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i32.const 24)
@@ -10142,46 +10142,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load8_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -10218,6 +10178,46 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.load8_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_1_U_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load8_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -10311,61 +10311,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.shr_s
-;; CHECK-NEXT:   (i32.shl
-;; CHECK-NEXT:    (i32.atomic.load16_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 16)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i32.const 16)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -10413,6 +10358,61 @@
 ;; CHECK-NEXT:  (i32.shr_s
 ;; CHECK-NEXT:   (i32.shl
 ;; CHECK-NEXT:    (i32.atomic.load16_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 16)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i32.const 16)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.shr_s
+;; CHECK-NEXT:   (i32.shl
+;; CHECK-NEXT:    (i32.atomic.load16_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i32.const 16)
@@ -10510,55 +10510,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load16_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -10604,6 +10555,55 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.load16_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_2_U_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load16_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -10746,55 +10746,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_AR (param $0 i32) (param $1 i32) (result i32)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.load acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_SC (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -10844,6 +10795,55 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_LOAD_i32_4_AR (param $0 i32) (param $1 i32) (result i32)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.load acqrel
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_1 (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -10881,52 +10881,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.load8_s
 ;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load8_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 56)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 56)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
@@ -10976,6 +10930,52 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load8_u acqrel
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 56)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 56)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_1 (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -11016,46 +11016,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load8_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -11092,6 +11052,46 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load8_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_1_U_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load8_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -11185,61 +11185,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load16_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 48)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 48)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -11287,6 +11232,61 @@
 ;; CHECK-NEXT:  (i64.shr_s
 ;; CHECK-NEXT:   (i64.shl
 ;; CHECK-NEXT:    (i64.atomic.load16_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 48)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 48)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load16_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i64.const 48)
@@ -11384,55 +11384,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load16_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -11478,6 +11429,55 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load16_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_2_U_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load16_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -11620,61 +11620,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.shr_s
-;; CHECK-NEXT:   (i64.shl
-;; CHECK-NEXT:    (i64.atomic.load32_u acqrel
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i64.const 32)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (i64.const 32)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -11722,6 +11667,61 @@
 ;; CHECK-NEXT:  (i64.shr_s
 ;; CHECK-NEXT:   (i64.shl
 ;; CHECK-NEXT:    (i64.atomic.load32_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i64.const 32)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (i64.const 32)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.shr_s
+;; CHECK-NEXT:   (i64.shl
+;; CHECK-NEXT:    (i64.atomic.load32_u acqrel
 ;; CHECK-NEXT:     (local.get $2)
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:    (i64.const 32)
@@ -11868,55 +11868,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load32_u acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -11962,6 +11913,55 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load32_u
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_4_U_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load32_u acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -12153,55 +12153,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_AR (param $0 i32) (param $1 i32) (result i64)
-;; CHECK-NEXT:  (local $2 i32)
-;; CHECK-NEXT:  (local.set $2
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $2)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $2)
-;; CHECK-NEXT:       (i32.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $2)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $2)
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.load acqrel
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_SC (param $0 i32) (param $1 i32) (result i64)
 ;; CHECK-NEXT:  (local $2 i32)
 ;; CHECK-NEXT:  (local.set $2
@@ -12247,6 +12198,55 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.load
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_LOAD_i64_8_AR (param $0 i32) (param $1 i32) (result i64)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $2)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $2)
+;; CHECK-NEXT:       (i32.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $2)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $2)
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.load acqrel
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -12853,47 +12853,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_AR (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store8 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_SC (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -12930,6 +12889,47 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -13026,56 +13026,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_AR (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store16 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_SC (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -13121,6 +13071,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.atomic.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -13267,56 +13267,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_AR (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_SC (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -13367,6 +13317,56 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_1 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -13408,47 +13408,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_AR (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store8 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_SC (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -13485,6 +13444,47 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -13581,56 +13581,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_AR (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store16 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_SC (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -13676,6 +13626,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -13822,56 +13822,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_AR (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store32 acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_SC (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -13917,6 +13867,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store32
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32 acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -14113,56 +14113,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_AR (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store acqrel
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_SC (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -14208,6 +14158,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.atomic.store
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store acqrel
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )

--- a/test/lit/passes/simplify-locals-atomic-effects.wast
+++ b/test/lit/passes/simplify-locals-atomic-effects.wast
@@ -898,4 +898,1198 @@
     (atomic.fence)
     (local.get $x)
   )
+
+  ;; Relaxed tests
+
+  ;; Relaxed with Unordered (Normal)
+
+  ;; CHECK:      (func $read-relaxed-read (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.atomic.get relaxed $shared-struct 0
+  ;; CHECK-NEXT:    (local.get $shared)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (array.get $shared-array
+  ;; CHECK-NEXT:   (local.get $shared-array)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $read-relaxed-read (param $shared (ref null $shared-struct))
+                           (param $shared-array (ref null $shared-array))
+                           (result i32)
+    ;; A normal read can be moved past a relaxed read.
+    (local $x i32)
+    (local.set $x
+      (array.get $shared-array
+        (local.get $shared-array)
+        (i32.const 0)
+      )
+    )
+    (drop
+      (struct.atomic.get relaxed $shared-struct 0
+        (local.get $shared)
+      )
+    )
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $relaxed-read-read (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (array.get $shared-array
+  ;; CHECK-NEXT:    (local.get $shared-array)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (struct.atomic.get relaxed $shared-struct 0
+  ;; CHECK-NEXT:   (local.get $shared)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $relaxed-read-read (param $shared (ref null $shared-struct))
+                           (param $shared-array (ref null $shared-array))
+                           (result i32)
+    ;; A relaxed read can be moved past a normal read.
+    (local $x i32)
+    (local.set $x
+      (struct.atomic.get relaxed $shared-struct 0
+        (local.get $shared)
+      )
+    )
+    (drop
+      (array.get $shared-array
+        (local.get $shared-array)
+        (i32.const 0)
+      )
+    )
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $read-relaxed-store (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (struct.atomic.set relaxed $shared-struct 0
+  ;; CHECK-NEXT:   (local.get $shared)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (array.get $shared-array
+  ;; CHECK-NEXT:   (local.get $shared-array)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $read-relaxed-store (param $shared (ref null $shared-struct))
+                            (param $shared-array (ref null $shared-array))
+                            (result i32)
+    ;; A normal read can be moved past a relaxed store.
+    (local $x i32)
+    (local.set $x
+      (array.get $shared-array
+        (local.get $shared-array)
+        (i32.const 0)
+      )
+    )
+    (struct.atomic.set relaxed $shared-struct 0
+      (local.get $shared)
+      (i32.const 0)
+    )
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $relaxed-store-read (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (array.get $shared-array
+  ;; CHECK-NEXT:    (local.get $shared-array)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (block (result i32)
+  ;; CHECK-NEXT:   (struct.atomic.set relaxed $shared-struct 0
+  ;; CHECK-NEXT:    (local.get $shared)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $relaxed-store-read (param $shared (ref null $shared-struct))
+                            (param $shared-array (ref null $shared-array))
+                            (result i32)
+    ;; A relaxed store can be moved past a non-aliasing normal read.
+    (local $x i32)
+    (local.set $x
+      (block (result i32)
+        (struct.atomic.set relaxed $shared-struct 0
+          (local.get $shared)
+          (i32.const 0)
+        )
+        (i32.const 1)
+      )
+    )
+    (drop
+      (array.get $shared-array
+        (local.get $shared-array)
+        (i32.const 0)
+      )
+    )
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $store-relaxed-read (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.atomic.get relaxed $shared-struct 0
+  ;; CHECK-NEXT:    (local.get $shared)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (block (result i32)
+  ;; CHECK-NEXT:   (array.set $shared-array
+  ;; CHECK-NEXT:    (local.get $shared-array)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $store-relaxed-read (param $shared (ref null $shared-struct))
+                            (param $shared-array (ref null $shared-array))
+                            (result i32)
+    ;; A normal store can be moved past a relaxed read.
+    (local $x i32)
+    (local.set $x
+      (block (result i32)
+        (array.set $shared-array
+          (local.get $shared-array)
+          (i32.const 0)
+          (i32.const 0)
+        )
+        (i32.const 1)
+      )
+    )
+    (drop
+      (struct.atomic.get relaxed $shared-struct 0
+        (local.get $shared)
+      )
+    )
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $relaxed-read-store (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (array.set $shared-array
+  ;; CHECK-NEXT:   (local.get $shared-array)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (struct.atomic.get relaxed $shared-struct 0
+  ;; CHECK-NEXT:   (local.get $shared)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $relaxed-read-store (param $shared (ref null $shared-struct))
+                            (param $shared-array (ref null $shared-array))
+                            (result i32)
+    ;; A relaxed read can be moved past a normal store.
+    (local $x i32)
+    (local.set $x
+      (struct.atomic.get relaxed $shared-struct 0
+        (local.get $shared)
+      )
+    )
+    (array.set $shared-array
+      (local.get $shared-array)
+      (i32.const 0)
+      (i32.const 0)
+    )
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $store-relaxed-store (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (struct.atomic.set relaxed $shared-struct 0
+  ;; CHECK-NEXT:   (local.get $shared)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (block (result i32)
+  ;; CHECK-NEXT:   (array.set $shared-array
+  ;; CHECK-NEXT:    (local.get $shared-array)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $store-relaxed-store (param $shared (ref null $shared-struct))
+                             (param $shared-array (ref null $shared-array))
+                             (result i32)
+    ;; A normal store can be moved past a non-aliasing relaxed store.
+    (local $x i32)
+    (local.set $x
+      (block (result i32)
+        (array.set $shared-array
+          (local.get $shared-array)
+          (i32.const 0)
+          (i32.const 0)
+        )
+        (i32.const 1)
+      )
+    )
+    (struct.atomic.set relaxed $shared-struct 0
+      (local.get $shared)
+      (i32.const 0)
+    )
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $relaxed-store-store (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (array.set $shared-array
+  ;; CHECK-NEXT:   (local.get $shared-array)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (block (result i32)
+  ;; CHECK-NEXT:   (struct.atomic.set relaxed $shared-struct 0
+  ;; CHECK-NEXT:    (local.get $shared)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $relaxed-store-store (param $shared (ref null $shared-struct))
+                             (param $shared-array (ref null $shared-array))
+                             (result i32)
+    ;; A relaxed store can be moved past a non-aliasing normal store.
+    (local $x i32)
+    (local.set $x
+      (block (result i32)
+        (struct.atomic.set relaxed $shared-struct 0
+          (local.get $shared)
+          (i32.const 0)
+        )
+        (i32.const 1)
+      )
+    )
+    (array.set $shared-array
+      (local.get $shared-array)
+      (i32.const 0)
+      (i32.const 0)
+    )
+    (local.get $x)
+  )
+
+  ;; Relaxed with Relaxed
+
+  ;; CHECK:      (func $relaxed-read-relaxed-read (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.atomic.get relaxed $shared-struct 0
+  ;; CHECK-NEXT:    (local.get $shared)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (array.atomic.get relaxed $shared-array
+  ;; CHECK-NEXT:   (local.get $shared-array)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $relaxed-read-relaxed-read (param $shared (ref null $shared-struct))
+                                   (param $shared-array (ref null $shared-array))
+                                   (result i32)
+    ;; A relaxed read can be moved past a relaxed read.
+    (local $x i32)
+    (local.set $x
+      (array.atomic.get relaxed $shared-array
+        (local.get $shared-array)
+        (i32.const 0)
+      )
+    )
+    (drop
+      (struct.atomic.get relaxed $shared-struct 0
+        (local.get $shared)
+      )
+    )
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $relaxed-store-relaxed-store (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (struct.atomic.set relaxed $shared-struct 0
+  ;; CHECK-NEXT:   (local.get $shared)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (block (result i32)
+  ;; CHECK-NEXT:   (array.atomic.set relaxed $shared-array
+  ;; CHECK-NEXT:    (local.get $shared-array)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $relaxed-store-relaxed-store (param $shared (ref null $shared-struct))
+                                     (param $shared-array (ref null $shared-array))
+                                     (result i32)
+    ;; A relaxed store can be moved past a non-aliasing relaxed store.
+    (local $x i32)
+    (local.set $x
+      (block (result i32)
+        (array.atomic.set relaxed $shared-array
+          (local.get $shared-array)
+          (i32.const 0)
+          (i32.const 0)
+        )
+        (i32.const 1)
+      )
+    )
+    (struct.atomic.set relaxed $shared-struct 0
+      (local.get $shared)
+      (i32.const 0)
+    )
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $relaxed-read-relaxed-store (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (array.atomic.get relaxed $shared-array
+  ;; CHECK-NEXT:    (local.get $shared-array)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (struct.atomic.set relaxed $shared-struct 0
+  ;; CHECK-NEXT:   (local.get $shared)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.get $x)
+  ;; CHECK-NEXT: )
+  (func $relaxed-read-relaxed-store (param $shared (ref null $shared-struct))
+                                    (param $shared-array (ref null $shared-array))
+                                    (result i32)
+    ;; A relaxed read cannot be moved forward past a relaxed store.
+    (local $x i32)
+    (local.set $x
+      (array.atomic.get relaxed $shared-array
+        (local.get $shared-array)
+        (i32.const 0)
+      )
+    )
+    (struct.atomic.set relaxed $shared-struct 0
+      (local.get $shared)
+      (i32.const 0)
+    )
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $relaxed-store-relaxed-read (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (array.atomic.get relaxed $shared-array
+  ;; CHECK-NEXT:    (local.get $shared-array)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (block (result i32)
+  ;; CHECK-NEXT:   (struct.atomic.set relaxed $shared-struct 0
+  ;; CHECK-NEXT:    (local.get $shared)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $relaxed-store-relaxed-read (param $shared (ref null $shared-struct))
+                                    (param $shared-array (ref null $shared-array))
+                                    (result i32)
+    ;; But a relaxed store can be moved forward past a non-aliasing relaxed read.
+    (local $x i32)
+    (local.set $x
+      (block (result i32)
+        (struct.atomic.set relaxed $shared-struct 0
+          (local.get $shared)
+          (i32.const 0)
+        )
+        (i32.const 1)
+      )
+    )
+    (drop
+      (array.atomic.get relaxed $shared-array
+        (local.get $shared-array)
+        (i32.const 0)
+      )
+    )
+    (local.get $x)
+  )
+
+  ;; Relaxed with AcqRel
+
+  ;; CHECK:      (func $relaxed-read-acquire (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.atomic.get acqrel $shared-struct 0
+  ;; CHECK-NEXT:    (local.get $shared)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (array.atomic.get relaxed $shared-array
+  ;; CHECK-NEXT:   (local.get $shared-array)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $relaxed-read-acquire (param $shared (ref null $shared-struct))
+                              (param $shared-array (ref null $shared-array))
+                              (result i32)
+    ;; A relaxed read can be moved forward past an acquire read.
+    (local $x i32)
+    (local.set $x
+      (array.atomic.get relaxed $shared-array
+        (local.get $shared-array)
+        (i32.const 0)
+      )
+    )
+    (drop
+      (struct.atomic.get acqrel $shared-struct 0
+        (local.get $shared)
+      )
+    )
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $acquire-relaxed-read (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (struct.atomic.get acqrel $shared-struct 0
+  ;; CHECK-NEXT:    (local.get $shared)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (array.atomic.get relaxed $shared-array
+  ;; CHECK-NEXT:    (local.get $shared-array)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.get $x)
+  ;; CHECK-NEXT: )
+  (func $acquire-relaxed-read (param $shared (ref null $shared-struct))
+                              (param $shared-array (ref null $shared-array))
+                              (result i32)
+    ;; But an acquire read cannot be moved forward past a relaxed read.
+    (local $x i32)
+    (local.set $x
+      (struct.atomic.get acqrel $shared-struct 0
+        (local.get $shared)
+      )
+    )
+    (drop
+      (array.atomic.get relaxed $shared-array
+        (local.get $shared-array)
+        (i32.const 0)
+      )
+    )
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $relaxed-store-acquire (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.atomic.get acqrel $shared-struct 0
+  ;; CHECK-NEXT:    (local.get $shared)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (block (result i32)
+  ;; CHECK-NEXT:   (array.atomic.set relaxed $shared-array
+  ;; CHECK-NEXT:    (local.get $shared-array)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $relaxed-store-acquire (param $shared (ref null $shared-struct))
+                               (param $shared-array (ref null $shared-array))
+                               (result i32)
+    ;; A relaxed store can be moved forward past a non-aliasing acquire read.
+    (local $x i32)
+    (local.set $x
+      (block (result i32)
+        (array.atomic.set relaxed $shared-array
+          (local.get $shared-array)
+          (i32.const 0)
+          (i32.const 0)
+        )
+        (i32.const 1)
+      )
+    )
+    (drop
+      (struct.atomic.get acqrel $shared-struct 0
+        (local.get $shared)
+      )
+    )
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $acquire-relaxed-store (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (struct.atomic.get acqrel $shared-struct 0
+  ;; CHECK-NEXT:    (local.get $shared)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (array.atomic.set relaxed $shared-array
+  ;; CHECK-NEXT:   (local.get $shared-array)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.get $x)
+  ;; CHECK-NEXT: )
+  (func $acquire-relaxed-store (param $shared (ref null $shared-struct))
+                               (param $shared-array (ref null $shared-array))
+                               (result i32)
+    ;; But an acquire read cannot be moved forward past a relaxed store.
+    (local $x i32)
+    (local.set $x
+      (struct.atomic.get acqrel $shared-struct 0
+        (local.get $shared)
+      )
+    )
+    (array.atomic.set relaxed $shared-array
+      (local.get $shared-array)
+      (i32.const 0)
+      (i32.const 0)
+    )
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $relaxed-read-release (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (array.atomic.get relaxed $shared-array
+  ;; CHECK-NEXT:    (local.get $shared-array)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (struct.atomic.set acqrel $shared-struct 0
+  ;; CHECK-NEXT:   (local.get $shared)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.get $x)
+  ;; CHECK-NEXT: )
+  (func $relaxed-read-release (param $shared (ref null $shared-struct))
+                              (param $shared-array (ref null $shared-array))
+                              (result i32)
+    ;; A relaxed read cannot be moved forward past a release store.
+    (local $x i32)
+    (local.set $x
+      (array.atomic.get relaxed $shared-array
+        (local.get $shared-array)
+        (i32.const 0)
+      )
+    )
+    (struct.atomic.set acqrel $shared-struct 0
+      (local.get $shared)
+      (i32.const 0)
+    )
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $release-relaxed-read (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (array.atomic.get relaxed $shared-array
+  ;; CHECK-NEXT:    (local.get $shared-array)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (block (result i32)
+  ;; CHECK-NEXT:   (struct.atomic.set acqrel $shared-struct 0
+  ;; CHECK-NEXT:    (local.get $shared)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $release-relaxed-read (param $shared (ref null $shared-struct))
+                              (param $shared-array (ref null $shared-array))
+                              (result i32)
+    ;; But a release store can be moved forward past a non-aliasing relaxed read.
+    (local $x i32)
+    (local.set $x
+      (block (result i32)
+        (struct.atomic.set acqrel $shared-struct 0
+          (local.get $shared)
+          (i32.const 0)
+        )
+        (i32.const 1)
+      )
+    )
+    (drop
+      (array.atomic.get relaxed $shared-array
+        (local.get $shared-array)
+        (i32.const 0)
+      )
+    )
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $relaxed-store-release (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (array.atomic.set relaxed $shared-array
+  ;; CHECK-NEXT:     (local.get $shared-array)
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (struct.atomic.set acqrel $shared-struct 0
+  ;; CHECK-NEXT:   (local.get $shared)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.get $x)
+  ;; CHECK-NEXT: )
+  (func $relaxed-store-release (param $shared (ref null $shared-struct))
+                               (param $shared-array (ref null $shared-array))
+                               (result i32)
+    ;; A relaxed store cannot be moved forward past a release store.
+    (local $x i32)
+    (local.set $x
+      (block (result i32)
+        (array.atomic.set relaxed $shared-array
+          (local.get $shared-array)
+          (i32.const 0)
+          (i32.const 0)
+        )
+        (i32.const 1)
+      )
+    )
+    (struct.atomic.set acqrel $shared-struct 0
+      (local.get $shared)
+      (i32.const 0)
+    )
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $release-relaxed-store (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (array.atomic.set relaxed $shared-array
+  ;; CHECK-NEXT:   (local.get $shared-array)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (block (result i32)
+  ;; CHECK-NEXT:   (struct.atomic.set acqrel $shared-struct 0
+  ;; CHECK-NEXT:    (local.get $shared)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $release-relaxed-store (param $shared (ref null $shared-struct))
+                               (param $shared-array (ref null $shared-array))
+                               (result i32)
+    ;; But a release store can be moved forward past a non-aliasing relaxed store.
+    (local $x i32)
+    (local.set $x
+      (block (result i32)
+        (struct.atomic.set acqrel $shared-struct 0
+          (local.get $shared)
+          (i32.const 0)
+        )
+        (i32.const 1)
+      )
+    )
+    (array.atomic.set relaxed $shared-array
+      (local.get $shared-array)
+      (i32.const 0)
+      (i32.const 0)
+    )
+    (local.get $x)
+  )
+
+  ;; Relaxed with SeqCst
+
+  ;; CHECK:      (func $relaxed-read-seqcst-read (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (array.atomic.get relaxed $shared-array
+  ;; CHECK-NEXT:    (local.get $shared-array)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.atomic.get $shared-struct 0
+  ;; CHECK-NEXT:    (local.get $shared)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.get $x)
+  ;; CHECK-NEXT: )
+  (func $relaxed-read-seqcst-read (param $shared (ref null $shared-struct))
+                                  (param $shared-array (ref null $shared-array))
+                                  (result i32)
+    ;; A relaxed read cannot be moved past a seqcst read.
+    (local $x i32)
+    (local.set $x
+      (array.atomic.get relaxed $shared-array
+        (local.get $shared-array)
+        (i32.const 0)
+      )
+    )
+    (drop
+      (struct.atomic.get seqcst $shared-struct 0
+        (local.get $shared)
+      )
+    )
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $seqcst-read-relaxed-read (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (struct.atomic.get $shared-struct 0
+  ;; CHECK-NEXT:    (local.get $shared)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (array.atomic.get relaxed $shared-array
+  ;; CHECK-NEXT:    (local.get $shared-array)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.get $x)
+  ;; CHECK-NEXT: )
+  (func $seqcst-read-relaxed-read (param $shared (ref null $shared-struct))
+                                  (param $shared-array (ref null $shared-array))
+                                  (result i32)
+    ;; A seqcst read cannot be moved past a relaxed read.
+    (local $x i32)
+    (local.set $x
+      (struct.atomic.get seqcst $shared-struct 0
+        (local.get $shared)
+      )
+    )
+    (drop
+      (array.atomic.get relaxed $shared-array
+        (local.get $shared-array)
+        (i32.const 0)
+      )
+    )
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $relaxed-store-seqcst-read (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (array.atomic.set relaxed $shared-array
+  ;; CHECK-NEXT:     (local.get $shared-array)
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.atomic.get $shared-struct 0
+  ;; CHECK-NEXT:    (local.get $shared)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.get $x)
+  ;; CHECK-NEXT: )
+  (func $relaxed-store-seqcst-read (param $shared (ref null $shared-struct))
+                                   (param $shared-array (ref null $shared-array))
+                                   (result i32)
+    ;; A relaxed store cannot be moved past a seqcst read.
+    (local $x i32)
+    (local.set $x
+      (block (result i32)
+        (array.atomic.set relaxed $shared-array
+          (local.get $shared-array)
+          (i32.const 0)
+          (i32.const 0)
+        )
+        (i32.const 1)
+      )
+    )
+    (drop
+      (struct.atomic.get seqcst $shared-struct 0
+        (local.get $shared)
+      )
+    )
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $seqcst-read-relaxed-store (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (struct.atomic.get $shared-struct 0
+  ;; CHECK-NEXT:    (local.get $shared)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (array.atomic.set relaxed $shared-array
+  ;; CHECK-NEXT:   (local.get $shared-array)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.get $x)
+  ;; CHECK-NEXT: )
+  (func $seqcst-read-relaxed-store (param $shared (ref null $shared-struct))
+                                   (param $shared-array (ref null $shared-array))
+                                   (result i32)
+    ;; A seqcst read cannot be moved past a relaxed store.
+    (local $x i32)
+    (local.set $x
+      (struct.atomic.get seqcst $shared-struct 0
+        (local.get $shared)
+      )
+    )
+    (array.atomic.set relaxed $shared-array
+      (local.get $shared-array)
+      (i32.const 0)
+      (i32.const 0)
+    )
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $relaxed-read-seqcst-store (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (array.atomic.get relaxed $shared-array
+  ;; CHECK-NEXT:    (local.get $shared-array)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (struct.atomic.set $shared-struct 0
+  ;; CHECK-NEXT:   (local.get $shared)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.get $x)
+  ;; CHECK-NEXT: )
+  (func $relaxed-read-seqcst-store (param $shared (ref null $shared-struct))
+                                   (param $shared-array (ref null $shared-array))
+                                   (result i32)
+    ;; A relaxed read cannot be moved past a seqcst store.
+    (local $x i32)
+    (local.set $x
+      (array.atomic.get relaxed $shared-array
+        (local.get $shared-array)
+        (i32.const 0)
+      )
+    )
+    (struct.atomic.set seqcst $shared-struct 0
+      (local.get $shared)
+      (i32.const 0)
+    )
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $seqcst-store-relaxed-read (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (struct.atomic.set $shared-struct 0
+  ;; CHECK-NEXT:     (local.get $shared)
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (array.atomic.get relaxed $shared-array
+  ;; CHECK-NEXT:    (local.get $shared-array)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.get $x)
+  ;; CHECK-NEXT: )
+  (func $seqcst-store-relaxed-read (param $shared (ref null $shared-struct))
+                                   (param $shared-array (ref null $shared-array))
+                                   (result i32)
+    ;; A seqcst store cannot be moved past a relaxed read.
+    (local $x i32)
+    (local.set $x
+      (block (result i32)
+        (struct.atomic.set seqcst $shared-struct 0
+          (local.get $shared)
+          (i32.const 0)
+        )
+        (i32.const 1)
+      )
+    )
+    (drop
+      (array.atomic.get relaxed $shared-array
+        (local.get $shared-array)
+        (i32.const 0)
+      )
+    )
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $relaxed-store-seqcst-store (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (array.atomic.set relaxed $shared-array
+  ;; CHECK-NEXT:     (local.get $shared-array)
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (struct.atomic.set $shared-struct 0
+  ;; CHECK-NEXT:   (local.get $shared)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.get $x)
+  ;; CHECK-NEXT: )
+  (func $relaxed-store-seqcst-store (param $shared (ref null $shared-struct))
+                                    (param $shared-array (ref null $shared-array))
+                                    (result i32)
+    ;; A relaxed store cannot be moved past a seqcst store.
+    (local $x i32)
+    (local.set $x
+      (block (result i32)
+        (array.atomic.set relaxed $shared-array
+          (local.get $shared-array)
+          (i32.const 0)
+          (i32.const 0)
+        )
+        (i32.const 1)
+      )
+    )
+    (struct.atomic.set seqcst $shared-struct 0
+      (local.get $shared)
+      (i32.const 0)
+    )
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $seqcst-store-relaxed-store (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (struct.atomic.set $shared-struct 0
+  ;; CHECK-NEXT:     (local.get $shared)
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (array.atomic.set relaxed $shared-array
+  ;; CHECK-NEXT:   (local.get $shared-array)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.get $x)
+  ;; CHECK-NEXT: )
+  (func $seqcst-store-relaxed-store (param $shared (ref null $shared-struct))
+                                    (param $shared-array (ref null $shared-array))
+                                    (result i32)
+    ;; A seqcst store cannot be moved past a relaxed store.
+    (local $x i32)
+    (local.set $x
+      (block (result i32)
+        (struct.atomic.set seqcst $shared-struct 0
+          (local.get $shared)
+          (i32.const 0)
+        )
+        (i32.const 1)
+      )
+    )
+    (array.atomic.set relaxed $shared-array
+      (local.get $shared-array)
+      (i32.const 0)
+      (i32.const 0)
+    )
+    (local.get $x)
+  )
+
+  ;; Relaxed with Fence
+
+  ;; CHECK:      (func $read-relaxed-fence (type $3) (param $shared (ref null $shared-struct)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (struct.atomic.get relaxed $shared-struct 0
+  ;; CHECK-NEXT:    (local.get $shared)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (atomic.fence)
+  ;; CHECK-NEXT:  (local.get $x)
+  ;; CHECK-NEXT: )
+  (func $read-relaxed-fence (param $shared (ref null $shared-struct)) (result i32)
+    (local $x i32)
+    ;; A relaxed struct read cannot be moved past an atomic.fence.
+    (local.set $x
+      (struct.atomic.get relaxed $shared-struct 0 (local.get $shared))
+    )
+    (atomic.fence)
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $write-relaxed-fence (type $3) (param $shared (ref null $shared-struct)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (struct.atomic.set relaxed $shared-struct 0
+  ;; CHECK-NEXT:     (local.get $shared)
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (atomic.fence)
+  ;; CHECK-NEXT:  (local.get $x)
+  ;; CHECK-NEXT: )
+  (func $write-relaxed-fence (param $shared (ref null $shared-struct)) (result i32)
+    (local $x i32)
+    ;; A relaxed struct write cannot be moved past an atomic.fence.
+    (local.set $x
+      (block (result i32)
+        (struct.atomic.set relaxed $shared-struct 0
+          (local.get $shared)
+          (i32.const 0)
+        )
+        (i32.const 1)
+      )
+    )
+    (atomic.fence)
+    (local.get $x)
+  )
+
+  ;; Branch-on tests for backward reordering across branches
+
+  ;; CHECK:      (func $br-on-relaxed-store-relaxed-read (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (block $l
+  ;; CHECK-NEXT:   (br_if $l
+  ;; CHECK-NEXT:    (block (result i32)
+  ;; CHECK-NEXT:     (drop
+  ;; CHECK-NEXT:      (array.atomic.get relaxed $shared-array
+  ;; CHECK-NEXT:       (local.get $shared-array)
+  ;; CHECK-NEXT:       (i32.const 0)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (local.set $x
+  ;; CHECK-NEXT:      (block (result i32)
+  ;; CHECK-NEXT:       (struct.atomic.set relaxed $shared-struct 0
+  ;; CHECK-NEXT:        (local.get $shared)
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (i32.const 42)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (i32.const 1)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (local.set $x
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.get $x)
+  ;; CHECK-NEXT: )
+  (func $br-on-relaxed-store-relaxed-read (param $shared (ref null $shared-struct))
+                                          (param $shared-array (ref null $shared-array))
+                                          (result i32)
+    (local $x i32)
+    (block $l
+      (br_if $l
+        (block (result i32)
+          ;; A relaxed store cannot be moved backward past a relaxed read.
+          (drop
+            (array.atomic.get relaxed $shared-array
+              (local.get $shared-array)
+              (i32.const 0)
+            )
+          )
+          (local.set $x
+            (block (result i32)
+              (struct.atomic.set relaxed $shared-struct 0
+                (local.get $shared)
+                (i32.const 0)
+              )
+              (i32.const 42)
+            )
+          )
+          (i32.const 1)
+        )
+      )
+      (local.set $x
+        (i32.const 0)
+      )
+    )
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $br-on-relaxed-read-relaxed-store (type $2) (param $shared (ref null $shared-struct)) (param $shared-array (ref null $shared-array)) (result i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (block $l (result i32)
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (br_if $l
+  ;; CHECK-NEXT:     (block (result i32)
+  ;; CHECK-NEXT:      (drop
+  ;; CHECK-NEXT:       (array.atomic.get relaxed $shared-array
+  ;; CHECK-NEXT:        (local.get $shared-array)
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (i32.const 42)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (block (result i32)
+  ;; CHECK-NEXT:      (struct.atomic.set relaxed $shared-struct 0
+  ;; CHECK-NEXT:       (local.get $shared)
+  ;; CHECK-NEXT:       (i32.const 0)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (nop)
+  ;; CHECK-NEXT:      (i32.const 1)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (nop)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $br-on-relaxed-read-relaxed-store (param $shared (ref null $shared-struct))
+                                          (param $shared-array (ref null $shared-array))
+                                          (result i32)
+    (local $x i32)
+    (block $l
+      (br_if $l
+        (block (result i32)
+          ;; A relaxed read can be moved backward past a relaxed store.
+          (struct.atomic.set relaxed $shared-struct 0
+            (local.get $shared)
+            (i32.const 0)
+          )
+          (local.set $x
+            (block (result i32)
+              (drop
+                (array.atomic.get relaxed $shared-array
+                  (local.get $shared-array)
+                  (i32.const 0)
+                )
+              )
+              (i32.const 42)
+            )
+          )
+          (i32.const 1)
+        )
+      )
+      (local.set $x
+        (i32.const 0)
+      )
+    )
+    (local.get $x)
+  )
 )

--- a/test/lit/validation/relaxed-atomics.wast
+++ b/test/lit/validation/relaxed-atomics.wast
@@ -1,0 +1,20 @@
+;; Test the feature flag for --relaxed-atomics
+;; The below tests set --enable-threads since it's required for shared memories.
+
+;; text
+;; RUN: wasm-opt --enable-threads --enable-relaxed-atomics %s 2>&1
+;; RUN: not wasm-opt --enable-threads --disable-relaxed-atomics %s 2>&1 | filecheck %s
+
+;; binary
+;; RUN: wasm-opt --enable-threads --enable-relaxed-atomics %s -o %t.wasm
+;; RUN: not wasm-opt --enable-threads --disable-relaxed-atomics %t.wasm 2>&1 | filecheck %s
+
+(module
+  (memory 1 1 shared)
+  (func $relaxed (result i32)
+    ;; CHECK: Relaxed operations require relaxed atomics [--enable-relaxed-atomics]
+    (i32.atomic.load relaxed
+      (i32.const 1)
+    )
+  )
+)


### PR DESCRIPTION
The memory order is not the C++ relaxed memory order, but rather the slightly stronger load-store ordered memory order, which prevents out-of-thin-air values by forbidding earlier atomic loads from being reordered past later atomic stores. This makes it impossible to construct the self-justifying causality cycle that gives rise to out-of-thin-air values. The name of the memory order in both the implementation and the text format is likely to change in the future to become more descriptive.
