### PR TITLE
Parallelize wasm2js test suite

### DIFF
--- a/scripts/test/wasm2js.py
+++ b/scripts/test/wasm2js.py
@@ -57,7 +57,81 @@ def check_for_stale_files():
             shared.fail_with_error(f'orphan test output: {f}')
 
 
+def run_one_wasm2js_test(item, stdout=None):
+    t, opt, expected_file = item
+    basename = os.path.basename(t)
+    print('..', basename, file=stdout)
+
+    split_file = f'split_{basename}_{opt}.wast'
+    mjs_file = f'a_{basename}_{opt}.2asm.mjs'
+    asserts_mjs_file = f'a_{basename}_{opt}.2asm.asserts.mjs'
+
+    all_js = []
+    all_out = ''
+
+    try:
+        for module, asserts in support.split_wast(t):
+            support.write_wast(split_file, module, asserts)
+
+            # wasm2js does not yet support EH or stack switching, and
+            # enabling them can reduce optimization opportunities
+            cmd = shared.WASM2JS + [split_file, '-all',
+                                    '--disable-exception-handling',
+                                    '--disable-stack-switching']
+            if opt:
+                cmd += ['-O']
+            if 'emscripten' in basename:
+                cmd += ['--emscripten']
+            if 'deterministic' in basename:
+                cmd += ['--deterministic']
+            js = support.run_command(cmd, stdout=stdout)
+            all_js.append(js)
+
+            if not shared.NODEJS and not shared.MOZJS:
+                print('No JS interpreters. Skipping spec tests.', file=stdout)
+                continue
+
+            with open(mjs_file, 'w') as f:
+                f.write(js)
+
+            cmd_asserts = cmd + ['--allow-asserts']
+            js_asserts = support.run_command(cmd_asserts, stdout=stdout)
+            # also verify it passes pass-debug verifications
+            support.run_command(cmd_asserts, stderr=subprocess.PIPE, stdout=stdout, env=shared.pass_debug_env())
+
+            with open(asserts_mjs_file, 'w') as f:
+                f.write(js_asserts)
+
+            # verify asm.js is valid js, note that we're using --experimental-modules
+            # to enable ESM syntax and we're also passing a custom loader to handle the
+            # `spectest` and `env` modules in our tests.
+            if shared.NODEJS:
+                loader = os.path.join(shared.options.binaryen_root, 'scripts', 'test', 'node-esm-loader.mjs')
+                node = [shared.NODEJS, '--experimental-modules', '--no-warnings', '--loader', loader]
+                cmd_node = node[:]
+                cmd_node.append(mjs_file)
+                out = support.run_command(cmd_node, stdout=stdout)
+                shared.fail_if_not_identical(out, '')
+                cmd_node = node[:]
+                cmd_node.append(asserts_mjs_file)
+                out = support.run_command(cmd_node, expected_err='', err_ignore='ExperimentalWarning', stdout=stdout)
+                all_out += out
+
+        shared.fail_if_not_identical_to_file(''.join(all_js), expected_file)
+        expected_out = os.path.join(shared.get_test_dir('spec'), 'expected-output', basename + '.log')
+        if os.path.exists(expected_out):
+            expected_out_text = open(expected_out).read()
+        else:
+            expected_out_text = ''
+        shared.fail_if_not_identical(all_out, expected_out_text)
+    finally:
+        shared.delete_from_orbit(split_file)
+        shared.delete_from_orbit(mjs_file)
+        shared.delete_from_orbit(asserts_mjs_file)
+
+
 def test_wasm2js_output():
+    tests = []
     for opt in (0, 1):
         for t in basic_tests + spec_tests + wasm2js_tests:
             basename = os.path.basename(t)
@@ -80,64 +154,9 @@ def test_wasm2js_output():
                 else:
                     raise Exception(f'missing expected file {expected_file}')
 
-            print('..', os.path.basename(t))
+            tests.append((t, opt, expected_file))
 
-            all_js = []
-            all_out = ''
-
-            for module, asserts in support.split_wast(t):
-                support.write_wast('split.wast', module, asserts)
-
-                # wasm2js does not yet support EH or stack switching, and
-                # enabling them can reduce optimization opportunities
-                cmd = shared.WASM2JS + ['split.wast', '-all',
-                                        '--disable-exception-handling',
-                                        '--disable-stack-switching']
-                if opt:
-                    cmd += ['-O']
-                if 'emscripten' in basename:
-                    cmd += ['--emscripten']
-                if 'deterministic' in basename:
-                    cmd += ['--deterministic']
-                js = support.run_command(cmd)
-                all_js.append(js)
-
-                if not shared.NODEJS and not shared.MOZJS:
-                    print('No JS interpreters. Skipping spec tests.')
-                    continue
-
-                open('a.2asm.mjs', 'w').write(js)
-
-                cmd += ['--allow-asserts']
-                js = support.run_command(cmd)
-                # also verify it passes pass-debug verifications
-                with shared.with_pass_debug():
-                    support.run_command(cmd, stderr=subprocess.PIPE)
-
-                open('a.2asm.asserts.mjs', 'w').write(js)
-
-                # verify asm.js is valid js, note that we're using --experimental-modules
-                # to enable ESM syntax and we're also passing a custom loader to handle the
-                # `spectest` and `env` modules in our tests.
-                if shared.NODEJS:
-                    loader = os.path.join(shared.options.binaryen_root, 'scripts', 'test', 'node-esm-loader.mjs')
-                    node = [shared.NODEJS, '--experimental-modules', '--no-warnings', '--loader', loader]
-                    cmd = node[:]
-                    cmd.append('a.2asm.mjs')
-                    out = support.run_command(cmd)
-                    shared.fail_if_not_identical(out, '')
-                    cmd = node[:]
-                    cmd.append('a.2asm.asserts.mjs')
-                    out = support.run_command(cmd, expected_err='', err_ignore='ExperimentalWarning')
-                    all_out += out
-
-            shared.fail_if_not_identical_to_file(''.join(all_js), expected_file)
-            expected_out = os.path.join(shared.get_test_dir('spec'), 'expected-output', os.path.basename(t) + '.log')
-            if os.path.exists(expected_out):
-                expected_out = open(expected_out).read()
-            else:
-                expected_out = ''
-            shared.fail_if_not_identical(all_out, expected_out)
+    shared.run_parallel_tests(run_one_wasm2js_test, tests)
 
 
 def test_asserts_output():

--- a/scripts/test/wasm2js.py
+++ b/scripts/test/wasm2js.py
@@ -62,9 +62,14 @@ def run_one_wasm2js_test(item, stdout=None):
     basename = os.path.basename(t)
     print('..', basename, file=stdout)
 
-    split_file = f'split_{basename}_{opt}.wast'
-    mjs_file = f'a_{basename}_{opt}.2asm.mjs'
-    asserts_mjs_file = f'a_{basename}_{opt}.2asm.asserts.mjs'
+    # Include the path to avoid collisions between test suites (e.g. lit/basic,
+    # spec, and wasm2js) when running in parallel.
+    # /path/to/binaryen/test/wasm2js/foo.wast -> wasm2js-foo
+    rel = os.path.relpath(t, shared.options.binaryen_test)
+    base_name = os.path.splitext(rel)[0].replace(os.sep, '-')
+    split_file = f'split_{base_name}_{opt}.wast'
+    mjs_file = f'a_{base_name}_{opt}.2asm.mjs'
+    asserts_mjs_file = f'a_{base_name}_{opt}.2asm.asserts.mjs'
 
     all_js = []
     all_out = ''


### PR DESCRIPTION
Run the wasm2js test suite in parallel to speed up check.py runs. Isolate per-test temporary files and pass the debug environment explicitly for thread safety.

This reduces runtime from 60s to 8s on a 128-core machine.