### PR TITLE
Replace `BINARYEN_ROOT` with `BINARYEN_BIN`. NFC

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -50,7 +50,7 @@ def parse_args(args):
         help=('Specifies the path to the Binaryen executables in the CMake build'
               ' directory. Default: bin/ of current directory (i.e. assume an'
               ' in-tree build).'
-              ' If not specified, the environment variable BINARYEN_ROOT= can also'
+              ' If not specified, the environment variable BINARYEN_BIN= can also'
               ' be used to adjust this.'))
     parser.add_argument(
         '--binaryen-lib', dest='binaryen_lib', default='',
@@ -128,16 +128,14 @@ def verbose_log(*args, **kwargs):
 
 # setup
 
+# Locate Binaryen source directory if not specified.
+if not options.binaryen_root:
+    options.binaryen_root = os.path.dirname(os.path.dirname(script_dir))
+
 # Locate Binaryen build artifacts directory (bin/ by default)
 if not options.binaryen_bin:
-    if os.environ.get('BINARYEN_ROOT'):
-        if os.path.isdir(os.path.join(os.environ.get('BINARYEN_ROOT'), 'bin')):
-            options.binaryen_bin = os.path.join(
-                os.environ.get('BINARYEN_ROOT'), 'bin')
-        else:
-            options.binaryen_bin = os.environ.get('BINARYEN_ROOT')
-    else:
-        options.binaryen_bin = 'bin'
+    default_bin = os.path.join(options.binaryen_root, 'bin')
+    options.binaryen_bin = os.environ.get('BINARYEN_BIN', default_bin)
 
 options.binaryen_bin = os.path.normpath(os.path.abspath(options.binaryen_bin))
 
@@ -148,17 +146,13 @@ options.binaryen_lib = os.path.normpath(os.path.abspath(options.binaryen_lib))
 
 options.binaryen_build = os.path.dirname(options.binaryen_bin)
 
-# ensure BINARYEN_ROOT is set up
-os.environ['BINARYEN_ROOT'] = os.path.dirname(options.binaryen_bin)
+# ensure BINARYEN_BIN is set up
+os.environ['BINARYEN_BIN'] = options.binaryen_bin
 
 wasm_dis_filenames = ['wasm-dis', 'wasm-dis.exe', 'wasm-dis.js']
 if not any(os.path.isfile(os.path.join(options.binaryen_bin, f))
            for f in wasm_dis_filenames):
     warn('Binaryen not found (or has not been successfully built to bin/ ?')
-
-# Locate Binaryen source directory if not specified.
-if not options.binaryen_root:
-    options.binaryen_root = os.path.dirname(os.path.dirname(script_dir))
 
 options.binaryen_test = os.path.join(options.binaryen_root, 'test')
 
@@ -360,7 +354,7 @@ def fail_if_not_identical_to_file(actual, expected_file):
 
 
 def get_test_dir(name):
-    """Return the test directory located at BINARYEN_ROOT/test/[name]."""
+    """Return the test directory located at <binaryen_root>/test/[name]."""
     return os.path.join(options.binaryen_test, name)
 
 

--- a/src/support/path.cpp
+++ b/src/support/path.cpp
@@ -85,19 +85,15 @@ std::string getBaseName(const std::string& path) {
   return path;
 }
 
-std::string getBinaryenRoot() {
-  auto* envVar = getenv("BINARYEN_ROOT");
-  if (envVar) {
-    return envVar;
-  }
-  return ".";
-}
-
 static std::string binDir;
 
 std::string getBinaryenBinDir() {
   if (binDir.empty()) {
-    return getBinaryenRoot() + getPathSeparator() + "bin" + getPathSeparator();
+    auto* envVar = getenv("BINARYEN_BIN");
+    if (envVar) {
+      return envVar;
+    }
+    return ".";
   } else {
     return binDir;
   }

--- a/src/support/path.h
+++ b/src/support/path.h
@@ -44,9 +44,6 @@ char getPathSeparator();
 std::string getDirName(const std::string& path);
 std::string getBaseName(const std::string& path);
 
-// Get the binaryen root dir.
-std::string getBinaryenRoot();
-
 // Get the binaryen bin dir.
 std::string getBinaryenBinDir();
 


### PR DESCRIPTION
This simplifies the code and also has couple of other nice benefits.

1. It matches the corresponding `--binaryen-bin` command line flags
2. Its clear that its not actually the binaryen source root so its not tempting to think that you can find e.g. tests in `BINARYEN_ROOT/tests`.  Basically `BINARYEN_ROOT` always really means `BINARYEN_BUILD_ROOT` but `BINARYEN_BIN` is not ambigious in the same way.

 The only folks who will be effected by this change are binaryen
 developer who use out-of-tree builds and use this environment
 variable rather than passing `--binaryen-bin=` all over the place.