### PR TITLE
Constraints: Fix float comparisons

### DIFF
--- a/src/ir/constraint.cpp
+++ b/src/ir/constraint.cpp
@@ -383,10 +383,6 @@ bool isImmediateContradiction(const Constraint& c) {
     return false;
   }
 
-  if (cc->type.isFloat()) {
-    return c.op == Eq && cc->isNaN();
-  }
-
   if (!cc->type.isInteger()) {
     return false;
   }

--- a/src/ir/constraint.cpp
+++ b/src/ir/constraint.cpp
@@ -170,9 +170,9 @@ Result provesConstantPair(Abstract::Op aOp,
   if (aOp == Eq) {
     switch (bOp) {
       case Eq:
-        return TrueFalse(aConstant == bConstant);
+        return TrueFalse(aConstant.eq(bConstant));
       case Ne:
-        return TrueFalse(aConstant != bConstant);
+        return TrueFalse(aConstant.ne(bConstant));
       case LtS:
         return TrueFalse(aConstant.ltS(bConstant));
       case LeS:
@@ -196,14 +196,14 @@ Result provesConstantPair(Abstract::Op aOp,
 
   // a != A =?=> a == B. False if A = B, else unknown.
   if (aOp == Ne && bOp == Eq) {
-    if (aConstant == bConstant) {
+    if (aConstant.eq(bConstant).getInteger()) {
       return False;
     }
   }
 
   // a != A =?=> a != B. True if A = B, else unknown.
   if (aOp == Ne && bOp == Ne) {
-    if (aConstant == bConstant) {
+    if (aConstant.eq(bConstant).getInteger()) {
       return True;
     }
   }
@@ -380,6 +380,14 @@ bool isImmediateContradiction(const Constraint& c) {
   auto* cc = std::get_if<Literal>(&c.term);
   if (!cc) {
     // Only operations on constants can be immediate contradictions.
+    return false;
+  }
+
+  if (cc->type.isFloat()) {
+    return c.op == Eq && cc->isNaN();
+  }
+
+  if (!cc->type.isInteger()) {
     return false;
   }
 

--- a/src/literal.h
+++ b/src/literal.h
@@ -358,9 +358,9 @@ public:
   bool operator!=(const Literal& other) const;
   bool operator<(const Literal& other) const;
 
-  bool isNaN();
-  bool isCanonicalNaN();
-  bool isArithmeticNaN();
+  bool isNaN() const;
+  bool isCanonicalNaN() const;
+  bool isArithmeticNaN() const;
 
   static uint32_t NaNPayload(float f);
   static uint64_t NaNPayload(double f);
@@ -425,9 +425,10 @@ public:
   Literal rotL(const Literal& other) const;
   Literal rotR(const Literal& other) const;
 
-  // Note that these functions perform equality checks based
-  // on the type of the literal, so that (unlike the == operator)
-  // a float nan would not be identical to itself.
+  // Note that these functions perform equality checks based on the type of the
+  // literal, and using the wasm semantics. That is, eq() works like i32.eq or
+  // ref.eq. For example, f32.eq of 0 and -0 returns 1 (they are equal), while
+  // the == operator would return false (because they are different Literals).
   Literal eq(const Literal& other) const;
   Literal ne(const Literal& other) const;
   Literal ltS(const Literal& other) const;

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -583,7 +583,7 @@ bool Literal::operator<(const Literal& other) const {
   return externalize() < other.externalize();
 }
 
-bool Literal::isNaN() {
+bool Literal::isNaN() const {
   if (type == Type::f32 && std::isnan(getf32())) {
     return true;
   }
@@ -594,7 +594,7 @@ bool Literal::isNaN() {
   return false;
 }
 
-bool Literal::isCanonicalNaN() {
+bool Literal::isCanonicalNaN() const {
   if (!isNaN()) {
     return false;
   }
@@ -602,7 +602,7 @@ bool Literal::isCanonicalNaN() {
          (type == Type::f64 && NaNPayload(getf64()) == (1ull << 51));
 }
 
-bool Literal::isArithmeticNaN() {
+bool Literal::isArithmeticNaN() const {
   if (!isNaN()) {
     return false;
   }
@@ -1602,37 +1602,53 @@ Literal Literal::rotR(const Literal& other) const {
 }
 
 Literal Literal::eq(const Literal& other) const {
-  switch (type.getBasic()) {
-    case Type::i32:
-      return Literal(i32 == other.i32);
-    case Type::i64:
-      return Literal(i64 == other.i64);
-    case Type::f32:
-      return Literal(getf32() == other.getf32());
-    case Type::f64:
-      return Literal(getf64() == other.getf64());
-    case Type::v128:
-    case Type::none:
-    case Type::unreachable:
-      WASM_UNREACHABLE("unexpected type");
+  if (type != other.type) {
+    return Literal(int32_t(0));
+  }
+  if (type.isBasic()) {
+    switch (type.getBasic()) {
+      case Type::i32:
+        return Literal(i32 == other.i32);
+      case Type::i64:
+        return Literal(i64 == other.i64);
+      case Type::f32:
+        return Literal(getf32() == other.getf32());
+      case Type::f64:
+        return Literal(getf64() == other.getf64());
+      case Type::v128:
+      case Type::none:
+      case Type::unreachable:
+        WASM_UNREACHABLE("unexpected type");
+    }
+  }
+  if (type.isRef()) {
+    return Literal(int32_t(*this == other));
   }
   WASM_UNREACHABLE("unexpected type");
 }
 
 Literal Literal::ne(const Literal& other) const {
-  switch (type.getBasic()) {
-    case Type::i32:
-      return Literal(i32 != other.i32);
-    case Type::i64:
-      return Literal(i64 != other.i64);
-    case Type::f32:
-      return Literal(getf32() != other.getf32());
-    case Type::f64:
-      return Literal(getf64() != other.getf64());
-    case Type::v128:
-    case Type::none:
-    case Type::unreachable:
-      WASM_UNREACHABLE("unexpected type");
+  if (type != other.type) {
+    return Literal(int32_t(1));
+  }
+  if (type.isBasic()) {
+    switch (type.getBasic()) {
+      case Type::i32:
+        return Literal(i32 != other.i32);
+      case Type::i64:
+        return Literal(i64 != other.i64);
+      case Type::f32:
+        return Literal(getf32() != other.getf32());
+      case Type::f64:
+        return Literal(getf64() != other.getf64());
+      case Type::v128:
+      case Type::none:
+      case Type::unreachable:
+        WASM_UNREACHABLE("unexpected type");
+    }
+  }
+  if (type.isRef()) {
+    return Literal(int32_t(*this != other));
   }
   WASM_UNREACHABLE("unexpected type");
 }

--- a/test/gtest/constraint.cpp
+++ b/test/gtest/constraint.cpp
@@ -1217,4 +1217,3 @@ TEST(ConstraintTest, FloatNaNContradiction) {
   t.approximateAnd({Ne, {Literal(float(NaN))}});
   EXPECT_FALSE(t.provesEverything());
 }
-

--- a/test/gtest/constraint.cpp
+++ b/test/gtest/constraint.cpp
@@ -1174,3 +1174,31 @@ TEST(ConstraintTest, GetSpanGC) {
   EXPECT_EQ((Constraint{Eq, {Literal::makeNull(HeapType::eq)}}.getSpan()),
             std::nullopt);
 }
+
+TEST(ConstraintTest, FloatNegativeZero) {
+  // f == 0.0 proves f == -0.0 is True.
+  AndedConstraintSet s;
+  s.set(Constraint{Eq, {Literal(double(0.0))}});
+  EXPECT_EQ(s.proves(Constraint{Eq, {Literal(double(-0.0))}}), True);
+  EXPECT_EQ(s.proves(Constraint{Ne, {Literal(double(-0.0))}}), False);
+  EXPECT_EQ(s.proves(Constraint{Eq, {Literal(double(1.0))}}), False);
+  EXPECT_EQ(s.proves(Constraint{Ne, {Literal(double(1.0))}}), True);
+
+  // f == -0.0 proves f == 0.0 is True.
+  AndedConstraintSet sNeg;
+  sNeg.set(Constraint{Eq, {Literal(double(-0.0))}});
+  EXPECT_EQ(sNeg.proves(Constraint{Eq, {Literal(double(0.0))}}), True);
+  EXPECT_EQ(sNeg.proves(Constraint{Ne, {Literal(double(0.0))}}), False);
+
+  // f != 0.0 proves f == -0.0 is False, and f != -0.0 is True.
+  AndedConstraintSet sNe;
+  sNe.set(Constraint{Ne, {Literal(double(0.0))}});
+  EXPECT_EQ(sNe.proves(Constraint{Eq, {Literal(double(-0.0))}}), False);
+  EXPECT_EQ(sNe.proves(Constraint{Ne, {Literal(double(-0.0))}}), True);
+
+  // Same for f32.
+  AndedConstraintSet s32;
+  s32.set(Constraint{Eq, {Literal(float(0.0f))}});
+  EXPECT_EQ(s32.proves(Constraint{Eq, {Literal(float(-0.0f))}}), True);
+  EXPECT_EQ(s32.proves(Constraint{Ne, {Literal(float(-0.0f))}}), False);
+}

--- a/test/gtest/constraint.cpp
+++ b/test/gtest/constraint.cpp
@@ -1202,18 +1202,3 @@ TEST(ConstraintTest, FloatNegativeZero) {
   EXPECT_EQ(s32.proves(Constraint{Eq, {Literal(float(-0.0f))}}), True);
   EXPECT_EQ(s32.proves(Constraint{Ne, {Literal(float(-0.0f))}}), False);
 }
-
-TEST(ConstraintTest, FloatNaNContradiction) {
-  // float == NaN is a contradiction, because x == NaN always returns false.
-  AndedConstraintSet s;
-  auto NaN = std::numeric_limits<float>::quiet_NaN();
-  s.setProvesNothing();
-  s.approximateAnd({Eq, {Literal(float(NaN))}});
-  EXPECT_TRUE(s.provesEverything());
-
-  // float != NaN is fine, though.
-  AndedConstraintSet t;
-  t.setProvesNothing();
-  t.approximateAnd({Ne, {Literal(float(NaN))}});
-  EXPECT_FALSE(t.provesEverything());
-}

--- a/test/gtest/constraint.cpp
+++ b/test/gtest/constraint.cpp
@@ -1202,3 +1202,19 @@ TEST(ConstraintTest, FloatNegativeZero) {
   EXPECT_EQ(s32.proves(Constraint{Eq, {Literal(float(-0.0f))}}), True);
   EXPECT_EQ(s32.proves(Constraint{Ne, {Literal(float(-0.0f))}}), False);
 }
+
+TEST(ConstraintTest, FloatNaNContradiction) {
+  // float == NaN is a contradiction, because x == NaN always returns false.
+  AndedConstraintSet s;
+  auto NaN = std::numeric_limits<float>::quiet_NaN();
+  s.setProvesNothing();
+  s.approximateAnd({Eq, {Literal(float(NaN))}});
+  EXPECT_TRUE(s.provesEverything());
+
+  // float != NaN is fine, though.
+  AndedConstraintSet t;
+  t.setProvesNothing();
+  t.approximateAnd({Ne, {Literal(float(NaN))}});
+  EXPECT_FALSE(t.provesEverything());
+}
+

--- a/test/lit/passes/constraint-analysis.wast
+++ b/test/lit/passes/constraint-analysis.wast
@@ -4556,6 +4556,60 @@
     )
   )
 
+  ;; CHECK:      (func $float-negative-zero (type $1)
+  ;; CHECK-NEXT:  (local $f f64)
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:   (then
+  ;; CHECK-NEXT:    (nop)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:   (then
+  ;; CHECK-NEXT:    (nop)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  ;; OPTIN:      (func $float-negative-zero (type $1)
+  ;; OPTIN-NEXT:  (local $f f64)
+  ;; OPTIN-NEXT:  (if
+  ;; OPTIN-NEXT:   (i32.const 0)
+  ;; OPTIN-NEXT:   (then
+  ;; OPTIN-NEXT:    (nop)
+  ;; OPTIN-NEXT:   )
+  ;; OPTIN-NEXT:  )
+  ;; OPTIN-NEXT:  (if
+  ;; OPTIN-NEXT:   (i32.const 1)
+  ;; OPTIN-NEXT:   (then
+  ;; OPTIN-NEXT:    (nop)
+  ;; OPTIN-NEXT:   )
+  ;; OPTIN-NEXT:  )
+  ;; OPTIN-NEXT: )
+  (func $float-negative-zero
+    (local $f f64)
+    ;; Negative zero is equal to zero, even though it has a different bit
+    ;; pattern. Both conditions here should be optimized to 1. FIXME
+    (if
+      (f64.eq
+        (local.get $f)
+        (f64.const -0)
+      )
+      (then
+        (nop)
+      )
+    )
+    (if
+      (f64.eq
+        (local.get $f)
+        (f64.const 0)
+      )
+      (then
+        (nop)
+      )
+    )
+  )
+
   ;; CHECK:      (func $tee (type $1)
   ;; CHECK-NEXT:  (local $x i32)
   ;; CHECK-NEXT:  (local $y i32)

--- a/test/lit/passes/constraint-analysis.wast
+++ b/test/lit/passes/constraint-analysis.wast
@@ -4559,7 +4559,7 @@
   ;; CHECK:      (func $float-negative-zero (type $1)
   ;; CHECK-NEXT:  (local $f f64)
   ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:   (i32.const 1)
   ;; CHECK-NEXT:   (then
   ;; CHECK-NEXT:    (nop)
   ;; CHECK-NEXT:   )
@@ -4574,7 +4574,7 @@
   ;; OPTIN:      (func $float-negative-zero (type $1)
   ;; OPTIN-NEXT:  (local $f f64)
   ;; OPTIN-NEXT:  (if
-  ;; OPTIN-NEXT:   (i32.const 0)
+  ;; OPTIN-NEXT:   (i32.const 1)
   ;; OPTIN-NEXT:   (then
   ;; OPTIN-NEXT:    (nop)
   ;; OPTIN-NEXT:   )
@@ -4589,7 +4589,7 @@
   (func $float-negative-zero
     (local $f f64)
     ;; Negative zero is equal to zero, even though it has a different bit
-    ;; pattern. Both conditions here should be optimized to 1. FIXME
+    ;; pattern. Both conditions here should be optimized to 1.
     (if
       (f64.eq
         (local.get $f)


### PR DESCRIPTION
We were doing `Literal == Literal`, but the right semantics are the wasm
ones that we are modelling, where `0 == -0` in floats, for example. Use
`Literal::eq` instead of `operator==`, and also make `Literal::eq` handle
refs properly.

As a drive-by, add `x == NaN` as an immediate contradiction.