### PR TITLE
ConstraintAnalysis fuzz bug: Do not AND after a branch is not taken

### DIFF
--- a/src/passes/ConstraintAnalysis.cpp
+++ b/src/passes/ConstraintAnalysis.cpp
@@ -655,13 +655,17 @@ struct ConstraintAnalysis
     if (branch.constraint.op == Abstract::LtS ||
         branch.constraint.op == Abstract::LeS) {
       constraints.set(branch.local, branch.constraint);
-      constraints.approximateAnd(branch.local, {GeS, {*N}});
+      if (!constraints.unreachable) {
+        constraints.approximateAnd(branch.local, {GeS, {*N}});
+      }
       return true;
     }
     if (branch.constraint.op == Abstract::LtU ||
         branch.constraint.op == Abstract::LeU) {
       constraints.set(branch.local, branch.constraint);
-      constraints.approximateAnd(branch.local, {GeU, {*N}});
+      if (!constraints.unreachable) {
+        constraints.approximateAnd(branch.local, {GeU, {*N}});
+      }
       return true;
     }
 

--- a/test/lit/passes/constraint-analysis-loops.wast
+++ b/test/lit/passes/constraint-analysis-loops.wast
@@ -1520,4 +1520,57 @@
       )
     )
   )
+
+  ;; CHECK:      (func $impossible-branch (type $0)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (local $y i32)
+  ;; CHECK-NEXT:  (loop $loop
+  ;; CHECK-NEXT:   (br_if $loop
+  ;; CHECK-NEXT:    (i32.lt_s
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:     (local.get $y)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $impossible-branch
+    (local $x i32)
+    (local $y i32)
+    (loop $loop
+      ;; x == y == 0, so x < y leads to a contradiction, and we never branch
+      ;; back up to the loop. We should not error here.
+      (br_if $loop
+        (i32.lt_s
+          (local.get $x)
+          (local.get $y)
+        )
+      )
+    )
+  )
+
+  ;; CHECK:      (func $impossible-branch-unsigned (type $0)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (local $y i32)
+  ;; CHECK-NEXT:  (loop $loop
+  ;; CHECK-NEXT:   (br_if $loop
+  ;; CHECK-NEXT:    (i32.lt_u
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:     (local.get $y)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $impossible-branch-unsigned
+    (local $x i32)
+    (local $y i32)
+    ;; As above, but unsigned.
+    (loop $loop
+      (br_if $loop
+        (i32.lt_u
+          (local.get $x)
+          (local.get $y)
+        )
+      )
+    )
+  )
 )


### PR DESCRIPTION
If we prove a branch is not taken, we'd hit an internal error if we tried
to perform an AND with more constraints on it later. Once we are in
unreachable code, we must not do anything (and the caller will handle
that).