### PR TITLE
Fix handling of indirect return calls in DAE2

### DIFF
--- a/src/passes/DeadArgumentElimination2.cpp
+++ b/src/passes/DeadArgumentElimination2.cpp
@@ -638,8 +638,12 @@ struct GraphBuilder : public WalkerPass<ExpressionStackWalker<GraphBuilder>> {
       HeapType rootType = getRootType(type);
       Location source = TypeResultLoc{rootType};
       if (isReturn) {
-        forwardToResult(source);
-        funcInfos[index].tailCalleeTypes.push_back(rootType);
+        if (optimizeReferencedFuncs) {
+          forwardToResult(source);
+          funcInfos[index].tailCalleeTypes.push_back(rootType);
+        } else {
+          funcInfos[index].resultUsage = used.getTop();
+        }
       } else if (optimizeReferencedFuncs) {
         getValueFromLocation(curr, source);
       }

--- a/test/lit/passes/dae2-results-open-world.wast
+++ b/test/lit/passes/dae2-results-open-world.wast
@@ -3,13 +3,9 @@
 ;; RUN: foreach %s %t wasm-opt -all --dae2 --closed-world -S -o - | filecheck %s --check-prefix=CLOSED
 
 (module
-  ;; OPEN:      (type $0 (func (result i32)))
-
   ;; OPEN:      (func $target (type $0) (result i32)
   ;; OPEN-NEXT:  (i32.const 42)
   ;; OPEN-NEXT: )
-  ;; CLOSED:      (type $0 (func (result i32)))
-
   ;; CLOSED:      (func $target (type $0) (result i32)
   ;; CLOSED-NEXT:  (i32.const 42)
   ;; CLOSED-NEXT: )
@@ -34,11 +30,7 @@
 )
 
 (module
-  ;; OPEN:      (type $0 (func (result i32)))
-
   ;; OPEN:      (import "env" "target" (func $target (type $0) (result i32)))
-  ;; CLOSED:      (type $0 (func (result i32)))
-
   ;; CLOSED:      (import "env" "target" (func $target (type $0) (result i32)))
   (import "env" "target" (func $target (result i32)))
   ;; OPEN:      (func $caller (type $1)
@@ -59,9 +51,6 @@
 
 (module
   ;; OPEN:      (type $sig (func (result i32)))
-  ;; CLOSED:      (rec
-  ;; CLOSED-NEXT:  (type $0 (func))
-
   ;; CLOSED:       (type $sig (func))
   (type $sig (func (result i32)))
   ;; OPEN:      (func $target (type $sig) (result i32)
@@ -91,50 +80,50 @@
 )
 
 (module
-  ;; OPEN:      (type $0 (func (result i32)))
-  ;; CLOSED:      (type $0 (func))
-  (type $0 (func (result i32)))
-  ;; OPEN:      (table $0 1 funcref)
-  ;; CLOSED:      (table $0 1 funcref)
-  (table $0 1 funcref)
-  ;; OPEN:      (func $caller (type $0) (result i32)
-  ;; OPEN-NEXT:  (return_call_indirect $0 (type $0)
+  ;; OPEN:      (type $f (func (result i32)))
+  ;; CLOSED:      (type $f (func))
+  (type $f (func (result i32)))
+  ;; OPEN:      (table $t 1 funcref)
+  ;; CLOSED:      (table $t 1 funcref)
+  (table $t 1 funcref)
+  ;; OPEN:      (func $caller (type $f) (result i32)
+  ;; OPEN-NEXT:  (return_call_indirect $t (type $f)
   ;; OPEN-NEXT:   (i32.const 0)
   ;; OPEN-NEXT:  )
   ;; OPEN-NEXT: )
-  ;; CLOSED:      (func $caller (type $0)
-  ;; CLOSED-NEXT:  (return_call_indirect $0 (type $0)
+  ;; CLOSED:      (func $caller (type $f)
+  ;; CLOSED-NEXT:  (return_call_indirect $t (type $f)
   ;; CLOSED-NEXT:   (i32.const 0)
   ;; CLOSED-NEXT:  )
   ;; CLOSED-NEXT: )
-  (func $caller (type $0) (result i32)
+  (func $caller (type $f) (result i32)
     ;; In open world, indirect call signatures cannot be modified, so the caller
     ;; cannot have its result removed even though the result is unused. In closed
     ;; world, both the signature and the caller can be optimized.
-    (return_call_indirect $0 (type $0)
+    (return_call_indirect $t (type $f)
       (i32.const 0)
     )
   )
 )
 
 (module
-  ;; OPEN:      (type $0 (func (result i32)))
+  ;; OPEN:      (type $f (func (result i32)))
   ;; CLOSED:      (rec
-  ;; CLOSED-NEXT:  (type $0 (func))
-  (type $0 (func (result i32)))
-  ;; OPEN:      (func $caller (type $1) (param $ref (ref $0)) (result i32)
-  ;; OPEN-NEXT:  (return_call_ref $0
+  ;; CLOSED-NEXT:  (type $f (func))
+  (type $f (func (result i32)))
+  ;; OPEN:      (func $caller (type $1) (param $ref (ref $f)) (result i32)
+  ;; OPEN-NEXT:  (return_call_ref $f
   ;; OPEN-NEXT:   (local.get $ref)
   ;; OPEN-NEXT:  )
   ;; OPEN-NEXT: )
-  ;; CLOSED:      (func $caller (type $2) (param $ref (ref $0))
-  ;; CLOSED-NEXT:  (return_call_ref $0
+  ;; CLOSED:      (func $caller (type $2) (param $ref (ref $f))
+  ;; CLOSED-NEXT:  (return_call_ref $f
   ;; CLOSED-NEXT:   (local.get $ref)
   ;; CLOSED-NEXT:  )
   ;; CLOSED-NEXT: )
-  (func $caller (param $ref (ref $0)) (result i32)
+  (func $caller (param $ref (ref $f)) (result i32)
     ;; Same with return_call_ref.
-    (return_call_ref $0
+    (return_call_ref $f
       (local.get $ref)
     )
   )

--- a/test/lit/passes/dae2-results-open-world.wast
+++ b/test/lit/passes/dae2-results-open-world.wast
@@ -3,9 +3,13 @@
 ;; RUN: foreach %s %t wasm-opt -all --dae2 --closed-world -S -o - | filecheck %s --check-prefix=CLOSED
 
 (module
+  ;; OPEN:      (type $0 (func (result i32)))
+
   ;; OPEN:      (func $target (type $0) (result i32)
   ;; OPEN-NEXT:  (i32.const 42)
   ;; OPEN-NEXT: )
+  ;; CLOSED:      (type $0 (func (result i32)))
+
   ;; CLOSED:      (func $target (type $0) (result i32)
   ;; CLOSED-NEXT:  (i32.const 42)
   ;; CLOSED-NEXT: )
@@ -30,7 +34,11 @@
 )
 
 (module
+  ;; OPEN:      (type $0 (func (result i32)))
+
   ;; OPEN:      (import "env" "target" (func $target (type $0) (result i32)))
+  ;; CLOSED:      (type $0 (func (result i32)))
+
   ;; CLOSED:      (import "env" "target" (func $target (type $0) (result i32)))
   (import "env" "target" (func $target (result i32)))
   ;; OPEN:      (func $caller (type $1)
@@ -51,6 +59,9 @@
 
 (module
   ;; OPEN:      (type $sig (func (result i32)))
+  ;; CLOSED:      (rec
+  ;; CLOSED-NEXT:  (type $0 (func))
+
   ;; CLOSED:       (type $sig (func))
   (type $sig (func (result i32)))
   ;; OPEN:      (func $target (type $sig) (result i32)
@@ -76,5 +87,55 @@
     ;; $target is referenced and $sig's result is unused. We can optimize in
     ;; closed world but not open world.
     (drop (ref.func $target))
+  )
+)
+
+(module
+  ;; OPEN:      (type $0 (func (result i32)))
+  ;; CLOSED:      (type $0 (func))
+  (type $0 (func (result i32)))
+  ;; OPEN:      (table $0 1 funcref)
+  ;; CLOSED:      (table $0 1 funcref)
+  (table $0 1 funcref)
+  ;; OPEN:      (func $caller (type $0) (result i32)
+  ;; OPEN-NEXT:  (return_call_indirect $0 (type $0)
+  ;; OPEN-NEXT:   (i32.const 0)
+  ;; OPEN-NEXT:  )
+  ;; OPEN-NEXT: )
+  ;; CLOSED:      (func $caller (type $0)
+  ;; CLOSED-NEXT:  (return_call_indirect $0 (type $0)
+  ;; CLOSED-NEXT:   (i32.const 0)
+  ;; CLOSED-NEXT:  )
+  ;; CLOSED-NEXT: )
+  (func $caller (type $0) (result i32)
+    ;; In open world, indirect call signatures cannot be modified, so the caller
+    ;; cannot have its result removed even though the result is unused. In closed
+    ;; world, both the signature and the caller can be optimized.
+    (return_call_indirect $0 (type $0)
+      (i32.const 0)
+    )
+  )
+)
+
+(module
+  ;; OPEN:      (type $0 (func (result i32)))
+  ;; CLOSED:      (rec
+  ;; CLOSED-NEXT:  (type $0 (func))
+  (type $0 (func (result i32)))
+  ;; OPEN:      (func $caller (type $1) (param $ref (ref $0)) (result i32)
+  ;; OPEN-NEXT:  (return_call_ref $0
+  ;; OPEN-NEXT:   (local.get $ref)
+  ;; OPEN-NEXT:  )
+  ;; OPEN-NEXT: )
+  ;; CLOSED:      (func $caller (type $2) (param $ref (ref $0))
+  ;; CLOSED-NEXT:  (return_call_ref $0
+  ;; CLOSED-NEXT:   (local.get $ref)
+  ;; CLOSED-NEXT:  )
+  ;; CLOSED-NEXT: )
+  (func $caller (param $ref (ref $0)) (result i32)
+    ;; Same with return_call_ref.
+    (return_call_ref $0
+      (local.get $ref)
+    )
   )
 )


### PR DESCRIPTION
In an open world, DAE2 cannot optimize indirect calls or indirect call targets. Since indirect return call results cannot be optimized out, and return call results must match the caller results, indirect return calls should prevent the caller's results from being optimized as well. We were not previously handling this correctly, leading to validation errors.

Fixes #8968.
