### PR TITLE
Do not emit trailing whitespace on blank lines

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -3884,13 +3884,13 @@ static std::ostream& printStackIR(StackIR* ir, PrintSExpression& printer) {
     }
     switch (inst->op) {
       case StackInst::Basic: {
-        doIndent();
         // Pop is a pseudo instruction and should not be printed in the stack IR
         // format to make it valid wat form.
         if (inst->origin->is<Pop>()) {
-          break;
+          continue;
         }
 
+        doIndent();
         PrintExpressionContents(printer).visit(inst->origin);
         break;
       }

--- a/src/support/command-line.cpp
+++ b/src/support/command-line.cpp
@@ -48,14 +48,18 @@ void printWrap(std::ostream& os, int leftPad, const std::string& content) {
         space = SCREEN_WIDTH - leftPad;
       }
       os << nextWord;
-      space -= nextWord.size() + 1;
-      if (space > 0) {
-        os << ' ';
-      }
+      space -= nextWord.size();
       nextWord.clear();
-      if (content[i] == '\n') {
-        os << '\n';
-        space = SCREEN_WIDTH - leftPad;
+      if (i < len) {
+        if (content[i] == ' ') {
+          if (space > 0) {
+            os << ' ';
+            space -= 1;
+          }
+        } else if (content[i] == '\n') {
+          os << '\n';
+          space = SCREEN_WIDTH - leftPad;
+        }
       }
     }
   }

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -110,7 +110,7 @@ For more on how to optimize effectively, see
 
   https://github.com/WebAssembly/binaryen/wiki/Optimizer-Cookbook
   https://github.com/WebAssembly/binaryen/wiki/GC-Optimization-Guidebook
-                            )");
+)");
 
   options
     .add("--output",

--- a/src/tools/wasm-reduce/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce/wasm-reduce.cpp
@@ -1396,7 +1396,7 @@ Comparison to creduce:
 More documentation can be found at
 
   https://github.com/WebAssembly/binaryen/wiki/Fuzzing#reducing
-                      )");
+)");
   options
     .add("--command",
          "-cmd",

--- a/test/lit/passes/stack-ir-eh-legacy.wast
+++ b/test/lit/passes/stack-ir-eh-legacy.wast
@@ -11,7 +11,6 @@
   ;; CHECK-NEXT:   i32.const 0
   ;; CHECK-NEXT:   throw $e0
   ;; CHECK-NEXT:  catch $e0
-  ;; CHECK-NEXT:   
   ;; CHECK-NEXT:   drop
   ;; CHECK-NEXT:  catch_all
   ;; CHECK-NEXT:   rethrow $l0


### PR DESCRIPTION
- In printWrap, avoid printing trailing spaces before newlines and on empty lines.
- Remove whitespace indentation before closing parentheses on raw string literal tool descriptions in wasm-opt and wasm-reduce.
- In printStackIR, skip Pop pseudo-instructions before emitting indentation so that they do not produce empty lines with indentation.

The version of filecheck we currently use handles whitespace-only lines fine, but LLVM FileCheck and newer versions of Python filecheck require explicit `{{^ +$}}` regex matchers for such lines. It's nicer to just not emit whitespace-only lines in the first place if we want to upgrade our version of filecheck.
