### PR TITLE
ConstraintAnalysis: Track local copies through fallthrough values

### DIFF
--- a/src/passes/ConstraintAnalysis.cpp
+++ b/src/passes/ConstraintAnalysis.cpp
@@ -178,9 +178,28 @@ struct ConstraintAnalysis
 
   void visitLocalSet(LocalSet* curr) {
     addAction();
-    if (auto* get = curr->value->dynCast<LocalGet>()) {
-      // TODO: handle tees once we handle them elsewhere
-      localCopySources[curr->index].push_back(get->index);
+
+    auto* value = curr->value;
+    while (true) {
+      if (auto* get = value->dynCast<LocalGet>()) {
+        localCopySources[curr->index].push_back(get->index);
+        // No children to look into.
+        break;
+      }
+
+      if (auto* tee = value->dynCast<LocalSet>()) {
+        localCopySources[curr->index].push_back(tee->index);
+        value = tee->value;
+        continue;
+      }
+
+      // Look through block fallthroughs to other possible tees and gets.
+      auto* next = Properties::getImmediateFallthrough(
+        value, getPassOptions(), *getModule());
+      if (next == value) {
+        break;
+      }
+      value = next;
     }
   }
 

--- a/src/passes/ConstraintAnalysis.cpp
+++ b/src/passes/ConstraintAnalysis.cpp
@@ -193,7 +193,7 @@ struct ConstraintAnalysis
         continue;
       }
 
-      // Look through block fallthroughs to other possible tees and gets.
+      // Look for other possible tees and gets that fall through.
       auto* next = Properties::getImmediateFallthrough(
         value, getPassOptions(), *getModule());
       if (next == value) {

--- a/test/lit/passes/constraint-analysis.wast
+++ b/test/lit/passes/constraint-analysis.wast
@@ -4650,6 +4650,166 @@
     )
   )
 
+  ;; CHECK:      (func $fallthrough-get (type $1)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (local $z i32)
+  ;; CHECK-NEXT:  (local $w i32)
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (local.get $z)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.set $z
+  ;; CHECK-NEXT:   (i32.const 42)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.set $w
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (local.get $z)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.eq
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (local.get $w)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  ;; OPTIN:      (func $fallthrough-get (type $1)
+  ;; OPTIN-NEXT:  (local $x i32)
+  ;; OPTIN-NEXT:  (local $z i32)
+  ;; OPTIN-NEXT:  (local $w i32)
+  ;; OPTIN-NEXT:  (local.set $x
+  ;; OPTIN-NEXT:   (block (result i32)
+  ;; OPTIN-NEXT:    (local.get $z)
+  ;; OPTIN-NEXT:   )
+  ;; OPTIN-NEXT:  )
+  ;; OPTIN-NEXT:  (local.set $z
+  ;; OPTIN-NEXT:   (i32.const 42)
+  ;; OPTIN-NEXT:  )
+  ;; OPTIN-NEXT:  (local.set $w
+  ;; OPTIN-NEXT:   (block (result i32)
+  ;; OPTIN-NEXT:    (local.get $z)
+  ;; OPTIN-NEXT:   )
+  ;; OPTIN-NEXT:  )
+  ;; OPTIN-NEXT:  (drop
+  ;; OPTIN-NEXT:   (i32.eq
+  ;; OPTIN-NEXT:    (local.get $x)
+  ;; OPTIN-NEXT:    (local.get $w)
+  ;; OPTIN-NEXT:   )
+  ;; OPTIN-NEXT:  )
+  ;; OPTIN-NEXT: )
+  (func $fallthrough-get
+    (local $x i32)
+    (local $z i32)
+    (local $w i32)
+    ;; $x gets the initial value of $z (0) via block fallthrough. We should
+    ;; notice that $z is relevant, i.e., we need to track its values, even
+    ;; though we get it through a fallthrough and not directly.
+    (local.set $x
+      (block (result i32)
+        (local.get $z)
+      )
+    )
+
+    ;; $z is modified to 42.
+    (local.set $z (i32.const 42))
+
+    ;; $w gets the updated value of $z (42), also via block fallthrough.
+    (local.set $w
+      (block (result i32)
+        (local.get $z)
+      )
+    )
+
+    ;; 0 == 42 is 0 at runtime. If we did not mark $z as relevant, we would see
+    ;; $x and $w as both equal to $z, i.e., that they are themselves equal, and
+    ;; misoptimize this to 1. The actual value at runtime is 0.
+    ;; TODO: actually optimize this to 0
+    (drop
+      (i32.eq
+        (local.get $x)
+        (local.get $w)
+      )
+    )
+  )
+
+  ;; CHECK:      (func $fallthrough-tee (type $0) (param $param i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (local $z i32)
+  ;; CHECK-NEXT:  (local $w i32)
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (local.tee $param
+  ;; CHECK-NEXT:    (local.get $z)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.set $z
+  ;; CHECK-NEXT:   (i32.const 42)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.set $w
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (local.get $z)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.eq
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (local.get $w)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  ;; OPTIN:      (func $fallthrough-tee (type $0) (param $param i32)
+  ;; OPTIN-NEXT:  (local $x i32)
+  ;; OPTIN-NEXT:  (local $z i32)
+  ;; OPTIN-NEXT:  (local $w i32)
+  ;; OPTIN-NEXT:  (local.set $x
+  ;; OPTIN-NEXT:   (local.tee $param
+  ;; OPTIN-NEXT:    (local.get $z)
+  ;; OPTIN-NEXT:   )
+  ;; OPTIN-NEXT:  )
+  ;; OPTIN-NEXT:  (local.set $z
+  ;; OPTIN-NEXT:   (i32.const 42)
+  ;; OPTIN-NEXT:  )
+  ;; OPTIN-NEXT:  (local.set $w
+  ;; OPTIN-NEXT:   (block (result i32)
+  ;; OPTIN-NEXT:    (local.get $z)
+  ;; OPTIN-NEXT:   )
+  ;; OPTIN-NEXT:  )
+  ;; OPTIN-NEXT:  (drop
+  ;; OPTIN-NEXT:   (i32.eq
+  ;; OPTIN-NEXT:    (local.get $x)
+  ;; OPTIN-NEXT:    (local.get $w)
+  ;; OPTIN-NEXT:   )
+  ;; OPTIN-NEXT:  )
+  ;; OPTIN-NEXT: )
+  (func $fallthrough-tee (param $param i32)
+    (local $x i32)
+    (local $z i32)
+    (local $w i32)
+    ;; Similar to above, but now a tee is used for the fallthrough.
+    (local.set $x
+      (local.tee $param ;; this changed
+        (local.get $z)
+      )
+    )
+
+    (local.set $z (i32.const 42))
+
+    (local.set $w
+      (block (result i32)
+        (local.get $z)
+      )
+    )
+
+    ;; As before, this should not be optimized to 1, and could be optimized to
+    ;; 0 (TODO).
+    (drop
+      (i32.eq
+        (local.get $x)
+        (local.get $w)
+      )
+    )
+  )
+
   ;; CHECK:      (func $eqz-condition (type $0) (param $x i32)
   ;; CHECK-NEXT:  (if
   ;; CHECK-NEXT:   (i32.eqz


### PR DESCRIPTION
We did not track values flowing through, say, a block, and also did not track
tees. Copies can arise in those ways, and if we didn't notice them, we might
not realize a local's values matter (and when we think it doesn't matter, we
don't track its values, which can lead to misoptimizations).