### PR TITLE
Fast-math mode can ignore the difference between negative zero and zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Current Trunk
 - Replace the `BINARYEN_ROOT` environment variable (used by developers who are
   doing out-of-tree builds of binaryen) with `BINARYEN_BIN` (#9023)
 - Reject non-natural alignment for atomic memory operations at parse time (#8962)
+- Note that fast-math mode can ignore the difference between negative zero and
+  zero (like clang and gcc).
 
 v132
 ----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Current Trunk
   doing out-of-tree builds of binaryen) with `BINARYEN_BIN` (#9023)
 - Reject non-natural alignment for atomic memory operations at parse time (#8962)
 - Note that fast-math mode can ignore the difference between negative zero and
-  zero (like clang and gcc).
+  zero (like clang and gcc). (#9056)
 
 v132
 ----

--- a/src/tools/optimization-options.h
+++ b/src/tools/optimization-options.h
@@ -306,7 +306,8 @@ struct OptimizationOptions : public ToolOptions {
       .add(
         "--fast-math",
         "-ffm",
-        "Optimize floats without handling corner cases of NaNs and rounding",
+        "Optimize floats without handling corner cases of NaNs, rounding, and "
+        "negative zero",
         OptimizationOptionsCategory,
         Options::Arguments::Zero,
         [this](Options*, const std::string&) { passOptions.fastMath = true; })

--- a/test/lit/help/wasm-metadce.test
+++ b/test/lit/help/wasm-metadce.test
@@ -679,8 +679,8 @@
 ;; CHECK-NEXT:                                                 application
 ;; CHECK-EMPTY:
 ;; CHECK-NEXT:   --fast-math,-ffm                              Optimize floats without handling
-;; CHECK-NEXT:                                                 corner cases of NaNs and 
-;; CHECK-NEXT:                                                 rounding
+;; CHECK-NEXT:                                                 corner cases of NaNs, rounding, 
+;; CHECK-NEXT:                                                 and negative zero
 ;; CHECK-EMPTY:
 ;; CHECK-NEXT:   --zero-filled-memory,-uim                     Assume that an imported memory 
 ;; CHECK-NEXT:                                                 will be zero-initialized

--- a/test/lit/help/wasm-opt.test
+++ b/test/lit/help/wasm-opt.test
@@ -715,8 +715,8 @@
 ;; CHECK-NEXT:                                                 application
 ;; CHECK-EMPTY:
 ;; CHECK-NEXT:   --fast-math,-ffm                              Optimize floats without handling
-;; CHECK-NEXT:                                                 corner cases of NaNs and 
-;; CHECK-NEXT:                                                 rounding
+;; CHECK-NEXT:                                                 corner cases of NaNs, rounding, 
+;; CHECK-NEXT:                                                 and negative zero
 ;; CHECK-EMPTY:
 ;; CHECK-NEXT:   --zero-filled-memory,-uim                     Assume that an imported memory 
 ;; CHECK-NEXT:                                                 will be zero-initialized

--- a/test/lit/help/wasm2js.test
+++ b/test/lit/help/wasm2js.test
@@ -643,8 +643,8 @@
 ;; CHECK-NEXT:                                                 application
 ;; CHECK-EMPTY:
 ;; CHECK-NEXT:   --fast-math,-ffm                              Optimize floats without handling
-;; CHECK-NEXT:                                                 corner cases of NaNs and 
-;; CHECK-NEXT:                                                 rounding
+;; CHECK-NEXT:                                                 corner cases of NaNs, rounding, 
+;; CHECK-NEXT:                                                 and negative zero
 ;; CHECK-EMPTY:
 ;; CHECK-NEXT:   --zero-filled-memory,-uim                     Assume that an imported memory 
 ;; CHECK-NEXT:                                                 will be zero-initialized


### PR DESCRIPTION
This is a standard part of `fast-math` in clang and gcc:

https://clang.llvm.org/docs/UsersManual.html#cmdoption-ffast-math

We may have already been optimizing it, I'm not sure, but a later
PR will do so, so it seems worth documenting explicitly.