### PR TITLE
Fix 64-bit safe integer boundary checks

### DIFF
--- a/src/support/safe_integer.cpp
+++ b/src/support/safe_integer.cpp
@@ -50,13 +50,11 @@ int32_t wasm::toSInteger32(double x) {
 }
 
 bool wasm::isUInteger64(double x) {
-  return !std::signbit(x) && isInteger(x) &&
-         x <= static_cast<double>(std::numeric_limits<uint64_t>::max());
+  return !std::signbit(x) && isInteger(x) && x < 0x1p64;
 }
 
 bool wasm::isSInteger64(double x) {
-  return isInteger(x) && x >= std::numeric_limits<int64_t>::min() &&
-         x <= static_cast<double>(std::numeric_limits<int64_t>::max());
+  return isInteger(x) && x >= -0x1p63 && x < 0x1p63;
 }
 
 uint64_t wasm::toUInteger64(double x) {

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -31,6 +31,7 @@ set(unittest_SOURCES
   principal-type.cpp
   printing.cpp
   public-type-validator.cpp
+  safe-integer.cpp
   scc.cpp
   sizes.cpp
   span.cpp

--- a/test/gtest/safe-integer.cpp
+++ b/test/gtest/safe-integer.cpp
@@ -1,0 +1,19 @@
+#include <cmath>
+#include <limits>
+
+#include "support/safe_integer.h"
+#include "gtest/gtest.h"
+
+TEST(SafeInteger, Unsigned64Boundaries) {
+  EXPECT_TRUE(wasm::isUInteger64(std::nextafter(0x1p64, 0.0)));
+  EXPECT_FALSE(wasm::isUInteger64(0x1p64));
+  EXPECT_FALSE(wasm::isUInteger64(-0.0));
+}
+
+TEST(SafeInteger, Signed64Boundaries) {
+  EXPECT_FALSE(wasm::isSInteger64(
+    std::nextafter(-0x1p63, -std::numeric_limits<double>::infinity())));
+  EXPECT_TRUE(wasm::isSInteger64(-0x1p63));
+  EXPECT_TRUE(wasm::isSInteger64(std::nextafter(0x1p63, 0.0)));
+  EXPECT_FALSE(wasm::isSInteger64(0x1p63));
+}

--- a/test/lit/passes/inlining-optimizing_optimize-level=3.wast
+++ b/test/lit/passes/inlining-optimizing_optimize-level=3.wast
@@ -693,7 +693,7 @@
  ;; CHECK-NEXT:          (call $_frexp
  ;; CHECK-NEXT:           (f64.mul
  ;; CHECK-NEXT:            (local.get $0)
- ;; CHECK-NEXT:            (f64.const 18446744073709551615)
+ ;; CHECK-NEXT:            (f64.const 18446744073709551616)
  ;; CHECK-NEXT:           )
  ;; CHECK-NEXT:           (local.get $1)
  ;; CHECK-NEXT:          )
@@ -793,7 +793,7 @@
            (call $_frexp
             (f64.mul
              (local.get $0)
-             (f64.const 18446744073709551615)
+             (f64.const 18446744073709551616)
             )
             (local.get $1)
            )

--- a/test/lit/passes/nontrapping-fptoint-lowering.wast
+++ b/test/lit/passes/nontrapping-fptoint-lowering.wast
@@ -127,7 +127,7 @@
  ;; CHECK-NEXT:      (local.tee $7
  ;; CHECK-NEXT:       (local.get $0)
  ;; CHECK-NEXT:      )
- ;; CHECK-NEXT:      (f32.const 18446744073709551615)
+ ;; CHECK-NEXT:      (f32.const 18446744073709551616)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:     (f32.ge
  ;; CHECK-NEXT:      (local.get $7)
@@ -175,7 +175,7 @@
  ;; CHECK-NEXT:      (local.tee $9
  ;; CHECK-NEXT:       (local.get $1)
  ;; CHECK-NEXT:      )
- ;; CHECK-NEXT:      (f64.const 18446744073709551615)
+ ;; CHECK-NEXT:      (f64.const 18446744073709551616)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:     (f64.ge
  ;; CHECK-NEXT:      (local.get $9)


### PR DESCRIPTION
## Summary

- compare 64-bit integer inputs against exact, exclusive power-of-two boundaries
- avoid rounding `INT64_MAX` and `UINT64_MAX` to out-of-range `double` values
- cover the adjacent representable values on both sides of the signed and unsigned limits

Closes #2291.

## Testing

- `./out/build/bin/binaryen-unittests --gtest_filter=SafeInteger.*` (2 passed)
- `./out/build/bin/binaryen-unittests` (422 passed)