### PR TITLE
Increase ConstraintAnalysis limit on basic block computations

### DIFF
--- a/src/passes/ConstraintAnalysis.cpp
+++ b/src/passes/ConstraintAnalysis.cpp
@@ -622,8 +622,10 @@ struct ConstraintAnalysis
         // of a bug (as assert is easier to diagnose, even if it happens after a
         // long delay).
         auto& count = binaryActionCounts[binary];
+#ifndef NDEBUG
         static const Index MaxBasicBlockActions = 1024 * 1024;
         assert(count < MaxBasicBlockActions);
+#endif
         count++;
         if (count >= MaxBinaryActions) {
           constraints.setProvesNothing(set->index);

--- a/src/passes/ConstraintAnalysis.cpp
+++ b/src/passes/ConstraintAnalysis.cpp
@@ -616,11 +616,8 @@ struct ConstraintAnalysis
         // MaxBinaryActions operations on it. That is enough to prevent
         // unbounded work on this binary, however, we may end up reaching this
         // basic block an even larger number of times for other reasons, i.e.,
-        // just because of a very complex CFG. That should be very rare, but we
-        // do not want to put an arbitrary limit on how many times we reach a
-        // binary. We do put a huge limit, however, on the number of times we
-        // reach this code for a particular binary (which is the number of
-        // times we reach the basic block); asserting on that is meant to throw
+        // just because of a very complex CFG. That should be very rare, but can
+        // happen. We do put a very high limit on it, though, intending to throw
         // an assert rather than just hang in the case of a bug (as assert is
         // easier to diagnose, even if it happens after a long delay).
         auto& count = binaryActionCounts[binary];

--- a/src/passes/ConstraintAnalysis.cpp
+++ b/src/passes/ConstraintAnalysis.cpp
@@ -617,9 +617,10 @@ struct ConstraintAnalysis
         // unbounded work on this binary, however, we may end up reaching this
         // basic block an even larger number of times for other reasons, i.e.,
         // just because of a very complex CFG. That should be very rare, but can
-        // happen. We do put a very high limit on it, though, intending to throw
-        // an assert rather than just hang in the case of a bug (as assert is
-        // easier to diagnose, even if it happens after a long delay).
+        // happen. In debug builds we check we do not exceed a very high limit
+        // there, intending to throw an assert rather than just hang in the case
+        // of a bug (as assert is easier to diagnose, even if it happens after a
+        // long delay).
         auto& count = binaryActionCounts[binary];
         static const Index MaxBasicBlockActions = 1024 * 1024;
         assert(count < MaxBasicBlockActions);

--- a/src/passes/ConstraintAnalysis.cpp
+++ b/src/passes/ConstraintAnalysis.cpp
@@ -612,10 +612,20 @@ struct ConstraintAnalysis
       // Now that we know the value, check binary action counting limits (see
       // above).
       if (auto* binary = value->dynCast<Binary>()) {
-        // The count may exceed the limit sometimes, but add a hard assert on
-        // never going up so high it is likely doing an unbounded computation.
+        // The code below will stop calculating this binary once we pass
+        // MaxBinaryActions operations on it. That is enough to prevent
+        // unbounded work on this binary, however, we may end up reaching this
+        // basic block an even larger number of times for other reasons, i.e.,
+        // just because of a very complex CFG. That should be very rare, but we
+        // do not want to put an arbitrary limit on how many times we reach a
+        // binary. We do put a huge limit, however, on the number of times we
+        // reach this code for a particular binary (which is the number of
+        // times we reach the basic block); asserting on that is meant to throw
+        // an assert rather than just hang in the case of a bug (as assert is
+        // easier to diagnose, even if it happens after a long delay).
         auto& count = binaryActionCounts[binary];
-        assert(count < MaxBinaryActions * 10);
+        static const Index MaxBasicBlockActions = 1024 * 1024;
+        assert(count < MaxBasicBlockActions);
         count++;
         if (count >= MaxBinaryActions) {
           constraints.setProvesNothing(set->index);


### PR DESCRIPTION
`10 * MaxBinaryActions` is far too low, as CFGs can be complex enough to
hit that. Use something far, far higher, unlikely to ever be seen in practice,
but enough to assert instead of hanging, in case we have a bug.