### PR TITLE
[i64-to-i32-lowering] Lower nontrapping float-to-int conversions

### DIFF
--- a/src/passes/I64ToI32Lowering.cpp
+++ b/src/passes/I64ToI32Lowering.cpp
@@ -699,7 +699,9 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
     BinaryOp ge, gt, min, div, sub;
     switch (curr->op) {
       case TruncSFloat32ToInt64:
-      case TruncUFloat32ToInt64: {
+      case TruncSatSFloat32ToInt64:
+      case TruncUFloat32ToInt64:
+      case TruncSatUFloat32ToInt64: {
         litZero = Literal((float)0);
         litOne = Literal((float)1);
         u32Max = Literal(((float)UINT_MAX) + 1);
@@ -717,7 +719,9 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
         break;
       }
       case TruncSFloat64ToInt64:
-      case TruncUFloat64ToInt64: {
+      case TruncSatSFloat64ToInt64:
+      case TruncUFloat64ToInt64:
+      case TruncSatUFloat64ToInt64: {
         litZero = Literal((double)0);
         litOne = Literal((double)1);
         u32Max = Literal(((double)UINT_MAX) + 1);
@@ -930,9 +934,13 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
       case ExtendUInt32:
       case WrapInt64:
       case TruncSFloat32ToInt64:
+      case TruncSatSFloat32ToInt64:
       case TruncUFloat32ToInt64:
+      case TruncSatUFloat32ToInt64:
       case TruncSFloat64ToInt64:
+      case TruncSatSFloat64ToInt64:
       case TruncUFloat64ToInt64:
+      case TruncSatUFloat64ToInt64:
       case ReinterpretFloat64:
       case ConvertSInt64ToFloat32:
       case ConvertSInt64ToFloat64:
@@ -981,9 +989,13 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
         lowerReinterpretInt64(curr);
         break;
       case TruncSFloat32ToInt64:
+      case TruncSatSFloat32ToInt64:
       case TruncUFloat32ToInt64:
+      case TruncSatUFloat32ToInt64:
       case TruncSFloat64ToInt64:
+      case TruncSatSFloat64ToInt64:
       case TruncUFloat64ToInt64:
+      case TruncSatUFloat64ToInt64:
         lowerTruncFloatToInt(curr);
         break;
       case ConvertSInt64ToFloat32:

--- a/test/lit/passes/flatten_i64-to-i32-lowering.wast
+++ b/test/lit/passes/flatten_i64-to-i32-lowering.wast
@@ -672,7 +672,11 @@
 
  (elem (i32.const 0) $f)
 
- ;; CHECK:      (type $0 (func (result i32)))
+ ;; CHECK:      (type $0 (func (param f32) (result i32)))
+
+ ;; CHECK:      (type $1 (func (param f64) (result i32)))
+
+ ;; CHECK:      (type $2 (func (result i32)))
 
  ;; CHECK:      (global $i64toi32_i32$HIGH_BITS (mut i32) (i32.const 0))
 
@@ -680,11 +684,407 @@
 
  ;; CHECK:      (elem $0 (i32.const 0) $f)
 
- ;; CHECK:      (func $f (type $0) (result i32)
+ ;; CHECK:      (func $f (type $2) (result i32)
  ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT: )
  (func $f (result i64)
   (unreachable)
+ )
+ ;; CHECK:      (func $trunc_sat_f32_s (type $0) (param $f f32) (result i32)
+ ;; CHECK-NEXT:  (local $1 f32)
+ ;; CHECK-NEXT:  (local $2 i32)
+ ;; CHECK-NEXT:  (local $2$hi i32)
+ ;; CHECK-NEXT:  (local $i64toi32_i32$0 f32)
+ ;; CHECK-NEXT:  (local $i64toi32_i32$1 i32)
+ ;; CHECK-NEXT:  (local $i64toi32_i32$2 i32)
+ ;; CHECK-NEXT:  (local.set $1
+ ;; CHECK-NEXT:   (local.get $f)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (block
+ ;; CHECK-NEXT:   (local.set $2
+ ;; CHECK-NEXT:    (block (result i32)
+ ;; CHECK-NEXT:     (local.set $i64toi32_i32$0
+ ;; CHECK-NEXT:      (local.get $1)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (local.set $i64toi32_i32$1
+ ;; CHECK-NEXT:      (if (result i32)
+ ;; CHECK-NEXT:       (f32.ge
+ ;; CHECK-NEXT:        (f32.abs
+ ;; CHECK-NEXT:         (local.get $i64toi32_i32$0)
+ ;; CHECK-NEXT:        )
+ ;; CHECK-NEXT:        (f32.const 1)
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:       (then
+ ;; CHECK-NEXT:        (if (result i32)
+ ;; CHECK-NEXT:         (f32.gt
+ ;; CHECK-NEXT:          (local.get $i64toi32_i32$0)
+ ;; CHECK-NEXT:          (f32.const 0)
+ ;; CHECK-NEXT:         )
+ ;; CHECK-NEXT:         (then
+ ;; CHECK-NEXT:          (i32.trunc_f32_u
+ ;; CHECK-NEXT:           (f32.min
+ ;; CHECK-NEXT:            (f32.floor
+ ;; CHECK-NEXT:             (f32.div
+ ;; CHECK-NEXT:              (local.get $i64toi32_i32$0)
+ ;; CHECK-NEXT:              (f32.const 4294967296)
+ ;; CHECK-NEXT:             )
+ ;; CHECK-NEXT:            )
+ ;; CHECK-NEXT:            (f32.sub
+ ;; CHECK-NEXT:             (f32.const 4294967296)
+ ;; CHECK-NEXT:             (f32.const 1)
+ ;; CHECK-NEXT:            )
+ ;; CHECK-NEXT:           )
+ ;; CHECK-NEXT:          )
+ ;; CHECK-NEXT:         )
+ ;; CHECK-NEXT:         (else
+ ;; CHECK-NEXT:          (i32.trunc_f32_u
+ ;; CHECK-NEXT:           (f32.ceil
+ ;; CHECK-NEXT:            (f32.div
+ ;; CHECK-NEXT:             (f32.sub
+ ;; CHECK-NEXT:              (local.get $i64toi32_i32$0)
+ ;; CHECK-NEXT:              (f32.convert_i32_u
+ ;; CHECK-NEXT:               (i32.trunc_f32_u
+ ;; CHECK-NEXT:                (local.get $i64toi32_i32$0)
+ ;; CHECK-NEXT:               )
+ ;; CHECK-NEXT:              )
+ ;; CHECK-NEXT:             )
+ ;; CHECK-NEXT:             (f32.const 4294967296)
+ ;; CHECK-NEXT:            )
+ ;; CHECK-NEXT:           )
+ ;; CHECK-NEXT:          )
+ ;; CHECK-NEXT:         )
+ ;; CHECK-NEXT:        )
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:       (else
+ ;; CHECK-NEXT:        (i32.const 0)
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (i32.trunc_f32_u
+ ;; CHECK-NEXT:      (local.get $i64toi32_i32$0)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (local.set $2$hi
+ ;; CHECK-NEXT:    (local.get $i64toi32_i32$1)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (block
+ ;; CHECK-NEXT:   (local.set $i64toi32_i32$2
+ ;; CHECK-NEXT:    (block (result i32)
+ ;; CHECK-NEXT:     (local.set $i64toi32_i32$1
+ ;; CHECK-NEXT:      (local.get $2$hi)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (local.get $2)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (global.set $i64toi32_i32$HIGH_BITS
+ ;; CHECK-NEXT:    (local.get $i64toi32_i32$1)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (return
+ ;; CHECK-NEXT:    (local.get $i64toi32_i32$2)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $trunc_sat_f32_s (param $f f32) (result i64)
+  (i64.trunc_sat_f32_s (local.get $f))
+ )
+ ;; CHECK:      (func $trunc_sat_f32_u (type $0) (param $f f32) (result i32)
+ ;; CHECK-NEXT:  (local $1 f32)
+ ;; CHECK-NEXT:  (local $2 i32)
+ ;; CHECK-NEXT:  (local $2$hi i32)
+ ;; CHECK-NEXT:  (local $i64toi32_i32$0 f32)
+ ;; CHECK-NEXT:  (local $i64toi32_i32$1 i32)
+ ;; CHECK-NEXT:  (local $i64toi32_i32$2 i32)
+ ;; CHECK-NEXT:  (local.set $1
+ ;; CHECK-NEXT:   (local.get $f)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (block
+ ;; CHECK-NEXT:   (local.set $2
+ ;; CHECK-NEXT:    (block (result i32)
+ ;; CHECK-NEXT:     (local.set $i64toi32_i32$0
+ ;; CHECK-NEXT:      (local.get $1)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (local.set $i64toi32_i32$1
+ ;; CHECK-NEXT:      (if (result i32)
+ ;; CHECK-NEXT:       (f32.ge
+ ;; CHECK-NEXT:        (f32.abs
+ ;; CHECK-NEXT:         (local.get $i64toi32_i32$0)
+ ;; CHECK-NEXT:        )
+ ;; CHECK-NEXT:        (f32.const 1)
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:       (then
+ ;; CHECK-NEXT:        (if (result i32)
+ ;; CHECK-NEXT:         (f32.gt
+ ;; CHECK-NEXT:          (local.get $i64toi32_i32$0)
+ ;; CHECK-NEXT:          (f32.const 0)
+ ;; CHECK-NEXT:         )
+ ;; CHECK-NEXT:         (then
+ ;; CHECK-NEXT:          (i32.trunc_f32_u
+ ;; CHECK-NEXT:           (f32.min
+ ;; CHECK-NEXT:            (f32.floor
+ ;; CHECK-NEXT:             (f32.div
+ ;; CHECK-NEXT:              (local.get $i64toi32_i32$0)
+ ;; CHECK-NEXT:              (f32.const 4294967296)
+ ;; CHECK-NEXT:             )
+ ;; CHECK-NEXT:            )
+ ;; CHECK-NEXT:            (f32.sub
+ ;; CHECK-NEXT:             (f32.const 4294967296)
+ ;; CHECK-NEXT:             (f32.const 1)
+ ;; CHECK-NEXT:            )
+ ;; CHECK-NEXT:           )
+ ;; CHECK-NEXT:          )
+ ;; CHECK-NEXT:         )
+ ;; CHECK-NEXT:         (else
+ ;; CHECK-NEXT:          (i32.trunc_f32_u
+ ;; CHECK-NEXT:           (f32.ceil
+ ;; CHECK-NEXT:            (f32.div
+ ;; CHECK-NEXT:             (f32.sub
+ ;; CHECK-NEXT:              (local.get $i64toi32_i32$0)
+ ;; CHECK-NEXT:              (f32.convert_i32_u
+ ;; CHECK-NEXT:               (i32.trunc_f32_u
+ ;; CHECK-NEXT:                (local.get $i64toi32_i32$0)
+ ;; CHECK-NEXT:               )
+ ;; CHECK-NEXT:              )
+ ;; CHECK-NEXT:             )
+ ;; CHECK-NEXT:             (f32.const 4294967296)
+ ;; CHECK-NEXT:            )
+ ;; CHECK-NEXT:           )
+ ;; CHECK-NEXT:          )
+ ;; CHECK-NEXT:         )
+ ;; CHECK-NEXT:        )
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:       (else
+ ;; CHECK-NEXT:        (i32.const 0)
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (i32.trunc_f32_u
+ ;; CHECK-NEXT:      (local.get $i64toi32_i32$0)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (local.set $2$hi
+ ;; CHECK-NEXT:    (local.get $i64toi32_i32$1)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (block
+ ;; CHECK-NEXT:   (local.set $i64toi32_i32$2
+ ;; CHECK-NEXT:    (block (result i32)
+ ;; CHECK-NEXT:     (local.set $i64toi32_i32$1
+ ;; CHECK-NEXT:      (local.get $2$hi)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (local.get $2)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (global.set $i64toi32_i32$HIGH_BITS
+ ;; CHECK-NEXT:    (local.get $i64toi32_i32$1)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (return
+ ;; CHECK-NEXT:    (local.get $i64toi32_i32$2)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $trunc_sat_f32_u (param $f f32) (result i64)
+  (i64.trunc_sat_f32_u (local.get $f))
+ )
+ ;; CHECK:      (func $trunc_sat_f64_s (type $1) (param $f f64) (result i32)
+ ;; CHECK-NEXT:  (local $1 f64)
+ ;; CHECK-NEXT:  (local $2 i32)
+ ;; CHECK-NEXT:  (local $2$hi i32)
+ ;; CHECK-NEXT:  (local $i64toi32_i32$0 f64)
+ ;; CHECK-NEXT:  (local $i64toi32_i32$1 i32)
+ ;; CHECK-NEXT:  (local $i64toi32_i32$2 i32)
+ ;; CHECK-NEXT:  (local.set $1
+ ;; CHECK-NEXT:   (local.get $f)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (block
+ ;; CHECK-NEXT:   (local.set $2
+ ;; CHECK-NEXT:    (block (result i32)
+ ;; CHECK-NEXT:     (local.set $i64toi32_i32$0
+ ;; CHECK-NEXT:      (local.get $1)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (local.set $i64toi32_i32$1
+ ;; CHECK-NEXT:      (if (result i32)
+ ;; CHECK-NEXT:       (f64.ge
+ ;; CHECK-NEXT:        (f64.abs
+ ;; CHECK-NEXT:         (local.get $i64toi32_i32$0)
+ ;; CHECK-NEXT:        )
+ ;; CHECK-NEXT:        (f64.const 1)
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:       (then
+ ;; CHECK-NEXT:        (if (result i32)
+ ;; CHECK-NEXT:         (f64.gt
+ ;; CHECK-NEXT:          (local.get $i64toi32_i32$0)
+ ;; CHECK-NEXT:          (f64.const 0)
+ ;; CHECK-NEXT:         )
+ ;; CHECK-NEXT:         (then
+ ;; CHECK-NEXT:          (i32.trunc_f64_u
+ ;; CHECK-NEXT:           (f64.min
+ ;; CHECK-NEXT:            (f64.floor
+ ;; CHECK-NEXT:             (f64.div
+ ;; CHECK-NEXT:              (local.get $i64toi32_i32$0)
+ ;; CHECK-NEXT:              (f64.const 4294967296)
+ ;; CHECK-NEXT:             )
+ ;; CHECK-NEXT:            )
+ ;; CHECK-NEXT:            (f64.sub
+ ;; CHECK-NEXT:             (f64.const 4294967296)
+ ;; CHECK-NEXT:             (f64.const 1)
+ ;; CHECK-NEXT:            )
+ ;; CHECK-NEXT:           )
+ ;; CHECK-NEXT:          )
+ ;; CHECK-NEXT:         )
+ ;; CHECK-NEXT:         (else
+ ;; CHECK-NEXT:          (i32.trunc_f64_u
+ ;; CHECK-NEXT:           (f64.ceil
+ ;; CHECK-NEXT:            (f64.div
+ ;; CHECK-NEXT:             (f64.sub
+ ;; CHECK-NEXT:              (local.get $i64toi32_i32$0)
+ ;; CHECK-NEXT:              (f64.convert_i32_u
+ ;; CHECK-NEXT:               (i32.trunc_f64_u
+ ;; CHECK-NEXT:                (local.get $i64toi32_i32$0)
+ ;; CHECK-NEXT:               )
+ ;; CHECK-NEXT:              )
+ ;; CHECK-NEXT:             )
+ ;; CHECK-NEXT:             (f64.const 4294967296)
+ ;; CHECK-NEXT:            )
+ ;; CHECK-NEXT:           )
+ ;; CHECK-NEXT:          )
+ ;; CHECK-NEXT:         )
+ ;; CHECK-NEXT:        )
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:       (else
+ ;; CHECK-NEXT:        (i32.const 0)
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (i32.trunc_f64_u
+ ;; CHECK-NEXT:      (local.get $i64toi32_i32$0)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (local.set $2$hi
+ ;; CHECK-NEXT:    (local.get $i64toi32_i32$1)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (block
+ ;; CHECK-NEXT:   (local.set $i64toi32_i32$2
+ ;; CHECK-NEXT:    (block (result i32)
+ ;; CHECK-NEXT:     (local.set $i64toi32_i32$1
+ ;; CHECK-NEXT:      (local.get $2$hi)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (local.get $2)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (global.set $i64toi32_i32$HIGH_BITS
+ ;; CHECK-NEXT:    (local.get $i64toi32_i32$1)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (return
+ ;; CHECK-NEXT:    (local.get $i64toi32_i32$2)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $trunc_sat_f64_s (param $f f64) (result i64)
+  (i64.trunc_sat_f64_s (local.get $f))
+ )
+ ;; CHECK:      (func $trunc_sat_f64_u (type $1) (param $f f64) (result i32)
+ ;; CHECK-NEXT:  (local $1 f64)
+ ;; CHECK-NEXT:  (local $2 i32)
+ ;; CHECK-NEXT:  (local $2$hi i32)
+ ;; CHECK-NEXT:  (local $i64toi32_i32$0 f64)
+ ;; CHECK-NEXT:  (local $i64toi32_i32$1 i32)
+ ;; CHECK-NEXT:  (local $i64toi32_i32$2 i32)
+ ;; CHECK-NEXT:  (local.set $1
+ ;; CHECK-NEXT:   (local.get $f)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (block
+ ;; CHECK-NEXT:   (local.set $2
+ ;; CHECK-NEXT:    (block (result i32)
+ ;; CHECK-NEXT:     (local.set $i64toi32_i32$0
+ ;; CHECK-NEXT:      (local.get $1)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (local.set $i64toi32_i32$1
+ ;; CHECK-NEXT:      (if (result i32)
+ ;; CHECK-NEXT:       (f64.ge
+ ;; CHECK-NEXT:        (f64.abs
+ ;; CHECK-NEXT:         (local.get $i64toi32_i32$0)
+ ;; CHECK-NEXT:        )
+ ;; CHECK-NEXT:        (f64.const 1)
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:       (then
+ ;; CHECK-NEXT:        (if (result i32)
+ ;; CHECK-NEXT:         (f64.gt
+ ;; CHECK-NEXT:          (local.get $i64toi32_i32$0)
+ ;; CHECK-NEXT:          (f64.const 0)
+ ;; CHECK-NEXT:         )
+ ;; CHECK-NEXT:         (then
+ ;; CHECK-NEXT:          (i32.trunc_f64_u
+ ;; CHECK-NEXT:           (f64.min
+ ;; CHECK-NEXT:            (f64.floor
+ ;; CHECK-NEXT:             (f64.div
+ ;; CHECK-NEXT:              (local.get $i64toi32_i32$0)
+ ;; CHECK-NEXT:              (f64.const 4294967296)
+ ;; CHECK-NEXT:             )
+ ;; CHECK-NEXT:            )
+ ;; CHECK-NEXT:            (f64.sub
+ ;; CHECK-NEXT:             (f64.const 4294967296)
+ ;; CHECK-NEXT:             (f64.const 1)
+ ;; CHECK-NEXT:            )
+ ;; CHECK-NEXT:           )
+ ;; CHECK-NEXT:          )
+ ;; CHECK-NEXT:         )
+ ;; CHECK-NEXT:         (else
+ ;; CHECK-NEXT:          (i32.trunc_f64_u
+ ;; CHECK-NEXT:           (f64.ceil
+ ;; CHECK-NEXT:            (f64.div
+ ;; CHECK-NEXT:             (f64.sub
+ ;; CHECK-NEXT:              (local.get $i64toi32_i32$0)
+ ;; CHECK-NEXT:              (f64.convert_i32_u
+ ;; CHECK-NEXT:               (i32.trunc_f64_u
+ ;; CHECK-NEXT:                (local.get $i64toi32_i32$0)
+ ;; CHECK-NEXT:               )
+ ;; CHECK-NEXT:              )
+ ;; CHECK-NEXT:             )
+ ;; CHECK-NEXT:             (f64.const 4294967296)
+ ;; CHECK-NEXT:            )
+ ;; CHECK-NEXT:           )
+ ;; CHECK-NEXT:          )
+ ;; CHECK-NEXT:         )
+ ;; CHECK-NEXT:        )
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:       (else
+ ;; CHECK-NEXT:        (i32.const 0)
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (i32.trunc_f64_u
+ ;; CHECK-NEXT:      (local.get $i64toi32_i32$0)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (local.set $2$hi
+ ;; CHECK-NEXT:    (local.get $i64toi32_i32$1)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (block
+ ;; CHECK-NEXT:   (local.set $i64toi32_i32$2
+ ;; CHECK-NEXT:    (block (result i32)
+ ;; CHECK-NEXT:     (local.set $i64toi32_i32$1
+ ;; CHECK-NEXT:      (local.get $2$hi)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (local.get $2)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (global.set $i64toi32_i32$HIGH_BITS
+ ;; CHECK-NEXT:    (local.get $i64toi32_i32$1)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (return
+ ;; CHECK-NEXT:    (local.get $i64toi32_i32$2)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $trunc_sat_f64_u (param $f f64) (result i64)
+  (i64.trunc_sat_f64_u (local.get $f))
  )
 )


### PR DESCRIPTION
Add support for `TruncSatSFloat32ToInt64`, `TruncSatUFloat32ToInt64`, `TruncSatSFloat64ToInt64`, and `TruncSatUFloat64ToInt64` to `I64ToI32Lowering.cpp`.

In Emscripten mode (`wasm2js --emscripten`), this is effectively a no-op because `llvm-nontrapping-fptoint-lowering` runs earlier in the pipeline and rewrites all `TruncSat` operations into trapping conversions before `i64-to-i32-lowering` executes.

However, landing this is still useful because:
1. Standalone `wasm2js` (without `--emscripten`) does not run `llvm-nontrapping-fptoint-lowering`, so modules with `i64.trunc_sat_*` instructions would otherwise fail during JS generation.
2. Direct invocations of `wasm-opt --flatten --i64-to-i32-lowering` will now correctly eliminate all 64-bit operations on modules using the nontrapping float-to-int feature.
3. It ensures `I64ToI32Lowering` is self-contained and handles all wasm i64-producing float truncation opcodes without relying on preceding lowering passes.
4. Since we removed the use of the `nontrapping-fptoint-lowering` pass in emscripten itself, I'm hoping we can followup by removing its use here too and marking it for removal.