### PR TITLE
[JS API] support heap type `none`

### DIFF
--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -29,7 +29,7 @@ function i8sToStack(i8s) {
 function initializeConstants() {
 
   // Types
-  [ ['none', 'None'],
+  [ ['void', 'None'],
     ['i32', 'Int32'],
     ['i64', 'Int64'],
     ['f32', 'Float32'],
@@ -61,11 +61,7 @@ function initializeConstants() {
     ['struct', 'Struct'],
     ['array', 'Array'],
     ['string', 'String'],
-    /*
-    TODO: Reconcile with `none` above (line 32).
-    Maybe keep this as 'none' and change the above to 'void'?
     ['none', 'None'],
-    */
     ['noextern', 'Noext'],
     ['nofunc', 'Nofunc'],
   ].forEach(entry => {
@@ -708,7 +704,7 @@ function wrapModule(module, self = {}) {
     return preserveStack(() =>
       Module['_BinaryenBlock'](module, name ? strToStack(name) : 0,
                                i32sToStack(children), children.length,
-                               typeof type !== 'undefined' ? type : Module['none'])
+                               typeof type !== 'undefined' ? type : Module['void'])
     );
   };
   self['if'] = function(condition, ifTrue, ifFalse) {

--- a/test/binaryen.js/atomics.js
+++ b/test/binaryen.js/atomics.js
@@ -7,7 +7,7 @@ var wast = `
 var module = binaryen.parseText(wast);
 
 // i32/i64.atomic.load/store
-module.addFunction("main", binaryen.none, binaryen.none, [], module.block("", [
+module.addFunction("main", binaryen.void, binaryen.void, [], module.block("", [
   // i32
   module.i32.atomic.store(0,
     module.i32.const(0),

--- a/test/binaryen.js/exception-handling.js
+++ b/test/binaryen.js/exception-handling.js
@@ -19,7 +19,7 @@ var module = new binaryen.Module();
 module.setFeatures(binaryen.Features.ReferenceTypes |
                    binaryen.Features.ExceptionHandling);
 
-module.addTag("e", binaryen.i32, binaryen.none);
+module.addTag("e", binaryen.i32, binaryen.void);
 
 // (try $l0
 //   (do
@@ -42,7 +42,7 @@ var try_catch = module.try(
         module.drop(module.i32.pop()),
         rethrow
       ],
-      binaryen.none
+      binaryen.void
     )
   ],
   ''
@@ -74,7 +74,7 @@ var try_delegate = module.try(
 );
 
 var body = module.block('', [try_catch, try_delegate])
-var func = module.addFunction("test", binaryen.none, binaryen.none, [], body);
+var func = module.addFunction("test", binaryen.void, binaryen.void, [], body);
 
 console.log(module.emitText());
 assert(module.validate());

--- a/test/binaryen.js/expressions.js
+++ b/test/binaryen.js/expressions.js
@@ -35,7 +35,7 @@ console.log("# Block");
   assert(theBlock instanceof binaryen.Expression);
   assert(theBlock.id === binaryen.BlockId);
   assert(theBlock.name === null);
-  assert(theBlock.type === binaryen.none);
+  assert(theBlock.type === binaryen.void);
   
   var info = binaryen.getExpressionInfo(theBlock);
   assert(info.id === theBlock.id);
@@ -181,7 +181,7 @@ console.log("# Loop");
   theLoop.body = body = module.drop(body);
   assert(theLoop.body === body);
   theLoop.finalize();
-  assert(theLoop.type === binaryen.none);
+  assert(theLoop.type === binaryen.void);
 
   info = binaryen.getExpressionInfo(theLoop);
   assert(info.type === theLoop.type);
@@ -383,8 +383,8 @@ console.log("# CallIndirect");
 
   var table = "0";
   var target = module.i32.const(42);
-  var params = binaryen.none;
-  var results = binaryen.none;
+  var params = binaryen.void;
+  var results = binaryen.void;
   var operands = [
     module.i32.const(1),
     module.i32.const(2)
@@ -510,7 +510,7 @@ console.log("# LocalSet");
   assert(theLocalSet.index === index);
   assert(theLocalSet.value === value);
   assert(theLocalSet.tee === false);
-  assert(theLocalSet.type == binaryen.none);
+  assert(theLocalSet.type == binaryen.void);
 
   var info = binaryen.getExpressionInfo(theLocalSet);
   assert(info.id === theLocalSet.id);
@@ -526,7 +526,7 @@ console.log("# LocalSet");
   theLocalSet.type = binaryen.i32;
   assert(theLocalSet.type === binaryen.i32);
   assert(theLocalSet.tee === true);
-  theLocalSet.type = binaryen.none;
+  theLocalSet.type = binaryen.void;
   theLocalSet.finalize();
 
   info = binaryen.getExpressionInfo(theLocalSet);
@@ -593,7 +593,7 @@ console.log("# GlobalSet");
   assert(theGlobalSet instanceof binaryen.Expression);
   assert(theGlobalSet.name === name);
   assert(theGlobalSet.value === value);
-  assert(theGlobalSet.type == binaryen.none);
+  assert(theGlobalSet.type == binaryen.void);
 
   var info = binaryen.getExpressionInfo(theGlobalSet);
   assert(info.id === theGlobalSet.id);
@@ -764,7 +764,7 @@ console.log("# Store");
   assert(theStore.bytes === 4);
   assert(theStore.atomic === false);
   assert(theStore.valueType === binaryen.i32);
-  assert(theStore.type === binaryen.none);
+  assert(theStore.type === binaryen.void);
 
   var info = binaryen.getExpressionInfo(theStore);
   assert(info.id === theStore.id);
@@ -1088,7 +1088,7 @@ console.log("# Drop");
   assert(theDrop instanceof binaryen.Drop);
   assert(theDrop instanceof binaryen.Expression);
   assert(theDrop.value === value);
-  assert(theDrop.type === binaryen.none);
+  assert(theDrop.type === binaryen.void);
 
   var info = binaryen.getExpressionInfo(theDrop);
   assert(info.id === theDrop.id);
@@ -1099,7 +1099,7 @@ console.log("# Drop");
   assert(theDrop.value === value);
 
   theDrop.finalize();
-  assert(theDrop.type === binaryen.none);
+  assert(theDrop.type === binaryen.void);
 
   info = binaryen.getExpressionInfo(theDrop);
   assert(info.type === theDrop.type);
@@ -1376,7 +1376,7 @@ console.log("# AtomicFence");
   assert(theAtomicFence instanceof binaryen.AtomicFence);
   assert(theAtomicFence instanceof binaryen.Expression);
   assert(theAtomicFence.order === binaryen.MemoryOrder.seqcst);
-  assert(theAtomicFence.type === binaryen.none);
+  assert(theAtomicFence.type === binaryen.void);
 
   var info = binaryen.getExpressionInfo(theAtomicFence);
   assert(info.id === theAtomicFence.id);
@@ -1756,7 +1756,7 @@ console.log("# SIMDLoadStoreLane");
   theSIMDLoadStoreLane.type = binaryen.f64;
   assert(theSIMDLoadStoreLane.store === true);
   theSIMDLoadStoreLane.finalize();
-  assert(theSIMDLoadStoreLane.type === binaryen.none);
+  assert(theSIMDLoadStoreLane.type === binaryen.void);
 
   info = binaryen.getExpressionInfo(theSIMDLoadStoreLane);
   assert(info.type === theSIMDLoadStoreLane.type);
@@ -1789,7 +1789,7 @@ console.log("# MemoryInit");
   assert(theMemoryInit.dest === dest);
   assert(theMemoryInit.offset === offset);
   assert(theMemoryInit.size === size);
-  assert(theMemoryInit.type === binaryen.none);
+  assert(theMemoryInit.type === binaryen.void);
 
   var info = binaryen.getExpressionInfo(theMemoryInit);
   assert(info.id === theMemoryInit.id);
@@ -1809,7 +1809,7 @@ console.log("# MemoryInit");
   assert(theMemoryInit.size === size);
   theMemoryInit.type = binaryen.f64;
   theMemoryInit.finalize();
-  assert(theMemoryInit.type === binaryen.none);
+  assert(theMemoryInit.type === binaryen.void);
 
   info = binaryen.getExpressionInfo(theMemoryInit);
   assert(info.type === theMemoryInit.type);
@@ -1837,7 +1837,7 @@ console.log("# DataDrop");
   assert(theDataDrop instanceof binaryen.DataDrop);
   assert(theDataDrop instanceof binaryen.Expression);
   assert(theDataDrop.segment === segment);
-  assert(theDataDrop.type === binaryen.none);
+  assert(theDataDrop.type === binaryen.void);
 
   var info = binaryen.getExpressionInfo(theDataDrop);
   assert(info.id === theDataDrop.id);
@@ -1848,7 +1848,7 @@ console.log("# DataDrop");
   assert(theDataDrop.segment === "2");
   theDataDrop.type = binaryen.f64;
   theDataDrop.finalize();
-  assert(theDataDrop.type === binaryen.none);
+  assert(theDataDrop.type === binaryen.void);
 
   info = binaryen.getExpressionInfo(theDataDrop);
   assert(info.type === theDataDrop.type);
@@ -1878,7 +1878,7 @@ console.log("# MemoryCopy");
   assert(theMemoryCopy.dest === dest);
   assert(theMemoryCopy.source === source);
   assert(theMemoryCopy.size === size);
-  assert(theMemoryCopy.type === binaryen.none);
+  assert(theMemoryCopy.type === binaryen.void);
 
   var info = binaryen.getExpressionInfo(theMemoryCopy);
   assert(info.id === theMemoryCopy.id);
@@ -1895,7 +1895,7 @@ console.log("# MemoryCopy");
   assert(theMemoryCopy.size === size);
   theMemoryCopy.type = binaryen.f64;
   theMemoryCopy.finalize();
-  assert(theMemoryCopy.type === binaryen.none);
+  assert(theMemoryCopy.type === binaryen.void);
 
   info = binaryen.getExpressionInfo(theMemoryCopy);
   assert(info.type === theMemoryCopy.type);
@@ -1927,7 +1927,7 @@ console.log("# MemoryFill");
   assert(theMemoryFill.dest === dest);
   assert(theMemoryFill.value === value);
   assert(theMemoryFill.size === size);
-  assert(theMemoryFill.type === binaryen.none);
+  assert(theMemoryFill.type === binaryen.void);
 
   var info = binaryen.getExpressionInfo(theMemoryFill);
   assert(info.id === theMemoryFill.id);
@@ -1944,7 +1944,7 @@ console.log("# MemoryFill");
   assert(theMemoryFill.size === size);
   theMemoryFill.type = binaryen.f64;
   theMemoryFill.finalize();
-  assert(theMemoryFill.type === binaryen.none);
+  assert(theMemoryFill.type === binaryen.void);
 
   info = binaryen.getExpressionInfo(theMemoryFill);
   assert(info.type === theMemoryFill.type);
@@ -2047,7 +2047,7 @@ console.log("# RefAs");
 console.log("# RefFunc");
 (function testRefFunc() {
   const module = new binaryen.Module();
-  module.addFunction("a", binaryen.none, binaryen.none, [], module.nop());
+  module.addFunction("a", binaryen.void, binaryen.void, [], module.nop());
   var type = binaryen.Function(module.getFunction("a")).type;
 
   var func = "a";
@@ -2411,7 +2411,7 @@ console.log("# StructSet");
   assert(theStructSet.index === index);
   assert(theStructSet.ref === ref);
   assert(theStructSet.value === value);
-  assert(theStructSet.type === binaryen.none);
+  assert(theStructSet.type === binaryen.void);
 
   var info = binaryen.getExpressionInfo(theStructSet);
   assert(info.id === theStructSet.id);
@@ -2428,7 +2428,7 @@ console.log("# StructSet");
   assert(theStructSet.value === value);
   theStructSet.type = binaryen.f64;
   theStructSet.finalize();
-  assert(theStructSet.type === binaryen.none);
+  assert(theStructSet.type === binaryen.void);
 
   info = binaryen.getExpressionInfo(theStructSet);
   assert(info.type === theStructSet.type);
@@ -2836,7 +2836,7 @@ console.log("# ArraySet");
   assert(theArraySet.ref === ref);
   assert(theArraySet.index === index);
   assert(theArraySet.value === value);
-  assert(theArraySet.type === binaryen.none);
+  assert(theArraySet.type === binaryen.void);
 
   var info = binaryen.getExpressionInfo(theArraySet);
   assert(info.id === theArraySet.id);
@@ -2853,7 +2853,7 @@ console.log("# ArraySet");
   assert(theArraySet.value === value);
   theArraySet.type = binaryen.i64;
   theArraySet.finalize();
-  assert(theArraySet.type === binaryen.none);
+  assert(theArraySet.type === binaryen.void);
 
   info = binaryen.getExpressionInfo(theArraySet);
   assert(info.type === theArraySet.type);
@@ -2938,7 +2938,7 @@ console.log("# ArrayFill");
   assert(theArrayFill.index === index);
   assert(theArrayFill.value === value);
   assert(theArrayFill.size === size);
-  assert(theArrayFill.type === binaryen.none);
+  assert(theArrayFill.type === binaryen.void);
 
   var info = binaryen.getExpressionInfo(theArrayFill);
   assert(info.id === theArrayFill.id);
@@ -2958,7 +2958,7 @@ console.log("# ArrayFill");
   assert(theArrayFill.size === size);
   theArrayFill.type = binaryen.i64;
   theArrayFill.finalize();
-  assert(theArrayFill.type === binaryen.none);
+  assert(theArrayFill.type === binaryen.void);
 
   info = binaryen.getExpressionInfo(theArrayFill);
   assert(info.type === theArrayFill.type);
@@ -3002,7 +3002,7 @@ console.log("# ArrayCopy");
   assert(theArrayCopy.srcRef === srcRef);
   assert(theArrayCopy.srcIndex === srcIndex);
   assert(theArrayCopy.length === length);
-  assert(theArrayCopy.type === binaryen.none);
+  assert(theArrayCopy.type === binaryen.void);
 
   var info = binaryen.getExpressionInfo(theArrayCopy);
   assert(info.id === theArrayCopy.id);
@@ -3025,7 +3025,7 @@ console.log("# ArrayCopy");
   assert(theArrayCopy.length === length);
   theArrayCopy.type = binaryen.i64;
   theArrayCopy.finalize();
-  assert(theArrayCopy.type === binaryen.none);
+  assert(theArrayCopy.type === binaryen.void);
 
   info = binaryen.getExpressionInfo(theArrayCopy);
   assert(info.type === theArrayCopy.type);
@@ -3070,7 +3070,7 @@ console.log("# ArrayInitData");
   assert(theArrayInitData.index === index);
   assert(theArrayInitData.offset === offset);
   assert(theArrayInitData.size === size);
-  assert(theArrayInitData.type === binaryen.none);
+  assert(theArrayInitData.type === binaryen.void);
   
   var info = binaryen.getExpressionInfo(theArrayInitData);
   assert(info.id === theArrayInitData.id);
@@ -3093,7 +3093,7 @@ console.log("# ArrayInitData");
   assert(theArrayInitData.size === size);
   theArrayInitData.type = binaryen.i64;
   theArrayInitData.finalize();
-  assert(theArrayInitData.type === binaryen.none);
+  assert(theArrayInitData.type === binaryen.void);
 
   info = binaryen.getExpressionInfo(theArrayInitData);
   assert(info.type === theArrayInitData.type);
@@ -3138,7 +3138,7 @@ console.log("# ArrayInitElem");
   assert(theArrayInitElem.index === index);
   assert(theArrayInitElem.offset === offset);
   assert(theArrayInitElem.size === size);
-  assert(theArrayInitElem.type === binaryen.none);
+  assert(theArrayInitElem.type === binaryen.void);
 
   var info = binaryen.getExpressionInfo(theArrayInitElem);
   assert(info.id === theArrayInitElem.id);
@@ -3161,7 +3161,7 @@ console.log("# ArrayInitElem");
   assert(theArrayInitElem.size === size);
   theArrayInitElem.type = binaryen.i64;
   theArrayInitElem.finalize();
-  assert(theArrayInitElem.type === binaryen.none);
+  assert(theArrayInitElem.type === binaryen.void);
 
   info = binaryen.getExpressionInfo(theArrayInitElem);
   assert(info.type === theArrayInitElem.type);
@@ -3184,9 +3184,9 @@ console.log("# ArrayInitElem");
 console.log("# Try");
 (function testTry() {
   const module = new binaryen.Module();
-  module.addTag("tag1", 0, binaryen.none, binaryen.none);
-  module.addTag("tag2", 0, binaryen.none, binaryen.none);
-  module.addTag("tag3", 0, binaryen.none, binaryen.none);
+  module.addTag("tag1", 0, binaryen.void, binaryen.void);
+  module.addTag("tag2", 0, binaryen.void, binaryen.void);
+  module.addTag("tag3", 0, binaryen.void, binaryen.void);
 
   var body = module.i32.const(1);
   var catchBodies = [
@@ -3557,7 +3557,7 @@ console.log("# CallRef");
   const module = new binaryen.Module();
 
   const funcName = "tiny";
-  module.addFunction(funcName, binaryen.createType([binaryen.i32, binaryen.i32]), binaryen.none, [], module.nop());
+  module.addFunction(funcName, binaryen.createType([binaryen.i32, binaryen.i32]), binaryen.void, [], module.nop());
   const funcType = binaryen.Function(module.getFunction(funcName)).type;
   const funcRef = binaryen.RefFunc(module.ref.func(funcName, funcType));
 
@@ -3566,11 +3566,11 @@ console.log("# CallRef");
     module.i32.const(7)
   ];
 
-  const theCallRef = binaryen.CallRef(module.call_ref(funcRef, operands, binaryen.none));
+  const theCallRef = binaryen.CallRef(module.call_ref(funcRef, operands, binaryen.void));
   assert(theCallRef instanceof binaryen.CallRef);
   assert(theCallRef instanceof binaryen.Expression);
   assert(theCallRef.numOperands === operands.length);
-  assert(theCallRef.type === binaryen.none);
+  assert(theCallRef.type === binaryen.void);
   assert(binaryen.RefFunc(theCallRef.target).func === funcName);
 
   const info = binaryen.getExpressionInfo(theCallRef);
@@ -3616,7 +3616,7 @@ console.log("# CallRef");
   theCallRef.setReturn(false);
   assert(theCallRef.isReturn() === false);
 
-  const theReturnCallRef = binaryen.CallRef(module.return_call_ref(funcRef, operands, binaryen.none));
+  const theReturnCallRef = binaryen.CallRef(module.return_call_ref(funcRef, operands, binaryen.void));
   assert(theReturnCallRef instanceof binaryen.CallRef);
   assert(theReturnCallRef instanceof binaryen.Expression);
   assert(theReturnCallRef.numOperands === operands.length);

--- a/test/binaryen.js/functions.js
+++ b/test/binaryen.js/functions.js
@@ -10,7 +10,7 @@ function cleanInfo(info) {
 
 var module = new binaryen.Module();
 
-var func = module.addFunction("a-function", binaryen.none, binaryen.i32, [],
+var func = module.addFunction("a-function", binaryen.void, binaryen.i32, [],
   module.i32.add(
     module.i32.const(1),
     module.i32.const(2)

--- a/test/binaryen.js/gc.js
+++ b/test/binaryen.js/gc.js
@@ -1,5 +1,5 @@
 var builder = new binaryen.TypeBuilder(4);
-builder.setSignatureType(0, binaryen.createType([binaryen.i32]), binaryen.none);
+builder.setSignatureType(0, binaryen.createType([binaryen.i32]), binaryen.void);
 builder.setStructType(1, [
   { type: binaryen.i32, packedType: binaryen.i16, mutable: true },
   { type: binaryen.f64, packedType: binaryen.notPacked, mutable: true }
@@ -162,17 +162,17 @@ var valueList = [
   // string
   module.string.const("hello 🌎"),
 ];
-module.addFunction("main", binaryen.none, binaryen.none, [],
+module.addFunction("main", binaryen.void, binaryen.void, [],
   module.block(
     null,
     valueList.map(value => {
       var type = binaryen.getExpressionType(value);
-      if (type === binaryen.none || type === binaryen.unreachable)
+      if (type === binaryen.void || type === binaryen.unreachable)
         return value;
       else
         return module.drop(value);
     }),
-    binaryen.none
+    binaryen.void
   )
 );
 

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -47,8 +47,8 @@ function makeDroppedInt32(x) {
 // tests
 
 function test_types() {
-  console.log("  // BinaryenTypeNone: " + binaryen.none);
-  console.log("  //", binaryen.expandType(binaryen.none).join(","));
+  console.log("  // BinaryenTypeNone: " + binaryen.void);
+  console.log("  //", binaryen.expandType(binaryen.void).join(","));
 
   console.log("  // BinaryenTypeUnreachable: " + binaryen.unreachable);
   console.log("  //", binaryen.expandType(binaryen.unreachable).join(","));
@@ -210,7 +210,7 @@ function test_core() {
   ], true);
 
   // Create a tag
-  var tag = module.addTag("a-tag", binaryen.i32, binaryen.none);
+  var tag = module.addTag("a-tag", binaryen.i32, binaryen.void);
 
   // Literals and consts
 
@@ -709,7 +709,7 @@ function test_core() {
   // Add drops of concrete expressions, except the last.
   for (var i = 0; i < valueList.length - 1; i++) {
     var type = binaryen.Expression.getType(valueList[i]);
-    if (type != binaryen.none && type != binaryen.unreachable) {
+    if (type != binaryen.void && type != binaryen.unreachable) {
       valueList[i] = module.drop(valueList[i]);
     }
   }
@@ -753,7 +753,7 @@ function test_core() {
   module.addFunctionImport("an-imported", "module", "base", iF, binaryen.f32);
   module.addGlobalImport("a-global-imp", "module", "base", binaryen.i32, false);
   module.addGlobalImport("a-mut-global-imp", "module", "base", binaryen.i32, true);
-  module.addTagImport("a-tag-imp", "module", "base", binaryen.i32, binaryen.none);
+  module.addTagImport("a-tag-imp", "module", "base", binaryen.i32, binaryen.void);
 
   // Exports
 
@@ -778,7 +778,7 @@ function test_core() {
   module.addTable("t2", 1, 1, binaryen.i31ref, module.ref.i31(module.i32.const(1)));
 
   // Start function. One per module
-  var starter = module.addFunction("starter", binaryen.none, binaryen.none, [], module.nop());
+  var starter = module.addFunction("starter", binaryen.void, binaryen.void, [], module.nop());
   module.setStart(starter);
   assert(module.getStart() == starter);
 
@@ -797,20 +797,20 @@ function test_core() {
 }
 
 function makeCallCheck(x) {
-  return module.call("check", [ makeInt32(x) ], binaryen.None);
+  return module.call("check", [ makeInt32(x) ], binaryen.void);
 }
 
 function test_relooper() {
   module = new binaryen.Module();
   var localTypes = [ binaryen.i32 ];
 
-  module.addFunctionImport("check", "module", "check", binaryen.i32, binaryen.none);
+  module.addFunctionImport("check", "module", "check", binaryen.i32, binaryen.void);
 
   { // trivial: just one block
     var relooper = new binaryen.Relooper(module);
     var block = relooper.addBlock(makeCallCheck(1337));
     var body = relooper.renderAndDispose(block, 0, module);
-    module.addFunction("just-one-block", binaryen.none, binaryen.none, localTypes, body);
+    module.addFunction("just-one-block", binaryen.void, binaryen.void, localTypes, body);
   }
   { // two blocks
     var relooper = new binaryen.Relooper(module);
@@ -818,7 +818,7 @@ function test_relooper() {
     var block1 = relooper.addBlock(makeCallCheck(1));
     relooper.addBranch(block0, block1); // no condition, no code on branch
     var body = relooper.renderAndDispose(block0, 0, module);
-    module.addFunction("two-blocks", binaryen.none, binaryen.none, localTypes, body);
+    module.addFunction("two-blocks", binaryen.void, binaryen.void, localTypes, body);
   }
   { // two blocks with code between them
     var relooper = new binaryen.Relooper(module);
@@ -826,7 +826,7 @@ function test_relooper() {
     var block1 = relooper.addBlock(makeCallCheck(1));
     relooper.addBranch(block0, block1, null, makeDroppedInt32(77)); // code on branch
     var body = relooper.renderAndDispose(block0, 0, module);
-    module.addFunction("two-blocks-plus-code", binaryen.none, binaryen.none, localTypes, body);
+    module.addFunction("two-blocks-plus-code", binaryen.void, binaryen.void, localTypes, body);
   }
   { // two blocks in a loop
     var relooper = new binaryen.Relooper(module);
@@ -835,7 +835,7 @@ function test_relooper() {
     relooper.addBranch(block0, block1, null, null);
     relooper.addBranch(block1, block0, null, null);
     var body = relooper.renderAndDispose(block0, 0, module);
-    module.addFunction("loop", binaryen.none, binaryen.none, localTypes, body);
+    module.addFunction("loop", binaryen.void, binaryen.void, localTypes, body);
   }
   { // two blocks in a loop with codes
     var relooper = new binaryen.Relooper(module);
@@ -844,7 +844,7 @@ function test_relooper() {
     relooper.addBranch(block0, block1, null, makeDroppedInt32(33));
     relooper.addBranch(block1, block0, null, makeDroppedInt32(-66));
     var body = relooper.renderAndDispose(block0, 0, module);
-    module.addFunction("loop-plus-code", binaryen.none, binaryen.none, localTypes, body);
+    module.addFunction("loop-plus-code", binaryen.void, binaryen.void, localTypes, body);
   }
   { // split
     var relooper = new binaryen.Relooper(module);
@@ -854,7 +854,7 @@ function test_relooper() {
     relooper.addBranch(block0, block1, makeInt32(55), null);
     relooper.addBranch(block0, block2, null, null);
     var body = relooper.renderAndDispose(block0, 0, module);
-    module.addFunction("split", binaryen.none, binaryen.none, localTypes, body);
+    module.addFunction("split", binaryen.void, binaryen.void, localTypes, body);
   }
   { // split + code
     var relooper = new binaryen.Relooper(module);
@@ -865,7 +865,7 @@ function test_relooper() {
     relooper.addBranch(block0, block1, makeInt32(55), temp);
     relooper.addBranch(block0, block2, null, makeDroppedInt32(20));
     var body = relooper.renderAndDispose(block0, 0, module);
-    module.addFunction("split-plus-code", binaryen.none, binaryen.none, localTypes, body);
+    module.addFunction("split-plus-code", binaryen.void, binaryen.void, localTypes, body);
   }
   { // if
     var relooper = new binaryen.Relooper(module);
@@ -876,7 +876,7 @@ function test_relooper() {
     relooper.addBranch(block0, block2, null, null);
     relooper.addBranch(block1, block2, null, null);
     var body = relooper.renderAndDispose(block0, 0, module);
-    module.addFunction("if", binaryen.none, binaryen.none, localTypes, body);
+    module.addFunction("if", binaryen.void, binaryen.void, localTypes, body);
   }
   { // if + code
     var relooper = new binaryen.Relooper(module);
@@ -888,7 +888,7 @@ function test_relooper() {
     relooper.addBranch(block0, block2, null, makeDroppedInt32(-2));
     relooper.addBranch(block1, block2, null, makeDroppedInt32(-3));
     var body = relooper.renderAndDispose(block0, 0, module);
-    module.addFunction("if-plus-code", binaryen.none, binaryen.none, localTypes, body);
+    module.addFunction("if-plus-code", binaryen.void, binaryen.void, localTypes, body);
   }
   { // if-else
     var relooper = new binaryen.Relooper(module);
@@ -901,7 +901,7 @@ function test_relooper() {
     relooper.addBranch(block1, block3, null, null);
     relooper.addBranch(block2, block3, null, null);
     var body = relooper.renderAndDispose(block0, 0, module);
-    module.addFunction("if-else", binaryen.none, binaryen.none, localTypes, body);
+    module.addFunction("if-else", binaryen.void, binaryen.void, localTypes, body);
   }
   { // loop+tail
     var relooper = new binaryen.Relooper(module);
@@ -912,7 +912,7 @@ function test_relooper() {
     relooper.addBranch(block1, block0, makeInt32(10), null);
     relooper.addBranch(block1, block2, null, null);
     var body = relooper.renderAndDispose(block0, 0, module);
-    module.addFunction("loop-tail", binaryen.none, binaryen.none, localTypes, body);
+    module.addFunction("loop-tail", binaryen.void, binaryen.void, localTypes, body);
   }
   { // nontrivial loop + phi to head
     var relooper = new binaryen.Relooper(module);
@@ -933,7 +933,7 @@ function test_relooper() {
     relooper.addBranch(block4, block5, null, null);
     relooper.addBranch(block5, block6, null, makeDroppedInt32(40));
     var body = relooper.renderAndDispose(block0, 0, module);
-    module.addFunction("nontrivial-loop-plus-phi-to-head", binaryen.none, binaryen.none, localTypes, body);
+    module.addFunction("nontrivial-loop-plus-phi-to-head", binaryen.void, binaryen.void, localTypes, body);
   }
   { // switch
     var relooper = new binaryen.Relooper(module);
@@ -946,7 +946,7 @@ function test_relooper() {
     relooper.addBranchForSwitch(block0, block2, [4], makeDroppedInt32(55));
     relooper.addBranchForSwitch(block0, block3, [], null);
     var body = relooper.renderAndDispose(block0, 0, module);
-    module.addFunction("switch", binaryen.none, binaryen.none, localTypes, body);
+    module.addFunction("switch", binaryen.void, binaryen.void, localTypes, body);
   }
   { // duff's device
     var relooper = new binaryen.Relooper(module);
@@ -958,7 +958,7 @@ function test_relooper() {
     relooper.addBranch(block1, block2, null, null);
     relooper.addBranch(block2, block1, null, null);
     var body = relooper.renderAndDispose(block0, 3, module); // use $3 as the helper var
-    module.addFunction("duffs-device", binaryen.none, binaryen.none, [ binaryen.i32, binaryen.i32, binaryen.i64, binaryen.i32, binaryen.f32, binaryen.f64, binaryen.i32 ], body);
+    module.addFunction("duffs-device", binaryen.void, binaryen.void, [ binaryen.i32, binaryen.i32, binaryen.i64, binaryen.i32, binaryen.f32, binaryen.f64, binaryen.i32 ], body);
   }
 
   { // return in a block
@@ -966,7 +966,7 @@ function test_relooper() {
     var list = module.block("the-list", [ makeCallCheck(42), module.return(makeInt32(1337)) ]);
     var block = relooper.addBlock(list);
     var body = relooper.renderAndDispose(block, 0, module);
-    module.addFunction("return", binaryen.none, binaryen.i32, localTypes, body);
+    module.addFunction("return", binaryen.void, binaryen.i32, localTypes, body);
   }
 
   console.log("raw:");
@@ -1001,7 +1001,7 @@ function test_binaries() {
     var adder = module.addFunction("adder", ii, binaryen.i32, [], add);
     var initExpr = module.i32.const(3);
     var global = module.addGlobal("a-global", binaryen.i32, false, initExpr)
-    var tag = module.addTag("a-tag", binaryen.createType([binaryen.i32, binaryen.i32]), binaryen.none);
+    var tag = module.addTag("a-tag", binaryen.createType([binaryen.i32, binaryen.i32]), binaryen.void);
     binaryen.setDebugInfo(true); // include names section
     buffer = module.emitBinary();
     binaryen.setDebugInfo(false);
@@ -1045,7 +1045,7 @@ function test_binaries_with_features() {
     )
   );
 
-  module.addFunction("get-field", binaryen.none, binaryen.i32, [],
+  module.addFunction("get-field", binaryen.void, binaryen.i32, [],
     module.struct.get(
       0,
       module.global.get("struct-global", structType),
@@ -1076,9 +1076,9 @@ function test_interpret() {
   // create a simple module with a start method that prints a number, and interpret it, printing that number.
   module = new binaryen.Module();
 
-  module.addFunctionImport("print-i32", "spectest", "print", binaryen.i32, binaryen.none);
-  var call = module.call("print-i32", [ makeInt32(1234) ], binaryen.None);
-  var starter = module.addFunction("starter", binaryen.none, binaryen.none, [], call);
+  module.addFunctionImport("print-i32", "spectest", "print", binaryen.i32, binaryen.void);
+  var call = module.call("print-i32", [ makeInt32(1234) ], binaryen.void);
+  var starter = module.addFunction("starter", binaryen.void, binaryen.void, [], call);
   module.setStart(starter);
 
   console.log(module.emitText());
@@ -1091,7 +1091,7 @@ function test_nonvalid() {
   // create a module that fails to validate
   module = new binaryen.Module();
 
-  var func = module.addFunction("func", binaryen.none, binaryen.none, [ binaryen.i32 ],
+  var func = module.addFunction("func", binaryen.void, binaryen.void, [ binaryen.i32 ],
     module.local.set(0, makeInt64(1234, 0)) // wrong type!
   );
 
@@ -1115,7 +1115,7 @@ function test_parsing() {
   var adder = module.addFunction("adder", ii, binaryen.i32, [], add);
   var initExpr = module.i32.const(3);
   var global = module.addGlobal("a-global", binaryen.i32, false, initExpr)
-  var tag = module.addTag("a-tag", binaryen.i32, binaryen.none);
+  var tag = module.addTag("a-tag", binaryen.i32, binaryen.void);
   text = module.emitText();
   module.dispose();
   module = null;
@@ -1158,9 +1158,9 @@ function test_for_each() {
   var funcNames = [ "fn0", "fn1", "fn2" ];
 
   var fns = [
-    module.addFunction(funcNames[0], binaryen.none, binaryen.none, [], module.nop()),
-    module.addFunction(funcNames[1], binaryen.none, binaryen.none, [], module.nop()),
-    module.addFunction(funcNames[2], binaryen.none, binaryen.none, [], module.nop())
+    module.addFunction(funcNames[0], binaryen.void, binaryen.void, [], module.nop()),
+    module.addFunction(funcNames[1], binaryen.void, binaryen.void, [], module.nop()),
+    module.addFunction(funcNames[2], binaryen.void, binaryen.void, [], module.nop())
   ];
 
   var i;
@@ -1296,7 +1296,7 @@ function test_relaxed_atomics() {
     fence,
   ], binaryen.auto);
 
-  module.addFunction("acquire-release-atomics", binaryen.none, binaryen.none, [], body);
+  module.addFunction("acquire-release-atomics", binaryen.void, binaryen.void, [], body);
 
   console.log(module.emitText());
   module.dispose();

--- a/test/binaryen.js/reloc.js
+++ b/test/binaryen.js/reloc.js
@@ -13,7 +13,7 @@ module.setMemory(1, -1, null, [
 
 // table with offset
 
-var func = module.addFunction("func", binaryen.none, binaryen.none, [], module.nop());
+var func = module.addFunction("func", binaryen.void, binaryen.void, [], module.nop());
 
 module.addGlobalImport("table_base", "env", "table_base", binaryen.i32, false);
 module.addTable("0", 1, -1, binaryen.funcref);

--- a/test/binaryen.js/sieve.js
+++ b/test/binaryen.js/sieve.js
@@ -51,7 +51,7 @@ var body = module.block(
     // calculate how many primes there are
     module.return(module.local.get(0, binaryen.i32))
   ],
-  binaryen.none
+  binaryen.void
 );
 
 // Create the add function

--- a/test/binaryen.js/sourcemap.js
+++ b/test/binaryen.js/sourcemap.js
@@ -10,7 +10,7 @@ var body = module.block("", [
   expr
 ], binaryen.i32);
 
-var func = module.addFunction("main", binaryen.none, binaryen.i32, [], body);
+var func = module.addFunction("main", binaryen.void, binaryen.i32, [], body);
 
 module.setDebugLocation(func, expr, fileIndex, 1, 2);
 module.setDebugLocation(func, body, fileIndex, 0, 3);

--- a/test/binaryen.js/tag.js
+++ b/test/binaryen.js/tag.js
@@ -13,7 +13,7 @@ module.setFeatures(binaryen.Features.ReferenceTypes |
 
 var pairType = binaryen.createType([binaryen.i32, binaryen.f32]);
 
-var tag = module.addTag("a-tag", binaryen.i32, binaryen.none);
+var tag = module.addTag("a-tag", binaryen.i32, binaryen.void);
 
 console.log("GetTag is equal: " + (tag === module.getTag("a-tag")));
 
@@ -21,7 +21,7 @@ var tagInfo = binaryen.getTagInfo(tag);
 console.log("getTagInfo=" + JSON.stringify(cleanInfo(tagInfo)));
 
 module.addTagExport("a-tag", "a-tag-exp");
-module.addTagImport("a-tag-imp", "module", "base", pairType, binaryen.none);
+module.addTagImport("a-tag-imp", "module", "base", pairType, binaryen.void);
 
 assert(module.validate());
 console.log(module.emitText());

--- a/test/binaryen.js/tail_calls.js
+++ b/test/binaryen.js/tail_calls.js
@@ -6,23 +6,23 @@ module.addTableImport("0", "env", "table");
 
 var foo = module.addFunction(
   "foo",
-  binaryen.none,
-  binaryen.none,
+  binaryen.void,
+  binaryen.void,
   [],
-  module.return_call("foo", [], binaryen.none, binaryen.none)
+  module.return_call("foo", [], binaryen.void, binaryen.void)
 );
 
 var bar = module.addFunction(
   "bar",
-  binaryen.none,
-  binaryen.none,
+  binaryen.void,
+  binaryen.void,
   [],
   module.return_call_indirect(
     "0",
     module.i32.const(0),
     [],
-    binaryen.none,
-    binaryen.none
+    binaryen.void,
+    binaryen.void
   )
 );
 

--- a/test/binaryen.js/validation_errors.js
+++ b/test/binaryen.js/validation_errors.js
@@ -1,6 +1,6 @@
 (function() {
   var mod = new binaryen.Module();
-  var func = mod.addFunction("test", binaryen.none, binaryen.none, [],
+  var func = mod.addFunction("test", binaryen.void, binaryen.void, [],
     mod.block("", [
       mod.drop(
         mod.global.get("missing", binaryen.i32)
@@ -13,7 +13,7 @@
 
 (function() {
   var mod = new binaryen.Module();
-  var func = mod.addFunction("test", binaryen.none, binaryen.none, [],
+  var func = mod.addFunction("test", binaryen.void, binaryen.void, [],
     mod.block("", [
       mod.drop(
         mod.local.get(0, binaryen.i32)


### PR DESCRIPTION
`BinaryenTypeNone` refers to the type
with stack effect `[] -> []` (e.g. the `(nop)` instruction).

`BinaryenHeapTypeNone` is the new GC heap type `none`, which is
“the common subtype of all forms of aggregate types.”
(https://webassembly.github.io/spec/core/syntax/types.html#heap-types)

The former had been named `'none'` in the JS API, predating the GC proposal.
However, this can be confusing with GC heap type support now finalized in Binaryen.
This PR renames the old type `'none'` to `'void'`,
and adds support for the heap type and gives it the name `'none'`.

**This is a breaking change.** Users who write `binaryen.none`,
when referring to the empty type, must rename it to `binaryen.void`.
The type `binaryen.none` may still be used but now refers to the GC heap type.