### PR TITLE
Update to filecheck 1.0.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,11 +56,6 @@ jobs:
         # currently macos-13, but unfortunately that doesn't exist in github
         # actions so we settle for macos-14.
         os: [ubuntu-22.04, ubuntu-latest, macos-14, windows-latest, windows-11-arm]
-    env:
-      # Enable UTF-8 mode for Python on Windows. This is required for filecheck
-      # 1.0.3 to handle Unicode filenames/checks and should be unnecessary in
-      # future versions of filecheck.
-      PYTHONUTF8: 1
     steps:
     - uses: actions/setup-python@v5
       with:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,5 @@
 # Install with `pip3 install -r requirements-dev.txt`
 
 ruff==0.16.0
-filecheck==1.0.3
+filecheck==1.0.5
 lit==0.11.0.post1


### PR DESCRIPTION
Remove the PYTHONUTF8 variable from the Windows CI because the new filecheck version handles UTF-8 correcty by default.
