### PR TITLE
[wasm-emscripten-finalize] Remove --no-legalize-javascript-ffi flag

### DIFF
--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -46,7 +46,6 @@ int main(int argc, const char* argv[]) {
   bool debugInfo = false;
   bool DWARF = false;
   bool sideModule = false;
-  bool legalizeJavaScriptFFI = true;
   bool bigInt = false;
   bool checkStackOverflow = false;
   bool standaloneWasm = false;
@@ -104,15 +103,6 @@ int main(int argc, const char* argv[]) {
          Options::Arguments::One,
          [&inputSourceMapFilename](Options* o, const std::string& argument) {
            inputSourceMapFilename = argument;
-         })
-    .add("--no-legalize-javascript-ffi",
-         "-nj",
-         "Do not fully legalize (i64->i32, "
-         "f32->f64) the imports and exports for interfacing with JS",
-         WasmEmscriptenFinalizeOption,
-         Options::Arguments::Zero,
-         [&legalizeJavaScriptFFI](Options* o, const std::string&) {
-           legalizeJavaScriptFFI = false;
          })
     .add("--bigint",
          "-bi",
@@ -261,8 +251,9 @@ int main(int argc, const char* argv[]) {
     }
   }
 
-  // Legalize the wasm, if BigInts don't make that moot.
-  if (!bigInt && legalizeJavaScriptFFI) {
+  // Legalize the Wasm imports/exports, by lowing away usages of i64,
+  // if BigInt integration is not available.
+  if (!bigInt) {
     passRunner.add("legalize-js-interface");
   }
 

--- a/test/lit/help/wasm-emscripten-finalize.test
+++ b/test/lit/help/wasm-emscripten-finalize.test
@@ -25,10 +25,6 @@
 ;; CHECK-NEXT:   --input-source-map,-ism              Consume source map from the specified
 ;; CHECK-NEXT:                                        file
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --no-legalize-javascript-ffi,-nj     Do not fully legalize (i64->i32,
-;; CHECK-NEXT:                                        f32->f64) the imports and exports for
-;; CHECK-NEXT:                                        interfacing with JS
-;; CHECK-NEXT:
 ;; CHECK-NEXT:   --bigint,-bi                         Assume JS will use wasm/JS BigInt
 ;; CHECK-NEXT:                                        integration, so wasm i64s will turn into
 ;; CHECK-NEXT:                                        JS BigInts, and there is no need for any


### PR DESCRIPTION
This flag was redundant given that we have `--bigint`.  See https://github.com/emscripten-core/emscripten/pull/27570 for where we stop using it in emscripten.