### PR TITLE
[wasm-split] Don't use ParallelFunctionAnalysis in scanModule

### DIFF
--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -704,26 +704,12 @@ ModuleSplitter::PrimarySecondaryUsedNames ModuleSplitter::computeUsedNames() {
   // Given a module, collect names used in the module
   auto scanModule = [&](Module& module) {
     UsedNames used;
-    ModuleUtils::ParallelFunctionAnalysis<UsedNames> nameCollector(
-      module, [&](Function* func, UsedNames& used) {
-        if (!func->imported()) {
-          NameCollector(used).walk(func->body);
-        }
-      });
-
-    for (auto& [_, funcUsed] : nameCollector.map) {
-      used.globals.insert(funcUsed.globals.begin(), funcUsed.globals.end());
-      used.memories.insert(funcUsed.memories.begin(), funcUsed.memories.end());
-      used.tables.insert(funcUsed.tables.begin(), funcUsed.tables.end());
-      used.tags.insert(funcUsed.tags.begin(), funcUsed.tags.end());
-      used.dataSegments.insert(funcUsed.dataSegments.begin(),
-                               funcUsed.dataSegments.end());
-      used.elementSegments.insert(funcUsed.elementSegments.begin(),
-                                  funcUsed.elementSegments.end());
-    }
-
     NameCollector collector(used);
-
+    for (auto& func : module.functions) {
+      if (!func->imported()) {
+        collector.walk(func->body);
+      }
+    }
     return used;
   };
 


### PR DESCRIPTION
This removes the use of `ParallelFunctionAnalysis` within `scanModule` (in `computeUsedNames`), which scans `UsedNames` for each module.

I'm not 100% sure why but this improves running time at least for Dart applications. I also previously tried to use `ParallelFunctionAnalysis` in other functions but it resulted in slowdown so didn't do it. Maybe cache locality works against the parallelism.

This reduces running time of acx_gallery (Jul 2026) by 7.8% (30.6s -> 28.2s) essentials by 4.2% (225.1s -> 215.6s).